### PR TITLE
CI: fix release job for numeric version tags (e.g. 5.93)

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
     tags:
       - 'v*'
+      - '[0-9]+.[0-9]+*'
   pull_request:
     branches: [ "master" ]
   workflow_dispatch:
@@ -59,7 +60,7 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "artifacts/Dopus5_os3.zip"
+          artifacts: "artifacts/Dopus5_*_os3.zip"
           generateReleaseNotes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Tag trigger now also matches plain numeric version tags like `5.93`, not just `v*`.
- The release job's artifact glob now matches the version-suffixed zip the makefile actually produces (`Dopus5_<ver>_os3.zip`); the previous hardcoded `Dopus5_os3.zip` never existed, so tagged releases uploaded no asset.

## Test plan
- [ ] Push a throwaway tag (e.g. `5.93-test`) and confirm the workflow triggers and the release is created with the expected zip attached.
- [ ] Delete the test tag/release after verification.