### PR TITLE
Fix XADOpus: handle non-Amiga LHA directory entries during extraction

### DIFF
--- a/source/Modules/xadopus/XADopus.c
+++ b/source/Modules/xadopus/XADopus.c
@@ -229,10 +229,17 @@ void BuildTree(struct xoData *data)
 			xadConvertDates(
 				XAD_DATEXADDATE, (IPTR)&xfi->xfi_Date, XAD_GETDATEDATESTAMP, (IPTR)&tree->fib.fib_Date, TAG_DONE);
 			tree->fib.fib_Protection = xfi->xfi_Protection;
-			if (xfi->xfi_Flags & XADFIF_DIRECTORY)
-				tree->fib.fib_DirEntryType = 1;
-			else
-				tree->fib.fib_DirEntryType = -1;
+			/* Detect directory entries: use XADFIF_DIRECTORY flag, but also
+			   check for trailing '/' as a fallback for non-Amiga LHA archives
+			   (e.g. created on Linux) where xadMaster may not set the flag. */
+			{
+				ULONG namelen = strlen(xfi->xfi_FileName);
+				if ((xfi->xfi_Flags & XADFIF_DIRECTORY) ||
+					(namelen > 0 && xfi->xfi_FileName[namelen - 1] == '/'))
+					tree->fib.fib_DirEntryType = 1;
+				else
+					tree->fib.fib_DirEntryType = -1;
+			}
 			tree->fib.fib_Size = xfi->xfi_Size;
 			tree->fib.fib_OwnerUID = xfi->xfi_OwnerUID;
 			tree->fib.fib_OwnerGID = xfi->xfi_OwnerGID;
@@ -737,8 +744,12 @@ void _copy(struct xoData *data, char *name, char *Dest, BOOL CopyAs)
 												  PW_FileSize,
 												  xfi->xfi_Size,
 												  TAG_DONE);
-							if (!(xfi->xfi_Flags & (XADFIF_INFOTEXT | XADFIF_NOFILENAME)) &&
-								(xfi->xfi_Flags & XADFIF_DIRECTORY))
+							if (xfi->xfi_Flags & (XADFIF_INFOTEXT | XADFIF_NOFILENAME))
+							{
+							}
+							else if ((xfi->xfi_Flags & XADFIF_DIRECTORY) ||
+									 (strlen(xfi->xfi_FileName) > 0 &&
+									  xfi->xfi_FileName[strlen(xfi->xfi_FileName) - 1] == '/'))
 							{
 								if ((dir = CreateDir(TreeName)))
 									UnLock(dir);
@@ -1010,7 +1021,9 @@ BOOL ExtractF(struct xoData *data)
 
 		if (xfi->xfi_Flags & (XADFIF_INFOTEXT | XADFIF_NOFILENAME))
 			;
-		else if (xfi->xfi_Flags & XADFIF_DIRECTORY)
+		else if ((xfi->xfi_Flags & XADFIF_DIRECTORY) ||
+				 (strlen(xfi->xfi_FileName) > 0 &&
+				  xfi->xfi_FileName[strlen(xfi->xfi_FileName) - 1] == '/'))
 		{
 			if ((dir = CreateDir(FileName)))
 				UnLock(dir);


### PR DESCRIPTION
## Summary

- Fix "opening file failed" errors when extracting files from LHA archives created on non-Amiga systems (e.g. Linux) via the XADOpus archive lister
- Add trailing `/` fallback for directory detection when `XADFIF_DIRECTORY` is not set by xadMaster
- Fix logic bug in `_copy()` where `XADFIF_INFOTEXT`/`XADFIF_NOFILENAME` entries were not properly skipped

## Problem

When opening a non-Amiga LHA archive in a DOpus lister and using Copy to extract files to a destination, every directory entry triggers an "opening file failed" error. Clicking OK dismisses it and files extract, but the error recurs for each subdirectory.

**Root cause (two issues):**

1. **Non-Amiga LHA directory entries**: Linux `lha` stores directory entries with paths like `"dir1/"` (trailing slash, OS type 'U'). xadMaster may not set `XADFIF_DIRECTORY` for these entries. When `_copy()` iterates archive entries under a selected directory, the explicit directory entry matches the prefix condition but falls through to `xadFileUnArc()` since the flag is missing.

2. **Logic bug in `_copy()`**: The condition at lines 740-741 merged the INFOTEXT/NOFILENAME skip-check with the directory check using `&&`, unlike `ExtractF()` which uses proper `if/else if/else`. This caused entries with `XADFIF_INFOTEXT` or `XADFIF_NOFILENAME` to also fall through to `xadFileUnArc()`.

## Changes

Three functions in `source/Modules/xadopus/XADopus.c`:

- **`BuildTree()`**: Add trailing `/` check as fallback directory detection when `XADFIF_DIRECTORY` is not set
- **`_copy()`**: Restructure to proper `if/else if/else` (matching `ExtractF`'s pattern) + add trailing `/` fallback
- **`ExtractF()`**: Add trailing `/` fallback for consistency

## Testing

Build the module and test with a Linux-created LHA archive (e.g. the CI artifacts from this repo):
1. Double-click the LHA to open in a lister
2. Select all entries and Copy to a destination lister
3. Verify no "opening file failed" errors for directory entries
4. Verify all files extract correctly

Also test with an Amiga-created LHA to confirm no regression.