### PR TITLE
Fix low-res arrow chip data pointer

### DIFF
--- a/source/Program/main.c
+++ b/source/Program/main.c
@@ -1314,7 +1314,7 @@ void startup_init_icons()
 	if ((arrow_lo_data_chip = AllocVec(sizeof(arrow_lo_data), MEMF_CHIP)))
 	{
 		CopyMem(arrow_lo_data, arrow_lo_data_chip, sizeof(arrow_lo_data));
-		arrow_image[1].ImageData = arrow_hi_data_chip;
+		arrow_image[1].ImageData = arrow_lo_data_chip;
 	}
 
 	if ((small_arrow_chip = AllocVec(sizeof(small_arrow), MEMF_CHIP)))


### PR DESCRIPTION
## Summary
- point the low-res toolbar arrow image at `arrow_lo_data_chip` after copying the low-res data into chip memory

## Verification
- `docker run --rm -v "D:/Github/dopus5allamigas:/work" sacredbanana/amiga-compiler:m68k-amigaos sh -c "cd /work/source && make os3 clean release debug=no"`
