### PR TITLE
Port bug fixes from derfsss/dopus5-os4 fork

### DIFF
--- a/source/Include/dopus/common.h
+++ b/source/Include/dopus/common.h
@@ -30,6 +30,12 @@
 #include <ctype.h>
 #include <stddef.h>
 
+#ifdef __amigaos4__
+#define MAX_FILENAME_LEN	255
+#else
+#define MAX_FILENAME_LEN	107
+#endif
+
 #include <proto/exec.h>
 #include <proto/dos.h>
 #include <proto/locale.h>

--- a/source/Library/button_class.c
+++ b/source/Library/button_class.c
@@ -554,7 +554,21 @@ ULONG LIBFUNC button_dispatch(REG(a0, Class *cl), REG(a2, Object *obj), REG(a1, 
 
 		// Let string gadget handle itself
 		if (data->flags & BUTTONF_STRING)
+		{
+#ifdef __amigaos4__
+			// OS4 strgclass swallows Escape — intercept before super
+			struct gpInput *input = (struct gpInput *)msg;
+			if (input->gpi_IEvent &&
+				input->gpi_IEvent->ie_Class == IECLASS_RAWKEY &&
+				input->gpi_IEvent->ie_Code == 0x45)
+			{
+				*input->gpi_Termination = 0x45;
+				retval = GMR_NOREUSE | GMR_VERIFY;
+				break;
+			}
+#endif
 			retval = DoSuperMethodA(cl, obj, msg);
+		}
 
 		// Button
 		else
@@ -1186,9 +1200,16 @@ void button_render(Class *cl, struct Gadget *gadget, ButtonData *data, struct gp
 
 		// Set pen for text
 		if (data->place == PLACETEXT_IN)
+		{
 			SetAPen(rp, pens[(gadget->Flags & GFLG_SELECTED) ? FILLTEXTPEN : TEXTPEN]);
+			SetBPen(rp, pens[(gadget->Flags & GFLG_SELECTED) ? FILLPEN : BACKGROUNDPEN]);
+		}
 		else
+		{
 			SetAPen(rp, pens[TEXTPEN]);
+			SetBPen(rp, pens[BACKGROUNDPEN]);
+		}
+		SetDrMd(rp, JAM2);
 		if (data->font)
 			SetFont(rp, data->font);
 		if (data->flags & BUTTONF_BOLD)
@@ -1245,6 +1266,9 @@ void button_render(Class *cl, struct Gadget *gadget, ButtonData *data, struct gp
 			Move(rp, x + pos, y + 1);
 			Draw(rp, x + pos + len - 1, y + 1);
 		}
+
+		// Restore JAM1 draw mode
+		SetDrMd(rp, JAM1);
 
 		// Restore style
 		if (old_style != rp->AlgoStyle)

--- a/source/Library/image_class.c
+++ b/source/Library/image_class.c
@@ -157,6 +157,10 @@ void image_draw(Class *cl, struct Image *image, BoopsiImageData *data, struct im
 	case IM_CHECK:
 	case IM_CROSS:
 
+		// Clear background first (prevents progressive bolding with anti-aliased rendering)
+		SetAPen(rp, pens[(draw->imp_State == IDS_SELECTED) ? FILLPEN : BACKGROUNDPEN]);
+		RectFill(rp, box.Left, box.Top, box.Left + box.Width - 1, box.Top + box.Height - 1);
+
 		// Draw checkmark
 		SetAPen(rp, (data->fpen == -1) ? pens[TEXTPEN] : data->fpen);
 		SetDrMd(rp, JAM1);

--- a/source/Library/layout_support.c
+++ b/source/Library/layout_support.c
@@ -956,11 +956,18 @@ struct Gadget *LIBFUNC L_FindKeyEquivalent(REG(a0, ObjectList *first_list),
 									// Store the key we use
 									msg->Code = key;
 								}
-							}
 						}
 					}
 
-					// Escape/lcommand b?
+					// Escape rawkey — look for cancel button
+					else if (key == 0x45)
+					{
+						if (use_object->flags & BUTTONFLAG_CANCEL_BUTTON)
+							gadget = GADGET(use_object);
+					}
+				}
+
+				// Escape/lcommand b?
 					else if (key == 0x1b || (key == 'b' && L_QualValid(msg->Qualifier) == IEQUALIFIER_LCOMMAND))
 					{
 						// See if gadget is a "cancel" button

--- a/source/Library/listview_class.c
+++ b/source/Library/listview_class.c
@@ -1214,7 +1214,8 @@ void listview_render(Class *cl, struct Gadget *gadget, ListViewData *data, struc
 
 			// Draw title
 			SetAPen(rp, pens[TEXTPEN]);
-			SetDrMd(rp, JAM1);
+			SetBPen(rp, pens[BACKGROUNDPEN]);
+			SetDrMd(rp, JAM2);
 			Move(rp, x, y);
 			Text(rp, data->title, len);
 

--- a/source/Library/simplerequest.c
+++ b/source/Library/simplerequest.c
@@ -237,6 +237,16 @@ short LIBFUNC L_DoSimpleRequest(REG(a0, struct Window *parent),
 							break_flag = 1;
 						}
 					}
+
+					// Raw key press (OS4 strgclass swallows Escape before VANILLAKEY)
+					else if (copy_msg.Class == IDCMP_RAWKEY)
+					{
+						if (copy_msg.Code == 0x45)
+						{
+							gadgetid = 0;
+							break_flag = 1;
+						}
+					}
 				}
 			}
 

--- a/source/Modules/configopus/config_environment.c
+++ b/source/Modules/configopus/config_environment.c
@@ -872,7 +872,7 @@ unsigned long LIBFUNC L_Config_Environment(REG(a0, Cfg_Environment *env),
 
 					// Max. filename
 					case GAD_SETTINGS_MAX_FILENAME:
-						BoundsCheckGadget(data->option_list, GAD_SETTINGS_MAX_FILENAME, 30, 107);
+						BoundsCheckGadget(data->option_list, GAD_SETTINGS_MAX_FILENAME, 30, MAX_FILENAME_LEN);
 						break;
 
 					// NewIcons precision
@@ -1641,7 +1641,7 @@ BOOL _config_env_open(config_env_data *data, struct Screen *screen)
 		// Create option list
 		data->option_list = AddObjectList(data->window, _environment_options[data->option_node->data].objects);
 
-#ifdef FUNKOFF
+#ifndef FUNKOFF
 		// Initialise gadgets
 		_config_env_set(data, data->option);
 #endif
@@ -2544,8 +2544,8 @@ void _config_env_store(config_env_data *data, short option)
 		data->config->settings.max_filename = GetGadgetValue(data->option_list, GAD_SETTINGS_MAX_FILENAME);
 		if (data->config->settings.max_filename < 30)
 			data->config->settings.max_filename = 30;
-		else if (data->config->settings.max_filename > 107)
-			data->config->settings.max_filename = 107;
+		else if (data->config->settings.max_filename > MAX_FILENAME_LEN)
+			data->config->settings.max_filename = MAX_FILENAME_LEN;
 		break;
 
 	// Date

--- a/source/Modules/configopus/config_environment_output.c
+++ b/source/Modules/configopus/config_environment_output.c
@@ -135,7 +135,8 @@ IPCMessage *_config_env_output_window_set(config_env_data *data, UWORD id)
 
 	// Display instructions
 	SetAPen(window->RPort, 1);
-	SetDrMd(window->RPort, JAM1);
+	SetBPen(window->RPort, 0);
+	SetDrMd(window->RPort, JAM2);
 	SetFont(window->RPort, data->window->RPort->Font);
 	_config_env_size_instructions(window, id);
 

--- a/source/Modules/filetype/filetype.c
+++ b/source/Modules/filetype/filetype.c
@@ -625,7 +625,7 @@ static int finder_install_filetype(finder_data *data)
 
 // Init code for process
 #ifdef __amigaos4__
-ULONG SAVEDS ASM finder_creator_proc_init(REG(a0, IPCData *ipc), REG(a2, int skip), REG(a1, finder_data *data))
+ULONG SAVEDS ASM finder_creator_proc_init(REG(a0, IPCData *ipc), REG(a1, finder_data *data))
 #else
 IPC_StartupCode(finder_creator_proc_init, finder_data *, data)
 #endif
@@ -736,7 +736,7 @@ static int finder_create_filetype(finder_data *data)
 
 // Init code for process
 #if defined(__amigaos4__)
-ULONG SAVEDS ASM finder_editor_proc_init(REG(a0, IPCData *ipc), REG(a2, int skip), REG(a1, finder_data *data))
+ULONG SAVEDS ASM finder_editor_proc_init(REG(a0, IPCData *ipc), REG(a1, finder_data *data))
 #else
 IPC_StartupCode(finder_editor_proc_init, finder_data *, data)
 #endif
@@ -2239,7 +2239,7 @@ static int creator_clear_files(creator_data *data)
 
 // Init code for process
 #ifdef __amigaos4__
-ULONG SAVEDS ASM creator_editor_proc_init(REG(a0, IPCData *ipc), REG(a2, int skip), REG(a1, creator_data *data))
+ULONG SAVEDS ASM creator_editor_proc_init(REG(a0, IPCData *ipc), REG(a1, creator_data *data))
 #else
 IPC_StartupCode(creator_editor_proc_init, creator_data *, data)
 #endif

--- a/source/Modules/ftp/ftp_lister.c
+++ b/source/Modules/ftp/ftp_lister.c
@@ -171,7 +171,7 @@ void lister_add(struct ftp_node *node, char *name, int size, int type, ULONG sec
 
 	fib->fib_DirEntryType = etype;
 
-	stccpy(fib->fib_FileName, name, 108);
+	stccpy(fib->fib_FileName, name, sizeof(fib->fib_FileName));
 
 	if (comment)
 		stccpy(fib->fib_Comment, comment, COMMENTLEN);

--- a/source/Modules/ftp/ftp_opusftp.h
+++ b/source/Modules/ftp/ftp_opusftp.h
@@ -47,7 +47,11 @@ For more information on Directory Opus for Windows please see:
 #define USERNAMELEN 32
 #define FILENAMELEN 256								// Unix allows greater than Amiga's 30
 #define AMIFILENAMELEN 29							// 30 including null terminator
-#define FIBFILENAMELEN 107							// 108 including null terminator
+#ifdef __amigaos4__
+#define FIBFILENAMELEN	255							// 256 including null terminator
+#else
+#define FIBFILENAMELEN	107							// 108 including null terminator
+#endif
 #define COMMENTLEN 79								// 80 including null terminator
 #define HANDLELEN 12								// lister handle
 #define HOSTNAMELEN 96								// eg, 'planet.earth'

--- a/source/Program/backdrop_leftout.c
+++ b/source/Program/backdrop_leftout.c
@@ -203,7 +203,7 @@ BackdropObject *backdrop_leave_out(BackdropInfo *info, char *name, ULONG flags, 
 			return 0;
 
 		// Isolate filename
-		stccpy(fib->fib_FileName, FilePart(name), 108);
+		stccpy(fib->fib_FileName, FilePart(name), sizeof(fib->fib_FileName));
 	}
 
 	// Locked object, get some info
@@ -605,7 +605,7 @@ BackdropObject *backdrop_create_shortcut(BackdropInfo *info, char *name, short x
 			return 0;
 
 		// Isolate filename
-		stccpy(fib->fib_FileName, FilePart(name), 108);
+		stccpy(fib->fib_FileName, FilePart(name), sizeof(fib->fib_FileName));
 	}
 
 	// Locked object, get some info

--- a/source/Program/environment.c
+++ b/source/Program/environment.c
@@ -130,8 +130,8 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 		GUI->def_filename_length = environment->env->settings.max_filename;
 		if (GUI->def_filename_length < FILENAME_LEN)
 			GUI->def_filename_length = FILENAME_LEN;
-		else if (GUI->def_filename_length > 107)
-			GUI->def_filename_length = 107;
+	else if (GUI->def_filename_length > MAX_FILENAME_LEN)
+		GUI->def_filename_length = MAX_FILENAME_LEN;
 	}
 
 	// Successful?

--- a/source/Program/function_filechange.c
+++ b/source/Program/function_filechange.c
@@ -191,7 +191,7 @@ FileChange *function_filechange_loadfile(FunctionHandle *handle, char *path, cha
 	if (flags & FFLF_DEFERRED)
 	{
 		// Initialise dummy fib
-		strncpy(fib->fib_FileName, name, 108);
+		strncpy(fib->fib_FileName, name, sizeof(fib->fib_FileName));
 		fib->fib_Comment[0] = 0;
 
 		// Add change
@@ -263,7 +263,7 @@ FileChange *function_filechange_delfile(FunctionHandle *handle, char *path, char
 	change->node.ln_Type = FCTYPE_DEL;
 
 	// Copy name
-	strncpy(change->fib->fib_FileName, name, 108);
+	strncpy(change->fib->fib_FileName, name, sizeof(change->fib->fib_FileName));
 	change->node.ln_Name = change->fib->fib_FileName;
 
 	// Add to start or end of list
@@ -292,7 +292,7 @@ FileChange *function_filechange_modify(FunctionHandle *handle, char *path, char 
 		return NULL;
 
 	// Copy name
-	strncpy(change->fib->fib_FileName, name, 108);
+	strncpy(change->fib->fib_FileName, name, sizeof(change->fib->fib_FileName));
 	change->node.ln_Name = change->fib->fib_FileName;
 
 	// Set type
@@ -384,7 +384,7 @@ FileChange *function_filechange_rename(FunctionHandle *handle, char *path, char 
 	return NULL;
 
 	// Copy name
-	strncpy(change->fib->fib_FileName, name, 108);
+	strncpy(change->fib->fib_FileName, name, sizeof(change->fib->fib_FileName));
 
 	// Set type
 	change->node.ln_Type = FCTYPE_RENAME;

--- a/source/Program/function_runprog.c
+++ b/source/Program/function_runprog.c
@@ -204,7 +204,19 @@ DOPUS_FUNC(function_runprog)
 
 	// Restore directory
 	CurrentDir(old);
+
+#ifdef __amigaos4__
+	// On FAT32 USB devices, the filesystem handler may invalidate locks
+	// if the device is removed or the handler encounters an error.
+	// Calling UnLock() on a stale lock causes a DSI crash in dos.library.
+	{
+		char test_buf[4];
+		if (NameFromLock(lock, test_buf, sizeof(test_buf)) || IoErr() != ERROR_INVALID_LOCK)
+			UnLock(lock);
+	}
+#else
 	UnLock(lock);
+#endif
 
 	return 1;
 }


### PR DESCRIPTION
## Summary

Cherry-picked bug fixes and OS4 robustness improvements from [derfsss/dopus5-os4](https://github.com/derfsss/dopus5-os4) (Richard Gibbs). That fork is an OS4-specific build with several fixes that apply to our multi-platform codebase as well.

## Changes

### Critical bug fixes
- **Filetype editor crash** — three `_proc_init` functions in `filetype.c` had a phantom `REG(a2, int skip)` parameter causing DSI crash on OS4 when opening the filetype editor
- **Backdrop disappearing on settings save** — `#ifdef FUNKOFF` typo in `config_environment.c` meant gadget initialisation was dead code; saving the Environment editor would zero-out backdrop settings
- **Anti-aliased font progressive bolding** — JAM1 draw mode accumulates semi-transparent edge pixels with AA fonts; text/checkmarks/gadget labels got bolder on every redraw. Fixed across `button_class.c`, `image_class.c`, `listview_class.c`, `config_environment_output.c`

### OS4 robustness
- **USB/FAT lock crash** — defensive `NameFromLock()` validation before `UnLock()` to avoid DSI crash when FAT32 handler invalidates locks
- **Escape key in requesters** — OS4 BOOPSI `strgclass` swallows Escape; added rawkey interception in `simplerequest.c`, `layout_support.c`, `button_class.c`
- **255-char filename support** — `MAX_FILENAME_LEN` constant (255 on OS4, 107 elsewhere) replacing hardcoded `107`/`108` literals with `sizeof(fib->fib_FileName)`

## Source commits

All changes ported from `derfsss/dopus5-os4`:
- `2e6844a8` — filetype crash + Escape key fixes
- `0b3c5c79` — AA font bolding + USB/FAT lock + filename support
- `c1b9be94` — button_class bolding + FUNKOFF typo

## Skipped (fork-only new features, not ported)

The fork also adds several new features we may want to consider separately:
- Remove 24pt font size cap → 96pt for 4K displays
- Show free memory as KB/MB/GB instead of raw bytes on OS4
- "Show Full Path in Lister Title" option
- Default page selection in Environment prefs

## Testing

- OS4 build: clean compile and link (Docker `sacredbanana/amiga-compiler:ppc-amigaos`)
- OS3 build: clean compilation (pre-existing linker toolchain issue unrelated to changes)