### PR TITLE
[codex] Add i386 and x86_64 AROS build packages

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -38,9 +38,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: os3, image: "sacredbanana/amiga-compiler:m68k-amigaos" }
-          - { name: os4, image: "sacredbanana/amiga-compiler:ppc-amigaos" }
-          - { name: mos, image: "sacredbanana/amiga-compiler:ppc-morphos" }
+          - { name: os3, image: "sacredbanana/amiga-compiler:m68k-amigaos", ftp_makefile: "makefile.os3", ftp_flags: "" }
+          - { name: os4, image: "sacredbanana/amiga-compiler:ppc-amigaos", ftp_makefile: "makefile.os4", ftp_flags: "" }
+          - { name: mos, image: "sacredbanana/amiga-compiler:ppc-morphos", ftp_makefile: "makefile.mos", ftp_flags: "" }
 
     name: sftp-build-${{ matrix.platform.name }}
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build FTP module with SFTP (${{ matrix.platform.name }})
         run: |
-          docker run --rm -v ${{ github.workspace }}:/work ${{ matrix.platform.image }} sh -c "cd /work/source/Modules/ftp && make -f makefile.${{ matrix.platform.name }} clean && make -f makefile.${{ matrix.platform.name }} sftp=yes"
+          docker run --rm -v ${{ github.workspace }}:/work ${{ matrix.platform.image }} sh -c "cd /work/source/Modules/ftp && make -f ${{ matrix.platform.ftp_makefile }} clean ${{ matrix.platform.ftp_flags }} && make -f ${{ matrix.platform.ftp_makefile }} sftp=yes ${{ matrix.platform.ftp_flags }}"
 
   build:
     needs: ftp-tests
@@ -58,9 +58,11 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: os3, image: "sacredbanana/amiga-compiler:m68k-amigaos" }
-          - { name: os4, image: "sacredbanana/amiga-compiler:ppc-amigaos" }
-          - { name: mos, image: "sacredbanana/amiga-compiler:ppc-morphos" }
+          - { name: os3, image: "sacredbanana/amiga-compiler:m68k-amigaos", package_image: "sacredbanana/amiga-compiler:m68k-amigaos" }
+          - { name: os4, image: "sacredbanana/amiga-compiler:ppc-amigaos", package_image: "sacredbanana/amiga-compiler:ppc-amigaos" }
+          - { name: mos, image: "sacredbanana/amiga-compiler:ppc-morphos", package_image: "sacredbanana/amiga-compiler:ppc-morphos" }
+          - { name: i386-aros, image: "midwan/aros-compiler:i386-aros", package_image: "sacredbanana/amiga-compiler:m68k-amigaos" }
+          - { name: x86_64-aros, image: "midwan/aros-compiler:x86_64-aros", package_image: "sacredbanana/amiga-compiler:m68k-amigaos" }
         variant:
           - { name: debug,   flags: "",          suffix: "_debug" }
           - { name: release, flags: "debug=no",  suffix: "" }
@@ -72,7 +74,8 @@ jobs:
 
       - name: Build (${{ matrix.platform.name }} ${{ matrix.variant.name }})
         run: |
-          docker run --rm -v ${{ github.workspace }}:/work ${{ matrix.platform.image }} sh -c "cd /work/source && make ${{ matrix.platform.name }} release ${{ matrix.variant.flags }}"
+          docker run --rm -v ${{ github.workspace }}:/work ${{ matrix.platform.image }} sh -c "cd /work/source && make ${{ matrix.platform.name }} all ${{ matrix.variant.flags }}"
+          docker run --rm -v ${{ github.workspace }}:/work ${{ matrix.platform.package_image }} sh -c "cd /work/source && make ${{ matrix.platform.name }} release-package ${{ matrix.variant.flags }}"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -97,7 +100,7 @@ jobs:
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "artifacts/Dopus5_*_os3.lha,artifacts/Dopus5_*_os4.lha,artifacts/Dopus5_*_mos.lha"
+          artifacts: "artifacts/Dopus5_*_os3.lha,artifacts/Dopus5_*_os4.lha,artifacts/Dopus5_*_mos.lha,artifacts/Dopus5_*_i386-aros.lha,artifacts/Dopus5_*_x86_64-aros.lha"
           generateReleaseNotes: true
           allowUpdates: true
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 */bin.os4/*
 */bin.mos/*
 */bin.i386-aros/*
-*/bin.arm-aros/*
+*/bin.x86_64-aros/*
 .omg
 .DS_Store
 releases

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GCC/cross-toolchain support, platform fixes, and ongoing module work.
 - **AmigaOS 3** (m68k, including OS3.9/OS3.2)
 - **AmigaOS 4** (PPC)
 - **MorphOS** (PPC)
-- **AROS** (i386 and ARM)
+- **AROS** (i386 ABIv0 and x86_64 ABIv11)
 
 ## Downloads
 
@@ -23,6 +23,8 @@ The project builds with GCC-based cross-compilation toolchains for each target
 platform. CI uses the
 [`sacredbanana/amiga-compiler`](https://hub.docker.com/r/sacredbanana/amiga-compiler)
 Docker images for AmigaOS 3, AmigaOS 4, and MorphOS.
+AROS builds use the `midwan/aros-compiler:i386-aros` and
+`midwan/aros-compiler:x86_64-aros` Docker images.
 
 General flow (inside the toolchain environment):
 
@@ -31,8 +33,8 @@ cd source
 make os3        # AmigaOS 3
 make os4        # AmigaOS 4
 make mos        # MorphOS
-make i386-aros  # AROS/i386
-make arm-aros   # AROS/ARM
+make i386-aros      # AROS/i386 ABIv0
+make x86_64-aros    # AROS/x86_64 ABIv11
 ```
 
 Release archives are built from the same makefile:

--- a/source/Include/defines/SysInfo.h
+++ b/source/Include/defines/SysInfo.h
@@ -7,6 +7,8 @@
 	#include <aros/libcall.h>
 #endif /* !AROS_LIBCALL_H */
 
+#include <defines/aros_voidcall.h>
+
 #ifndef SYSINFO_BASE_NAME
 	#define SYSINFO_BASE_NAME SysInfoBase
 #endif /* !SYSINFO_BASE_NAME */
@@ -23,11 +25,11 @@
 			 /* s */)
 
 #define FreeSysInfo(___si)                                                                                       \
-	AROS_LC1(void, FreeSysInfo, AROS_LCA(struct SysInfo *, (___si), A0), struct Library *, SYSINFO_BASE_NAME, 6, \
+	AROS_VOID_LC1( FreeSysInfo, AROS_LCA(struct SysInfo *, (___si), A0), struct Library *, SYSINFO_BASE_NAME, 6, \
 			 /* s */)
 
 #define GetCpuUsage(___si, ___usage)                         \
-	AROS_LC2(void,                                           \
+	AROS_VOID_LC2(                                           \
 			 GetCpuUsage,                                    \
 			 AROS_LCA(struct SysInfo *, (___si), A0),        \
 			 AROS_LCA(struct SI_CpuUsage *, (___usage), A1), \
@@ -37,7 +39,7 @@
 			 /* s */)
 
 #define GetLoadAverage(___si, ___la)                         \
-	AROS_LC2(void,                                           \
+	AROS_VOID_LC2(                                           \
 			 GetLoadAverage,                                 \
 			 AROS_LCA(struct SysInfo *, (___si), A0),        \
 			 AROS_LCA(struct SI_LoadAverage *, (___la), A1), \
@@ -80,7 +82,7 @@
 #define InitSysInfo() AROS_LC0(struct SysInfo *, InitSysInfo, struct Library *, SYSINFO_BASE_NAME, 5, /* s */)
 
 #define RemoveNotify(___si, ___notify)                      \
-	AROS_LC2(void,                                          \
+	AROS_VOID_LC2(                                          \
 			 RemoveNotify,                                  \
 			 AROS_LCA(struct SysInfo *, (___si), A0),       \
 			 AROS_LCA(struct SI_Notify *, (___notify), A1), \

--- a/source/Include/defines/aros_voidcall.h
+++ b/source/Include/defines/aros_voidcall.h
@@ -1,0 +1,21 @@
+#ifndef DEFINES_AROS_VOIDCALL_H
+#define DEFINES_AROS_VOIDCALL_H
+
+#define AROS_VOID_LC0(n, bt, bn, o, s) \
+	(((void (*)(__AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC1(n, a1, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC2(n, a1, a2, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LPA(a2), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LCA(a2), __AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC3(n, a1, a2, a3, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LPA(a2), __AROS_LPA(a3), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LCA(a2), __AROS_LCA(a3), __AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC4(n, a1, a2, a3, a4, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LPA(a2), __AROS_LPA(a3), __AROS_LPA(a4), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LCA(a2), __AROS_LCA(a3), __AROS_LCA(a4), __AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC5(n, a1, a2, a3, a4, a5, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LPA(a2), __AROS_LPA(a3), __AROS_LPA(a4), __AROS_LPA(a5), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LCA(a2), __AROS_LCA(a3), __AROS_LCA(a4), __AROS_LCA(a5), __AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC6(n, a1, a2, a3, a4, a5, a6, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LPA(a2), __AROS_LPA(a3), __AROS_LPA(a4), __AROS_LPA(a5), __AROS_LPA(a6), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LCA(a2), __AROS_LCA(a3), __AROS_LCA(a4), __AROS_LCA(a5), __AROS_LCA(a6), __AROS_LC_BASE(bt, bn)))
+#define AROS_VOID_LC7(n, a1, a2, a3, a4, a5, a6, a7, bt, bn, o, s) \
+	(((void (*)(__AROS_LPA(a1), __AROS_LPA(a2), __AROS_LPA(a3), __AROS_LPA(a4), __AROS_LPA(a5), __AROS_LPA(a6), __AROS_LPA(a7), __AROS_LP_BASE(bt, bn)))__AROS_GETVECADDR(bn, o))(__AROS_LCA(a1), __AROS_LCA(a2), __AROS_LCA(a3), __AROS_LCA(a4), __AROS_LCA(a5), __AROS_LCA(a6), __AROS_LCA(a7), __AROS_LC_BASE(bt, bn)))
+
+#endif /* DEFINES_AROS_VOIDCALL_H */

--- a/source/Include/defines/dopus5.h
+++ b/source/Include/defines/dopus5.h
@@ -8,13 +8,14 @@
 #endif /* !AROS_LIBCALL_H */
 
 #include <aros/preprocessor/variadic/cast2iptr.hpp>
+#include <defines/aros_voidcall.h>
 
 #ifndef DOPUS_BASE_NAME
 	#define DOPUS_BASE_NAME DOpusBase
 #endif /* !DOPUS_BASE_NAME */
 
 #define ActivateStrGad(___gadget, ___window)             \
-	AROS_LC2(void,                                       \
+	AROS_VOID_LC2(                                       \
 			 ActivateStrGad,                             \
 			 AROS_LCA(struct Gadget *, (___gadget), A0), \
 			 AROS_LCA(struct Window *, (___window), A1), \
@@ -34,7 +35,7 @@
 			 /* s */)
 
 #define AddDragImage(___drag) \
-	AROS_LC1(void, AddDragImage, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 38, /* s */)
+	AROS_VOID_LC1( AddDragImage, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 38, /* s */)
 
 #define AddNotifyRequest(___type, ___data, ___port)     \
 	AROS_LC3(APTR,                                      \
@@ -70,7 +71,7 @@
 			 /* s */)
 
 #define AddSorted(___list, ___node)                  \
-	AROS_LC2(void,                                   \
+	AROS_VOID_LC2(                                   \
 			 AddSorted,                              \
 			 AROS_LCA(struct List *, (___list), A0), \
 			 AROS_LCA(struct Node *, (___node), A1), \
@@ -80,7 +81,7 @@
 			 /* s */)
 
 #define AddWindowMenus(___window, ___data)               \
-	AROS_LC2(void,                                       \
+	AROS_VOID_LC2(                                       \
 			 AddWindowMenus,                             \
 			 AROS_LCA(struct Window *, (___window), A0), \
 			 AROS_LCA(MenuData *, (___data), A1),        \
@@ -121,7 +122,7 @@
 			 /* s */)
 
 #define AnimDecodeRIFFSet(___delta, ___plane, ___rowbytes, ___sourcebytes) \
-	AROS_LC4(void,                                                         \
+	AROS_VOID_LC4(                                                         \
 			 AnimDecodeRIFFSet,                                            \
 			 AROS_LCA(unsigned char *, (___delta), A0),                    \
 			 AROS_LCA(char *, (___plane), A1),                             \
@@ -133,7 +134,7 @@
 			 /* s */)
 
 #define AnimDecodeRIFFXor(___delta, ___plane, ___rowbytes, ___sourcebytes) \
-	AROS_LC4(void,                                                         \
+	AROS_VOID_LC4(                                                         \
 			 AnimDecodeRIFFXor,                                            \
 			 AROS_LCA(unsigned char *, (___delta), A0),                    \
 			 AROS_LCA(char *, (___plane), A1),                             \
@@ -177,7 +178,7 @@
 			 /* s */)
 
 #define Att_ChangeNodeName(___node, ___name)      \
-	AROS_LC2(void,                                \
+	AROS_VOID_LC2(                                \
 			 Att_ChangeNodeName,                  \
 			 AROS_LCA(Att_Node *, (___node), A0), \
 			 AROS_LCA(char *, (___name), A1),     \
@@ -265,7 +266,7 @@
 			 /* s */)
 
 #define Att_PosNode(___list, ___node, ___before)    \
-	AROS_LC3(void,                                  \
+	AROS_VOID_LC3(                                  \
 			 Att_PosNode,                           \
 			 AROS_LCA(Att_List *, (___list), A0),   \
 			 AROS_LCA(Att_Node *, (___node), A1),   \
@@ -276,7 +277,7 @@
 			 /* s */)
 
 #define Att_RemList(___list, ___flags)            \
-	AROS_LC2(void,                                \
+	AROS_VOID_LC2(                                \
 			 Att_RemList,                         \
 			 AROS_LCA(Att_List *, (___list), A0), \
 			 AROS_LCA(long, (___flags), D0),      \
@@ -286,10 +287,10 @@
 			 /* s */)
 
 #define Att_RemNode(___node) \
-	AROS_LC1(void, Att_RemNode, AROS_LCA(Att_Node *, (___node), A0), struct Library *, DOPUS_BASE_NAME, 75, /* s */)
+	AROS_VOID_LC1( Att_RemNode, AROS_LCA(Att_Node *, (___node), A0), struct Library *, DOPUS_BASE_NAME, 75, /* s */)
 
 #define BOOPSIFree(___list)                                                                                         \
-	AROS_LC1(void, BOOPSIFree, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 175, /* s \
+	AROS_VOID_LC1( BOOPSIFree, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 175, /* s \
 																												*/)
 
 #define BoundsCheckGadget(___list, ___id, ___min, ___max) \
@@ -305,7 +306,7 @@
 			 /* s */)
 
 #define BtoCStr(___bstr, ___cstr, ___len)     \
-	AROS_LC3(void,                            \
+	AROS_VOID_LC3(                            \
 			 BtoCStr,                         \
 			 AROS_LCA(BSTR, (___bstr), A0),   \
 			 AROS_LCA(char *, (___cstr), A1), \
@@ -316,7 +317,7 @@
 			 /* s */)
 
 #define BuildKeyString(___code, ___qual, ___mask, ___same, ___buffer) \
-	AROS_LC5(void,                                                    \
+	AROS_VOID_LC5(                                                    \
 			 BuildKeyString,                                          \
 			 AROS_LCA(UWORD, (___code), D0),                          \
 			 AROS_LCA(UWORD, (___qual), D1),                          \
@@ -373,7 +374,7 @@
 			 /* s */)
 
 #define BytesToString(___bytes, ___string, ___places, ___sep) \
-	AROS_LC4(void,                                            \
+	AROS_VOID_LC4(                                            \
 			 BytesToString,                                   \
 			 AROS_LCA(ULONG, (___bytes), D0),                 \
 			 AROS_LCA(char *, (___string), A0),               \
@@ -385,7 +386,7 @@
 			 /* s */)
 
 #define BytesToString64(___bytes, ___string, ___str_size, ___places, ___sep) \
-	AROS_LC5(void,                                                           \
+	AROS_VOID_LC5(                                                           \
 			 BytesToString64,                                                \
 			 AROS_LCA(UQUAD *, (___bytes), A0),                              \
 			 AROS_LCA(char *, (___string), A1),                              \
@@ -453,7 +454,7 @@
 			 /* s */)
 
 #define ChangeAppIcon(___icon, ___render, ___select, ___title, ___flags) \
-	AROS_LC5(void,                                                       \
+	AROS_VOID_LC5(                                                       \
 			 ChangeAppIcon,                                              \
 			 AROS_LCA(APTR, (___icon), A0),                              \
 			 AROS_LCA(struct Image *, (___render), A1),                  \
@@ -521,49 +522,49 @@
 			 196,                             \
 			 /* s */)
 
-#define ClearFiletypeCache() AROS_LC0(void, ClearFiletypeCache, struct Library *, DOPUS_BASE_NAME, 332, /* s */)
+#define ClearFiletypeCache() AROS_VOID_LC0( ClearFiletypeCache, struct Library *, DOPUS_BASE_NAME, 332, /* s */)
 
 #define ClearMemHandle(___handle) \
-	AROS_LC1(void, ClearMemHandle, AROS_LCA(void *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 113, /* s */)
+	AROS_VOID_LC1( ClearMemHandle, AROS_LCA(void *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 113, /* s */)
 
 #define ClearWindowBusy(___window)                                                                                     \
-	AROS_LC1(void, ClearWindowBusy, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 66, \
+	AROS_VOID_LC1( ClearWindowBusy, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 66, \
 			 /* s */)
 
 #define CloseBuf(___file) \
 	AROS_LC1(long, CloseBuf, AROS_LCA(APTR, (___file), A0), struct Library *, DOPUS_BASE_NAME, 165, /* s */)
 
 #define CloseButtonBank(___bank)                                                                                       \
-	AROS_LC1(void, CloseButtonBank, AROS_LCA(Cfg_ButtonBank *, (___bank), A0), struct Library *, DOPUS_BASE_NAME, 132, \
+	AROS_VOID_LC1( CloseButtonBank, AROS_LCA(Cfg_ButtonBank *, (___bank), A0), struct Library *, DOPUS_BASE_NAME, 132, \
 			 /* s */)
 
 #define CloseClipBoard(___clip)                                                                                     \
-	AROS_LC1(                                                                                                       \
-		void, CloseClipBoard, AROS_LCA(struct ClipHandle *, (___clip), A0), struct Library *, DOPUS_BASE_NAME, 211, \
+	AROS_VOID_LC1(                                                                                                       \
+		 CloseClipBoard, AROS_LCA(struct ClipHandle *, (___clip), A0), struct Library *, DOPUS_BASE_NAME, 211, \
 		/* s */)
 
 #define CloseConfigWindow(___window)                                                                                \
-	AROS_LC1(                                                                                                       \
-		void, CloseConfigWindow, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 41, \
+	AROS_VOID_LC1(                                                                                                       \
+		 CloseConfigWindow, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 41, \
 		/* s */)
 
 #define CloseDisk(___handle)                                                                                        \
-	AROS_LC1(void, CloseDisk, AROS_LCA(DiskHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 172, /* s \
+	AROS_VOID_LC1( CloseDisk, AROS_LCA(DiskHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 172, /* s \
 																												*/)
 
 #define CloseIFFFile(___iff)                                                                                         \
-	AROS_LC1(void, CloseIFFFile, AROS_LCA(struct IFFHandle *, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 154, \
+	AROS_VOID_LC1( CloseIFFFile, AROS_LCA(struct IFFHandle *, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 154, \
 			 /* s */)
 
 #define CloseImage(___image) \
-	AROS_LC1(void, CloseImage, AROS_LCA(APTR, (___image), A0), struct Library *, DOPUS_BASE_NAME, 106, /* s */)
+	AROS_VOID_LC1( CloseImage, AROS_LCA(APTR, (___image), A0), struct Library *, DOPUS_BASE_NAME, 106, /* s */)
 
 #define CloseProgressWindow(___win) \
-	AROS_LC1(void, CloseProgressWindow, AROS_LCA(APTR, (___win), A0), struct Library *, DOPUS_BASE_NAME, 272, /* s */)
+	AROS_VOID_LC1( CloseProgressWindow, AROS_LCA(APTR, (___win), A0), struct Library *, DOPUS_BASE_NAME, 272, /* s */)
 
 #define CloseWindowSafely(___window)                                                                                \
-	AROS_LC1(                                                                                                       \
-		void, CloseWindowSafely, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 45, \
+	AROS_VOID_LC1(                                                                                                       \
+		 CloseWindowSafely, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 45, \
 		/* s */)
 
 #define CompareListFormat(___f1, ___f2)           \
@@ -588,8 +589,8 @@
 			 /* s */)
 
 #define ConvertStartMenu(___bank)                                                                                  \
-	AROS_LC1(                                                                                                      \
-		void, ConvertStartMenu, AROS_LCA(Cfg_ButtonBank *, (___bank), A0), struct Library *, DOPUS_BASE_NAME, 367, \
+	AROS_VOID_LC1(                                                                                                      \
+		 ConvertStartMenu, AROS_LCA(Cfg_ButtonBank *, (___bank), A0), struct Library *, DOPUS_BASE_NAME, 367, \
 		/* s */)
 
 #define CopyAppMessage(___msg, ___mem)                  \
@@ -668,7 +669,7 @@
 	AROS_LC1(APTR, CopyImage, AROS_LCA(APTR, (___image), A0), struct Library *, DOPUS_BASE_NAME, 107, /* s */)
 
 #define CopyLocalEnv(___base)                                                                                       \
-	AROS_LC1(void, CopyLocalEnv, AROS_LCA(struct Library *, (___base), A0), struct Library *, DOPUS_BASE_NAME, 193, \
+	AROS_VOID_LC1( CopyLocalEnv, AROS_LCA(struct Library *, (___base), A0), struct Library *, DOPUS_BASE_NAME, 193, \
 			 /* s */)
 
 #define CreateRexxMsgEx(___port, ___extension, ___host) \
@@ -720,7 +721,7 @@
 			 /* s */)
 
 #define DecodeILBM(___src, ___w, ___h, ___d, ___dst, ___mask, ___comp) \
-	AROS_LC7(void,                                                     \
+	AROS_VOID_LC7(                                                     \
 			 DecodeILBM,                                               \
 			 AROS_LCA(char *, (___src), A0),                           \
 			 AROS_LCA(UWORD, (___w), D0),                              \
@@ -735,17 +736,17 @@
 			 /* s */)
 
 #define DecodeRLE(___rleinfo) \
-	AROS_LC1(void, DecodeRLE, AROS_LCA(RLEinfo *, (___rleinfo), A0), struct Library *, DOPUS_BASE_NAME, 161, /* s */)
+	AROS_VOID_LC1( DecodeRLE, AROS_LCA(RLEinfo *, (___rleinfo), A0), struct Library *, DOPUS_BASE_NAME, 161, /* s */)
 
 #define DefaultButtonBank() \
 	AROS_LC0(Cfg_ButtonBank *, DefaultButtonBank, struct Library *, DOPUS_BASE_NAME, 128, /* s */)
 
 #define DefaultEnvironment(___env)                                                                                 \
-	AROS_LC1(void, DefaultEnvironment, AROS_LCA(CFG_ENVR *, (___env), A0), struct Library *, DOPUS_BASE_NAME, 127, \
+	AROS_VOID_LC1( DefaultEnvironment, AROS_LCA(CFG_ENVR *, (___env), A0), struct Library *, DOPUS_BASE_NAME, 127, \
 			 /* s */)
 
 #define DefaultSettings(___settings)                                                                                 \
-	AROS_LC1(void, DefaultSettings, AROS_LCA(CFG_SETS *, (___settings), A0), struct Library *, DOPUS_BASE_NAME, 126, \
+	AROS_VOID_LC1( DefaultSettings, AROS_LCA(CFG_SETS *, (___settings), A0), struct Library *, DOPUS_BASE_NAME, 126, \
 			 /* s */)
 
 #define DeleteIcon(___name) \
@@ -783,7 +784,7 @@
 			 /* s */)
 
 #define DisableObject(___list, ___id, ___state)     \
-	AROS_LC3(void,                                  \
+	AROS_VOID_LC3(                                  \
 			 DisableObject,                         \
 			 AROS_LCA(ObjectList *, (___list), A0), \
 			 AROS_LCA(ULONG, (___id), D0),          \
@@ -794,7 +795,7 @@
 			 /* s */)
 
 #define DisplayObject(___window, ___object, ___fg, ___bg, ___txt) \
-	AROS_LC5(void,                                                \
+	AROS_VOID_LC5(                                                \
 			 DisplayObject,                                       \
 			 AROS_LCA(struct Window *, (___window), A0),          \
 			 AROS_LCA(GL_Object *, (___object), A1),              \
@@ -807,14 +808,14 @@
 			 /* s */)
 
 #define DisposeArgs(___args) \
-	AROS_LC1(void, DisposeArgs, AROS_LCA(FuncArgs *, (___args), A0), struct Library *, DOPUS_BASE_NAME, 309, /* s */)
+	AROS_VOID_LC1( DisposeArgs, AROS_LCA(FuncArgs *, (___args), A0), struct Library *, DOPUS_BASE_NAME, 309, /* s */)
 
 #define DisposeBitMap(___b)                                                                                      \
-	AROS_LC1(void, DisposeBitMap, AROS_LCA(struct BitMap *, (___b), A0), struct Library *, DOPUS_BASE_NAME, 307, \
+	AROS_VOID_LC1( DisposeBitMap, AROS_LCA(struct BitMap *, (___b), A0), struct Library *, DOPUS_BASE_NAME, 307, \
 			 /* s */)
 
 #define DivideToString(___string, ___num, ___div, ___places, ___sep) \
-	AROS_LC5(void,                                                   \
+	AROS_VOID_LC5(                                                   \
 			 DivideToString,                                         \
 			 AROS_LCA(char *, (___string), A0),                      \
 			 AROS_LCA(ULONG, (___num), D0),                          \
@@ -827,7 +828,7 @@
 			 /* s */)
 
 #define DivideToString64(___string, ___str_size, ___bytes, ___div, ___places, ___sep) \
-	AROS_LC6(void,                                                                    \
+	AROS_VOID_LC6(                                                                    \
 			 DivideToString64,                                                        \
 			 AROS_LCA(char *, (___string), A0),                                       \
 			 AROS_LCA(int, (___str_size), D0),                                        \
@@ -853,7 +854,7 @@
 			 /* s */)
 
 #define DivideU64(___num, ___div, ___rem, ___quo) \
-	AROS_LC4(void,                                \
+	AROS_VOID_LC4(                                \
 			 DivideU64,                           \
 			 AROS_LCA(UQUAD *, (___num), A0),     \
 			 AROS_LCA(ULONG, (___div), D0),       \
@@ -891,7 +892,7 @@
 			 /* s */)
 
 #define DrawBox(___rp, ___rect, ___info, ___recess)       \
-	AROS_LC4(void,                                        \
+	AROS_VOID_LC4(                                        \
 			 DrawBox,                                     \
 			 AROS_LCA(struct RastPort *, (___rp), A0),    \
 			 AROS_LCA(struct Rectangle *, (___rect), A1), \
@@ -903,7 +904,7 @@
 			 /* s */)
 
 #define DrawDragList(___rp, ___vp, ___flags)           \
-	AROS_LC3(void,                                     \
+	AROS_VOID_LC3(                                     \
 			 DrawDragList,                             \
 			 AROS_LCA(struct RastPort *, (___rp), A0), \
 			 AROS_LCA(struct ViewPort *, (___vp), A1), \
@@ -914,7 +915,7 @@
 			 /* s */)
 
 #define DrawFieldBox(___rp, ___rect, ___info)             \
-	AROS_LC3(void,                                        \
+	AROS_VOID_LC3(                                        \
 			 DrawFieldBox,                                \
 			 AROS_LCA(struct RastPort *, (___rp), A0),    \
 			 AROS_LCA(struct Rectangle *, (___rect), A1), \
@@ -925,8 +926,8 @@
 			 /* s */)
 
 #define EndRefreshConfigWindow(___win)                                                                                 \
-	AROS_LC1(                                                                                                          \
-		void, EndRefreshConfigWindow, AROS_LCA(struct Window *, (___win), A0), struct Library *, DOPUS_BASE_NAME, 302, \
+	AROS_VOID_LC1(                                                                                                          \
+		 EndRefreshConfigWindow, AROS_LCA(struct Window *, (___win), A0), struct Library *, DOPUS_BASE_NAME, 302, \
 		/* s */)
 
 #define ExamineBuf(___file, ___fib)                          \
@@ -1028,24 +1029,24 @@
 			 /* s */)
 
 #define FixTitleGadgets(___win)                                                                                      \
-	AROS_LC1(void, FixTitleGadgets, AROS_LCA(struct Window *, (___win), A0), struct Library *, DOPUS_BASE_NAME, 328, \
+	AROS_VOID_LC1( FixTitleGadgets, AROS_LCA(struct Window *, (___win), A0), struct Library *, DOPUS_BASE_NAME, 328, \
 			 /* s */)
 
 #define FlushBuf(___file) \
 	AROS_LC1(long, FlushBuf, AROS_LCA(APTR, (___file), A0), struct Library *, DOPUS_BASE_NAME, 168, /* s */)
 
-#define FlushImages() AROS_LC0(void, FlushImages, struct Library *, DOPUS_BASE_NAME, 108, /* s */)
+#define FlushImages() AROS_VOID_LC0( FlushImages, struct Library *, DOPUS_BASE_NAME, 108, /* s */)
 
 #define FreeAppMessage(___msg)                                                                                        \
-	AROS_LC1(void, FreeAppMessage, AROS_LCA(DOpusAppMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 298, \
+	AROS_VOID_LC1( FreeAppMessage, AROS_LCA(DOpusAppMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 298, \
 			 /* s */)
 
 #define FreeButton(___button)                                                                                        \
-	AROS_LC1(void, FreeButton, AROS_LCA(Cfg_Button *, (___button), A0), struct Library *, DOPUS_BASE_NAME, 136, /* s \
+	AROS_VOID_LC1( FreeButton, AROS_LCA(Cfg_Button *, (___button), A0), struct Library *, DOPUS_BASE_NAME, 136, /* s \
 																												 */)
 
 #define FreeButtonFunction(___func)                         \
-	AROS_LC1(void,                                          \
+	AROS_VOID_LC1(                                          \
 			 FreeButtonFunction,                            \
 			 AROS_LCA(Cfg_ButtonFunction *, (___func), A0), \
 			 struct Library *,                              \
@@ -1054,15 +1055,15 @@
 			 /* s */)
 
 #define FreeButtonImages(___list)                                                                                    \
-	AROS_LC1(void, FreeButtonImages, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 135, \
+	AROS_VOID_LC1( FreeButtonImages, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 135, \
 			 /* s */)
 
 #define FreeButtonList(___list)                                                                                    \
-	AROS_LC1(void, FreeButtonList, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 134, \
+	AROS_VOID_LC1( FreeButtonList, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 134, \
 			 /* s */)
 
 #define FreeCachedDiskObject(___icon)                      \
-	AROS_LC1(void,                                         \
+	AROS_VOID_LC1(                                         \
 			 FreeCachedDiskObject,                         \
 			 AROS_LCA(struct DiskObject *, (___icon), A0), \
 			 struct Library *,                             \
@@ -1071,7 +1072,7 @@
 			 /* s */)
 
 #define FreeDiskObjectCopy(___icon)                        \
-	AROS_LC1(void,                                         \
+	AROS_VOID_LC1(                                         \
 			 FreeDiskObjectCopy,                           \
 			 AROS_LCA(struct DiskObject *, (___icon), A0), \
 			 struct Library *,                             \
@@ -1080,64 +1081,64 @@
 			 /* s */)
 
 #define FreeDosListCopy(___list)                                                                                    \
-	AROS_LC1(void, FreeDosListCopy, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 342, \
+	AROS_VOID_LC1( FreeDosListCopy, AROS_LCA(struct List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 342, \
 			 /* s */)
 
 #define FreeDosPathList(___list) \
-	AROS_LC1(void, FreeDosPathList, AROS_LCA(BPTR, (___list), A0), struct Library *, DOPUS_BASE_NAME, 24, /* s */)
+	AROS_VOID_LC1( FreeDosPathList, AROS_LCA(BPTR, (___list), A0), struct Library *, DOPUS_BASE_NAME, 24, /* s */)
 
 #define FreeDragInfo(___draginfo)                                                                                \
-	AROS_LC1(void, FreeDragInfo, AROS_LCA(DragInfo *, (___draginfo), A0), struct Library *, DOPUS_BASE_NAME, 31, \
+	AROS_VOID_LC1( FreeDragInfo, AROS_LCA(DragInfo *, (___draginfo), A0), struct Library *, DOPUS_BASE_NAME, 31, \
 			 /* s */)
 
 #define FreeEditHook(___hook)                                                                                    \
-	AROS_LC1(void, FreeEditHook, AROS_LCA(struct Hook *, (___hook), A0), struct Library *, DOPUS_BASE_NAME, 236, \
+	AROS_VOID_LC1( FreeEditHook, AROS_LCA(struct Hook *, (___hook), A0), struct Library *, DOPUS_BASE_NAME, 236, \
 			 /* s */)
 
 #define FreeFiletype(___type)                                                                                     \
-	AROS_LC1(void, FreeFiletype, AROS_LCA(Cfg_Filetype *, (___type), A0), struct Library *, DOPUS_BASE_NAME, 147, \
+	AROS_VOID_LC1( FreeFiletype, AROS_LCA(Cfg_Filetype *, (___type), A0), struct Library *, DOPUS_BASE_NAME, 147, \
 			 /* s */)
 
 #define FreeFiletypeList(___list)                                                                                    \
-	AROS_LC1(                                                                                                        \
-		void, FreeFiletypeList, AROS_LCA(Cfg_FiletypeList *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 146, \
+	AROS_VOID_LC1(                                                                                                        \
+		 FreeFiletypeList, AROS_LCA(Cfg_FiletypeList *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 146, \
 		/* s */)
 
 #define FreeFunction(___function)                                                                                     \
-	AROS_LC1(void, FreeFunction, AROS_LCA(Cfg_Function *, (___function), A0), struct Library *, DOPUS_BASE_NAME, 137, \
+	AROS_VOID_LC1( FreeFunction, AROS_LCA(Cfg_Function *, (___function), A0), struct Library *, DOPUS_BASE_NAME, 137, \
 			 /* s */)
 
 #define FreeILBM(___ilbm) \
-	AROS_LC1(void, FreeILBM, AROS_LCA(ILBMHandle *, (___ilbm), A0), struct Library *, DOPUS_BASE_NAME, 159, /* s */)
+	AROS_VOID_LC1( FreeILBM, AROS_LCA(ILBMHandle *, (___ilbm), A0), struct Library *, DOPUS_BASE_NAME, 159, /* s */)
 
 #define FreeImageRemap(___remap)                                                                                   \
-	AROS_LC1(void, FreeImageRemap, AROS_LCA(ImageRemap *, (___remap), A0), struct Library *, DOPUS_BASE_NAME, 256, \
+	AROS_VOID_LC1( FreeImageRemap, AROS_LCA(ImageRemap *, (___remap), A0), struct Library *, DOPUS_BASE_NAME, 256, \
 			 /* s */)
 
 #define FreeInstruction(___ins)                                                                                        \
-	AROS_LC1(void, FreeInstruction, AROS_LCA(Cfg_Instruction *, (___ins), A0), struct Library *, DOPUS_BASE_NAME, 138, \
+	AROS_VOID_LC1( FreeInstruction, AROS_LCA(Cfg_Instruction *, (___ins), A0), struct Library *, DOPUS_BASE_NAME, 138, \
 			 /* s */)
 
 #define FreeInstructionList(___func)                                                                                \
-	AROS_LC1(                                                                                                       \
-		void, FreeInstructionList, AROS_LCA(Cfg_Function *, (___func), A0), struct Library *, DOPUS_BASE_NAME, 139, \
+	AROS_VOID_LC1(                                                                                                       \
+		 FreeInstructionList, AROS_LCA(Cfg_Function *, (___func), A0), struct Library *, DOPUS_BASE_NAME, 139, \
 		/* s */)
 
 #define FreeListerDef(___lister)                                                                                   \
-	AROS_LC1(void, FreeListerDef, AROS_LCA(Cfg_Lister *, (___lister), A0), struct Library *, DOPUS_BASE_NAME, 133, \
+	AROS_VOID_LC1( FreeListerDef, AROS_LCA(Cfg_Lister *, (___lister), A0), struct Library *, DOPUS_BASE_NAME, 133, \
 			 /* s */)
 
 #define FreeMatchHandle(___handle) \
-	AROS_LC1(void, FreeMatchHandle, AROS_LCA(APTR, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 290, /* s */)
+	AROS_VOID_LC1( FreeMatchHandle, AROS_LCA(APTR, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 290, /* s */)
 
 #define FreeMemH(___memory) \
-	AROS_LC1(void, FreeMemH, AROS_LCA(void *, (___memory), A0), struct Library *, DOPUS_BASE_NAME, 115, /* s */)
+	AROS_VOID_LC1( FreeMemH, AROS_LCA(void *, (___memory), A0), struct Library *, DOPUS_BASE_NAME, 115, /* s */)
 
 #define FreeMemHandle(___handle) \
-	AROS_LC1(void, FreeMemHandle, AROS_LCA(void *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 112, /* s */)
+	AROS_VOID_LC1( FreeMemHandle, AROS_LCA(void *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 112, /* s */)
 
 #define FreeObject(___objlist, ___object)              \
-	AROS_LC2(void,                                     \
+	AROS_VOID_LC2(                                     \
 			 FreeObject,                               \
 			 AROS_LCA(ObjectList *, (___objlist), A0), \
 			 AROS_LCA(GL_Object *, (___object), A1),   \
@@ -1147,11 +1148,11 @@
 			 /* s */)
 
 #define FreeObjectList(___objlist)                                                                                  \
-	AROS_LC1(void, FreeObjectList, AROS_LCA(ObjectList *, (___objlist), A0), struct Library *, DOPUS_BASE_NAME, 50, \
+	AROS_VOID_LC1( FreeObjectList, AROS_LCA(ObjectList *, (___objlist), A0), struct Library *, DOPUS_BASE_NAME, 50, \
 			 /* s */)
 
 #define FreeRemapImage(___image, ___remap)           \
-	AROS_LC2(void,                                   \
+	AROS_VOID_LC2(                                   \
 			 FreeRemapImage,                         \
 			 AROS_LCA(APTR, (___image), A0),         \
 			 AROS_LCA(ImageRemap *, (___remap), A1), \
@@ -1161,20 +1162,20 @@
 			 /* s */)
 
 #define FreeRexxMsgEx(___msg)                                                                                       \
-	AROS_LC1(void, FreeRexxMsgEx, AROS_LCA(struct RexxMsg *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 335, \
+	AROS_VOID_LC1( FreeRexxMsgEx, AROS_LCA(struct RexxMsg *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 335, \
 			 /* s */)
 
 #define FreeSemaphore(___sem)                                                                                          \
-	AROS_LC1(                                                                                                          \
-		void, FreeSemaphore, AROS_LCA(struct SignalSemaphore *, (___sem), A0), struct Library *, DOPUS_BASE_NAME, 224, \
+	AROS_VOID_LC1(                                                                                                          \
+		 FreeSemaphore, AROS_LCA(struct SignalSemaphore *, (___sem), A0), struct Library *, DOPUS_BASE_NAME, 224, \
 		/* s */)
 
 #define FreeTimer(___handle)                                                                                        \
-	AROS_LC1(void, FreeTimer, AROS_LCA(TimerHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 19, /* s \
+	AROS_VOID_LC1( FreeTimer, AROS_LCA(TimerHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 19, /* s \
 																												*/)
 
 #define FreeWindowMenus(___window)                                                                                     \
-	AROS_LC1(void, FreeWindowMenus, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 64, \
+	AROS_VOID_LC1( FreeWindowMenus, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 64, \
 			 /* s */)
 
 #define GetCachedDefDiskObject(___type)     \
@@ -1218,7 +1219,7 @@
 			 /* s */)
 
 #define GetDosListCopy(___list, ___memory)           \
-	AROS_LC2(void,                                   \
+	AROS_VOID_LC2(                                   \
 			 GetDosListCopy,                         \
 			 AROS_LCA(struct List *, (___list), A0), \
 			 AROS_LCA(APTR, (___memory), A1),        \
@@ -1231,7 +1232,7 @@
 	AROS_LC1(BPTR, GetDosPathList, AROS_LCA(BPTR, (___copy), A0), struct Library *, DOPUS_BASE_NAME, 23, /* s */)
 
 #define GetDragImage(___draginfo, ___x, ___y)         \
-	AROS_LC3(void,                                    \
+	AROS_VOID_LC3(                                    \
 			 GetDragImage,                            \
 			 AROS_LCA(DragInfo *, (___draginfo), A0), \
 			 AROS_LCA(ULONG, (___x), D0),             \
@@ -1255,7 +1256,7 @@
 			 /* s */)
 
 #define GetDragMask(___drag) \
-	AROS_LC1(void, GetDragMask, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 36, /* s */)
+	AROS_VOID_LC1( GetDragMask, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 36, /* s */)
 
 #define GetEditHook(___type, ___flags, ___tags)         \
 	AROS_LC3(struct Hook *,                             \
@@ -1305,7 +1306,7 @@
 		/* s */)
 
 #define GetIconPosition(___icon, ___x, ___y)               \
-	AROS_LC3(void,                                         \
+	AROS_VOID_LC3(                                         \
 			 GetIconPosition,                              \
 			 AROS_LCA(struct DiskObject *, (___icon), A0), \
 			 AROS_LCA(short *, (___x), A1),                \
@@ -1320,7 +1321,7 @@
 			 /* s */)
 
 #define GetImageAttrs(___image, ___tags)                \
-	AROS_LC2(void,                                      \
+	AROS_VOID_LC2(                                      \
 			 GetImageAttrs,                             \
 			 AROS_LCA(APTR, (___image), A0),            \
 			 AROS_LCA(struct TagItem *, (___tags), A1), \
@@ -1379,7 +1380,7 @@
 			 /* s */)
 
 #define GetPalette32(___vp, ___palette, ___count, ___first) \
-	AROS_LC4(void,                                          \
+	AROS_VOID_LC4(                                          \
 			 GetPalette32,                                  \
 			 AROS_LCA(struct ViewPort *, (___vp), A0),      \
 			 AROS_LCA(ULONG *, (___palette), A1),           \
@@ -1391,7 +1392,7 @@
 			 /* s */)
 
 #define GetPopUpImageSize(___window, ___menu, ___width, ___height) \
-	AROS_LC4(void,                                                 \
+	AROS_VOID_LC4(                                                 \
 			 GetPopUpImageSize,                                    \
 			 AROS_LCA(struct Window *, (___window), A0),           \
 			 AROS_LCA(PopUpMenu *, (___menu), A1),                 \
@@ -1413,7 +1414,7 @@
 			 /* s */)
 
 #define GetProgressWindow(___win, ___tags)              \
-	AROS_LC2(void,                                      \
+	AROS_VOID_LC2(                                      \
 			 GetProgressWindow,                         \
 			 AROS_LCA(APTR, (___win), A0),              \
 			 AROS_LCA(struct TagItem *, (___tags), A1), \
@@ -1505,11 +1506,11 @@
 			 /* s */)
 
 #define HideDragImage(___draginfo)                                                                                \
-	AROS_LC1(void, HideDragImage, AROS_LCA(DragInfo *, (___draginfo), A0), struct Library *, DOPUS_BASE_NAME, 34, \
+	AROS_VOID_LC1( HideDragImage, AROS_LCA(DragInfo *, (___draginfo), A0), struct Library *, DOPUS_BASE_NAME, 34, \
 			 /* s */)
 
 #define HideProgressWindow(___win) \
-	AROS_LC1(void, HideProgressWindow, AROS_LCA(APTR, (___win), A0), struct Library *, DOPUS_BASE_NAME, 273, /* s */)
+	AROS_VOID_LC1( HideProgressWindow, AROS_LCA(APTR, (___win), A0), struct Library *, DOPUS_BASE_NAME, 273, /* s */)
 
 #define IFFChunkID(___iff) \
 	AROS_LC1(ULONG, IFFChunkID, AROS_LCA(APTR, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 232, /* s */)
@@ -1521,10 +1522,10 @@
 	AROS_LC1(long, IFFChunkSize, AROS_LCA(APTR, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 228, /* s */)
 
 #define IFFClose(___handle) \
-	AROS_LC1(void, IFFClose, AROS_LCA(APTR, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 201, /* s */)
+	AROS_VOID_LC1( IFFClose, AROS_LCA(APTR, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 201, /* s */)
 
 #define IFFFailure(___iff) \
-	AROS_LC1(void, IFFFailure, AROS_LCA(APTR, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 265, /* s */)
+	AROS_VOID_LC1( IFFFailure, AROS_LCA(APTR, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 265, /* s */)
 
 #define IFFFileHandle(___iff) \
 	AROS_LC1(APTR, IFFFileHandle, AROS_LCA(APTR, (___iff), A0), struct Library *, DOPUS_BASE_NAME, 230, /* s */)
@@ -1627,17 +1628,17 @@
 			 /* s */)
 
 #define IPC_Flush(___port) \
-	AROS_LC1(void, IPC_Flush, AROS_LCA(IPCData *, (___port), A0), struct Library *, DOPUS_BASE_NAME, 101, /* s */)
+	AROS_VOID_LC1( IPC_Flush, AROS_LCA(IPCData *, (___port), A0), struct Library *, DOPUS_BASE_NAME, 101, /* s */)
 
 #define IPC_Free(___ipc) \
-	AROS_LC1(void, IPC_Free, AROS_LCA(IPCData *, (___ipc), A0), struct Library *, DOPUS_BASE_NAME, 94, /* s */)
+	AROS_VOID_LC1( IPC_Free, AROS_LCA(IPCData *, (___ipc), A0), struct Library *, DOPUS_BASE_NAME, 94, /* s */)
 
 #define IPC_GetGoodbye(___msg)                                                                                   \
 	AROS_LC1(ULONG, IPC_GetGoodbye, AROS_LCA(IPCMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 99, \
 			 /* s */)
 
 #define IPC_Goodbye(___ipc, ___owner, ___flags)   \
-	AROS_LC3(void,                                \
+	AROS_VOID_LC3(                                \
 			 IPC_Goodbye,                         \
 			 AROS_LCA(IPCData *, (___ipc), A0),   \
 			 AROS_LCA(IPCData *, (___owner), A1), \
@@ -1648,7 +1649,7 @@
 			 /* s */)
 
 #define IPC_Hello(___ipc, ___owner)               \
-	AROS_LC2(void,                                \
+	AROS_VOID_LC2(                                \
 			 IPC_Hello,                           \
 			 AROS_LCA(IPCData *, (___ipc), A0),   \
 			 AROS_LCA(IPCData *, (___owner), A1), \
@@ -1673,7 +1674,7 @@
 			 /* s */)
 
 #define IPC_ListCommand(___list, ___command, ___flags, ___data, ___wait) \
-	AROS_LC5(void,                                                       \
+	AROS_VOID_LC5(                                                       \
 			 IPC_ListCommand,                                            \
 			 AROS_LCA(struct ListLock *, (___list), A0),                 \
 			 AROS_LCA(ULONG, (___command), D0),                          \
@@ -1708,7 +1709,7 @@
 			 /* s */)
 
 #define IPC_Quit(___ipc, ___flags, ___wait)     \
-	AROS_LC3(void,                              \
+	AROS_VOID_LC3(                              \
 			 IPC_Quit,                          \
 			 AROS_LCA(IPCData *, (___ipc), A0), \
 			 AROS_LCA(ULONG, (___flags), D0),   \
@@ -1719,7 +1720,7 @@
 			 /* s */)
 
 #define IPC_QuitName(___list, ___name, ___flags)         \
-	AROS_LC3(void,                                       \
+	AROS_VOID_LC3(                                       \
 			 IPC_QuitName,                               \
 			 AROS_LCA(struct ListLock *, (___list), A0), \
 			 AROS_LCA(char *, (___name), A1),            \
@@ -1730,7 +1731,7 @@
 			 /* s */)
 
 #define IPC_Reply(___msg) \
-	AROS_LC1(void, IPC_Reply, AROS_LCA(IPCMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 93, /* s */)
+	AROS_VOID_LC1( IPC_Reply, AROS_LCA(IPCMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 93, /* s */)
 
 #define IPC_SafeCommand(___ipc, ___command, ___flags, ___data, ___data_free, ___reply, ___list) \
 	AROS_LC7(ULONG,                                                                             \
@@ -1772,7 +1773,7 @@
 	AROS_LC1(BOOL, InitDragDBuf, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 334, /* s */)
 
 #define InitListLock(___ll, ___name)                   \
-	AROS_LC2(void,                                     \
+	AROS_VOID_LC2(                                     \
 			 InitListLock,                             \
 			 AROS_LCA(struct ListLock *, (___ll), A0), \
 			 AROS_LCA(char *, (___name), A1),          \
@@ -1782,7 +1783,7 @@
 			 /* s */)
 
 #define InitWindowDims(___window, ___dims)                \
-	AROS_LC2(void,                                        \
+	AROS_VOID_LC2(                                        \
 			 InitWindowDims,                              \
 			 AROS_LCA(struct Window *, (___window), A0),  \
 			 AROS_LCA(WindowDimensions *, (___dims), A1), \
@@ -1801,7 +1802,7 @@
 		/* s */)
 
 #define Ito26(___num, ___str)                \
-	AROS_LC2(void,                           \
+	AROS_VOID_LC2(                           \
 			 Ito26,                          \
 			 AROS_LCA(ULONG, (___num), D0),  \
 			 AROS_LCA(char *, (___str), A0), \
@@ -1811,7 +1812,7 @@
 			 /* s */)
 
 #define Itoa(___num, ___str, ___sep)         \
-	AROS_LC3(void,                           \
+	AROS_VOID_LC3(                           \
 			 Itoa,                           \
 			 AROS_LCA(long, (___num), D0),   \
 			 AROS_LCA(char *, (___str), A0), \
@@ -1822,7 +1823,7 @@
 			 /* s */)
 
 #define ItoaU(___num, ___str, ___sep)        \
-	AROS_LC3(void,                           \
+	AROS_VOID_LC3(                           \
 			 ItoaU,                          \
 			 AROS_LCA(ULONG, (___num), D0),  \
 			 AROS_LCA(char *, (___str), A0), \
@@ -1833,7 +1834,7 @@
 			 /* s */)
 
 #define ItoaU64(___num, ___str, ___str_size, ___sep) \
-	AROS_LC4(void,                                   \
+	AROS_VOID_LC4(                                   \
 			 ItoaU64,                                \
 			 AROS_LCA(UQUAD *, (___num), A0),        \
 			 AROS_LCA(char *, (___str), A1),         \
@@ -1845,11 +1846,11 @@
 			 /* s */)
 
 #define LayoutResize(___window)                                                                                      \
-	AROS_LC1(void, LayoutResize, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 292, \
+	AROS_VOID_LC1( LayoutResize, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 292, \
 			 /* s */)
 
 #define LoadPalette32(___vp, ___palette)               \
-	AROS_LC2(void,                                     \
+	AROS_VOID_LC2(                                     \
 			 LoadPalette32,                            \
 			 AROS_LCA(struct ViewPort *, (___vp), A0), \
 			 AROS_LCA(ULONG *, (___palette), A1),      \
@@ -1872,7 +1873,7 @@
 #define LockAppList() AROS_LC0(APTR, LockAppList, struct Library *, DOPUS_BASE_NAME, 184, /* s */)
 
 #define LockAttList(___list, ___exclusive)        \
-	AROS_LC2(void,                                \
+	AROS_VOID_LC2(                                \
 			 LockAttList,                         \
 			 AROS_LCA(Att_List *, (___list), A0), \
 			 AROS_LCA(short, (___exclusive), D0), \
@@ -1891,7 +1892,7 @@
 			 /* s */)
 
 #define MUFSLogin(___window, ___name, ___password)       \
-	AROS_LC3(void,                                       \
+	AROS_VOID_LC3(                                       \
 			 MUFSLogin,                                  \
 			 AROS_LCA(struct Window *, (___window), A0), \
 			 AROS_LCA(char *, (___name), A1),            \
@@ -2009,7 +2010,7 @@
 			 185,                            \
 			 /* s */)
 
-#define NotifyDiskChange() AROS_LC0(void, NotifyDiskChange, struct Library *, DOPUS_BASE_NAME, 340, /* s */)
+#define NotifyDiskChange() AROS_VOID_LC0( NotifyDiskChange, struct Library *, DOPUS_BASE_NAME, 340, /* s */)
 
 #define OpenBuf(___name, ___mode, ___buffer_size)  \
 	AROS_LC3(APTR,                                 \
@@ -2213,11 +2214,11 @@
 			 /* s */)
 
 #define PopUpEndSub(___handle)                                                                                    \
-	AROS_LC1(void, PopUpEndSub, AROS_LCA(PopUpHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 379, \
+	AROS_VOID_LC1( PopUpEndSub, AROS_LCA(PopUpHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 379, \
 			 /* s */)
 
 #define PopUpFreeHandle(___handle)                                                                                    \
-	AROS_LC1(void, PopUpFreeHandle, AROS_LCA(PopUpHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 375, \
+	AROS_VOID_LC1( PopUpFreeHandle, AROS_LCA(PopUpHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 375, \
 			 /* s */)
 
 #define PopUpItemSub(___handle, ___item)               \
@@ -2254,7 +2255,7 @@
 			 /* s */)
 
 #define PopUpSeparator(___handle)                                                                                    \
-	AROS_LC1(void, PopUpSeparator, AROS_LCA(PopUpHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 377, \
+	AROS_VOID_LC1( PopUpSeparator, AROS_LCA(PopUpHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 377, \
 			 /* s */)
 
 #define PopUpSetFlags(___menu, ___id, ___value, ___mask) \
@@ -2371,7 +2372,7 @@
 			 /* s */)
 
 #define RefreshObjectList(___window, ___list)            \
-	AROS_LC2(void,                                       \
+	AROS_VOID_LC2(                                       \
 			 RefreshObjectList,                          \
 			 AROS_LCA(struct Window *, (___window), A0), \
 			 AROS_LCA(ObjectList *, (___list), A1),      \
@@ -2381,11 +2382,11 @@
 			 /* s */)
 
 #define RemAllocBitmapPatch(___handle)                                                                           \
-	AROS_LC1(void, RemAllocBitmapPatch, AROS_LCA(APTR, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 382, \
+	AROS_VOID_LC1( RemAllocBitmapPatch, AROS_LCA(APTR, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 382, \
 			 /* s */)
 
 #define RemDragImage(___drag) \
-	AROS_LC1(void, RemDragImage, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 39, /* s */)
+	AROS_VOID_LC1( RemDragImage, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 39, /* s */)
 
 #define RemapIcon(___icon, ___screen, ___free)             \
 	AROS_LC3(BOOL,                                         \
@@ -2410,36 +2411,36 @@
 			 /* s */)
 
 #define RemoveDragImage(___drag)                                                                                 \
-	AROS_LC1(void, RemoveDragImage, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 349, \
+	AROS_VOID_LC1( RemoveDragImage, AROS_LCA(DragInfo *, (___drag), A0), struct Library *, DOPUS_BASE_NAME, 349, \
 			 /* s */)
 
 #define RemoveNotifyRequest(___node)                                                                                \
-	AROS_LC1(void, RemoveNotifyRequest, AROS_LCA(APTR, (___node), A0), struct Library *, DOPUS_BASE_NAME, 188, /* s \
+	AROS_VOID_LC1( RemoveNotifyRequest, AROS_LCA(APTR, (___node), A0), struct Library *, DOPUS_BASE_NAME, 188, /* s \
 																												*/)
 
-#define RemovedFunc1() AROS_LC0(void, RemovedFunc1, struct Library *, DOPUS_BASE_NAME, 216, /* s */)
+#define RemovedFunc1() AROS_VOID_LC0( RemovedFunc1, struct Library *, DOPUS_BASE_NAME, 216, /* s */)
 
-#define RemovedFunc10() AROS_LC0(void, RemovedFunc10, struct Library *, DOPUS_BASE_NAME, 260, /* s */)
+#define RemovedFunc10() AROS_VOID_LC0( RemovedFunc10, struct Library *, DOPUS_BASE_NAME, 260, /* s */)
 
-#define RemovedFunc11() AROS_LC0(void, RemovedFunc11, struct Library *, DOPUS_BASE_NAME, 261, /* s */)
+#define RemovedFunc11() AROS_VOID_LC0( RemovedFunc11, struct Library *, DOPUS_BASE_NAME, 261, /* s */)
 
-#define RemovedFunc12() AROS_LC0(void, RemovedFunc12, struct Library *, DOPUS_BASE_NAME, 262, /* s */)
+#define RemovedFunc12() AROS_VOID_LC0( RemovedFunc12, struct Library *, DOPUS_BASE_NAME, 262, /* s */)
 
-#define RemovedFunc2() AROS_LC0(void, RemovedFunc2, struct Library *, DOPUS_BASE_NAME, 217, /* s */)
+#define RemovedFunc2() AROS_VOID_LC0( RemovedFunc2, struct Library *, DOPUS_BASE_NAME, 217, /* s */)
 
-#define RemovedFunc3() AROS_LC0(void, RemovedFunc3, struct Library *, DOPUS_BASE_NAME, 218, /* s */)
+#define RemovedFunc3() AROS_VOID_LC0( RemovedFunc3, struct Library *, DOPUS_BASE_NAME, 218, /* s */)
 
-#define RemovedFunc4() AROS_LC0(void, RemovedFunc4, struct Library *, DOPUS_BASE_NAME, 219, /* s */)
+#define RemovedFunc4() AROS_VOID_LC0( RemovedFunc4, struct Library *, DOPUS_BASE_NAME, 219, /* s */)
 
-#define RemovedFunc5() AROS_LC0(void, RemovedFunc5, struct Library *, DOPUS_BASE_NAME, 220, /* s */)
+#define RemovedFunc5() AROS_VOID_LC0( RemovedFunc5, struct Library *, DOPUS_BASE_NAME, 220, /* s */)
 
-#define RemovedFunc6() AROS_LC0(void, RemovedFunc6, struct Library *, DOPUS_BASE_NAME, 221, /* s */)
+#define RemovedFunc6() AROS_VOID_LC0( RemovedFunc6, struct Library *, DOPUS_BASE_NAME, 221, /* s */)
 
-#define RemovedFunc7() AROS_LC0(void, RemovedFunc7, struct Library *, DOPUS_BASE_NAME, 222, /* s */)
+#define RemovedFunc7() AROS_VOID_LC0( RemovedFunc7, struct Library *, DOPUS_BASE_NAME, 222, /* s */)
 
-#define RemovedFunc8() AROS_LC0(void, RemovedFunc8, struct Library *, DOPUS_BASE_NAME, 246, /* s */)
+#define RemovedFunc8() AROS_VOID_LC0( RemovedFunc8, struct Library *, DOPUS_BASE_NAME, 246, /* s */)
 
-#define RemovedFunc9() AROS_LC0(void, RemovedFunc9, struct Library *, DOPUS_BASE_NAME, 258, /* s */)
+#define RemovedFunc9() AROS_VOID_LC0( RemovedFunc9, struct Library *, DOPUS_BASE_NAME, 258, /* s */)
 
 #define RenderImage(___rp, ___image, ___left, ___top, ___tags) \
 	AROS_LC5(short,                                            \
@@ -2463,15 +2464,15 @@
 #endif /* !NO_INLINE_STDARG */
 
 #define ReplyAppMessage(___msg)                                                                                        \
-	AROS_LC1(void, ReplyAppMessage, AROS_LCA(DOpusAppMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 299, \
+	AROS_VOID_LC1( ReplyAppMessage, AROS_LCA(DOpusAppMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 299, \
 			 /* s */)
 
 #define ReplyFreeMsg(___msg) \
-	AROS_LC1(void, ReplyFreeMsg, AROS_LCA(APTR, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 197, /* s */)
+	AROS_VOID_LC1( ReplyFreeMsg, AROS_LCA(APTR, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 197, /* s */)
 
 #define ReplyWindowMsg(___msg)                                                                                      \
-	AROS_LC1(                                                                                                       \
-		void, ReplyWindowMsg, AROS_LCA(struct IntuiMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 43, \
+	AROS_VOID_LC1(                                                                                                       \
+		 ReplyWindowMsg, AROS_LCA(struct IntuiMessage *, (___msg), A0), struct Library *, DOPUS_BASE_NAME, 43, \
 		/* s */)
 
 #define SaveButton(___iff, ___button)                 \
@@ -2563,7 +2564,7 @@
 			 /* s */)
 
 #define Seed(___seed) \
-	AROS_LC1(void, Seed, AROS_LCA(int, (___seed), D0), struct Library *, DOPUS_BASE_NAME, 259, /* s */)
+	AROS_VOID_LC1( Seed, AROS_LCA(int, (___seed), D0), struct Library *, DOPUS_BASE_NAME, 259, /* s */)
 
 #define SeekBuf(___file, ___offset, ___mode)  \
 	AROS_LC3(long,                            \
@@ -2606,7 +2607,7 @@
 			  /* s */)
 
 #define SendNotifyMsg(___type, ___data, ___flags, ___wait, ___name, ___fib) \
-	AROS_LC6(void,                                                          \
+	AROS_VOID_LC6(                                                          \
 			 SendNotifyMsg,                                                 \
 			 AROS_LCA(ULONG, (___type), D0),                                \
 			 AROS_LCA(ULONG, (___data), D1),                                \
@@ -2645,11 +2646,11 @@
 			 /* s */)
 
 #define SetBusyPointer(___window)                                                                                     \
-	AROS_LC1(void, SetBusyPointer, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 15, \
+	AROS_VOID_LC1( SetBusyPointer, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 15, \
 			 /* s */)
 
 #define SetConfigWindowLimits(___window, ___min, ___max) \
-	AROS_LC3(void,                                       \
+	AROS_VOID_LC3(                                       \
 			 SetConfigWindowLimits,                      \
 			 AROS_LCA(struct Window *, (___window), A0), \
 			 AROS_LCA(ConfigWindow *, (___min), A1),     \
@@ -2660,7 +2661,7 @@
 			 /* s */)
 
 #define SetEnv(___name, ___data, ___save)     \
-	AROS_LC3(void,                            \
+	AROS_VOID_LC3(                            \
 			 SetEnv,                          \
 			 AROS_LCA(char *, (___name), A0), \
 			 AROS_LCA(char *, (___data), A1), \
@@ -2671,7 +2672,7 @@
 			 /* s */)
 
 #define SetGadgetChoices(___list, ___id, ___choices) \
-	AROS_LC3(void,                                   \
+	AROS_VOID_LC3(                                   \
 			 SetGadgetChoices,                       \
 			 AROS_LCA(ObjectList *, (___list), A0),  \
 			 AROS_LCA(ULONG, (___id), D0),           \
@@ -2682,7 +2683,7 @@
 			 /* s */)
 
 #define SetGadgetValue(___list, ___id, ___value)    \
-	AROS_LC3(void,                                  \
+	AROS_VOID_LC3(                                  \
 			 SetGadgetValue,                        \
 			 AROS_LCA(ObjectList *, (___list), A0), \
 			 AROS_LCA(UWORD, (___id), D0),          \
@@ -2693,7 +2694,7 @@
 			 /* s */)
 
 #define SetIconFlags(___icon, ___flags)                    \
-	AROS_LC2(void,                                         \
+	AROS_VOID_LC2(                                         \
 			 SetIconFlags,                                 \
 			 AROS_LCA(struct DiskObject *, (___icon), A0), \
 			 AROS_LCA(ULONG, (___flags), D0),              \
@@ -2703,7 +2704,7 @@
 			 /* s */)
 
 #define SetIconPosition(___icon, ___x, ___y)               \
-	AROS_LC3(void,                                         \
+	AROS_VOID_LC3(                                         \
 			 SetIconPosition,                              \
 			 AROS_LCA(struct DiskObject *, (___icon), A0), \
 			 AROS_LCA(short, (___x), D0),                  \
@@ -2724,7 +2725,7 @@
 			 /* s */)
 
 #define SetNewIconsFlags(___flags, ___prec)   \
-	AROS_LC2(void,                            \
+	AROS_VOID_LC2(                            \
 			 SetNewIconsFlags,                \
 			 AROS_LCA(ULONG, (___flags), D0), \
 			 AROS_LCA(short, (___prec), D1),  \
@@ -2734,7 +2735,7 @@
 			 /* s */)
 
 #define SetNotifyRequest(___req, ___flags, ___mask) \
-	AROS_LC3(void,                                  \
+	AROS_VOID_LC3(                                  \
 			 SetNotifyRequest,                      \
 			 AROS_LCA(APTR, (___req), A0),          \
 			 AROS_LCA(ULONG, (___flags), D0),       \
@@ -2745,7 +2746,7 @@
 			 /* s */)
 
 #define SetObjectKind(___list, ___id, ___kind)      \
-	AROS_LC3(void,                                  \
+	AROS_VOID_LC3(                                  \
 			 SetObjectKind,                         \
 			 AROS_LCA(ObjectList *, (___list), A0), \
 			 AROS_LCA(ULONG, (___id), D0),          \
@@ -2756,10 +2757,10 @@
 			 /* s */)
 
 #define SetPopUpDelay(___delay) \
-	AROS_LC1(void, SetPopUpDelay, AROS_LCA(short, (___delay), D0), struct Library *, DOPUS_BASE_NAME, 370, /* s */)
+	AROS_VOID_LC1( SetPopUpDelay, AROS_LCA(short, (___delay), D0), struct Library *, DOPUS_BASE_NAME, 370, /* s */)
 
 #define SetProgressWindow(___win, ___tags)              \
-	AROS_LC2(void,                                      \
+	AROS_VOID_LC2(                                      \
 			 SetProgressWindow,                         \
 			 AROS_LCA(APTR, (___win), A0),              \
 			 AROS_LCA(struct TagItem *, (___tags), A1), \
@@ -2777,7 +2778,7 @@
 #endif /* !NO_INLINE_STDARG */
 
 #define SetReqBackFill(___hook, ___scr)                \
-	AROS_LC2(void,                                     \
+	AROS_VOID_LC2(                                     \
 			 SetReqBackFill,                           \
 			 AROS_LCA(struct Hook *, (___hook), A0),   \
 			 AROS_LCA(struct Screen **, (___scr), A1), \
@@ -2799,7 +2800,7 @@
 			 /* s */)
 
 #define SetStatusText(___window, ___text)                \
-	AROS_LC2(void,                                       \
+	AROS_VOID_LC2(                                       \
 			 SetStatusText,                              \
 			 AROS_LCA(struct Window *, (___window), A0), \
 			 AROS_LCA(char *, (___text), A1),            \
@@ -2822,11 +2823,11 @@
 			 /* s */)
 
 #define SetWindowBusy(___window)                                                                                     \
-	AROS_LC1(void, SetWindowBusy, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 65, \
+	AROS_VOID_LC1( SetWindowBusy, AROS_LCA(struct Window *, (___window), A0), struct Library *, DOPUS_BASE_NAME, 65, \
 			 /* s */)
 
 #define SetWindowID(___window, ___id_ptr, ___id, ___port) \
-	AROS_LC4(void,                                        \
+	AROS_VOID_LC4(                                        \
 			 SetWindowID,                                 \
 			 AROS_LCA(struct Window *, (___window), A0),  \
 			 AROS_LCA(WindowID *, (___id_ptr), A1),       \
@@ -2838,7 +2839,7 @@
 			 /* s */)
 
 #define ShowDragImage(___draginfo, ___x, ___y)        \
-	AROS_LC3(void,                                    \
+	AROS_VOID_LC3(                                    \
 			 ShowDragImage,                           \
 			 AROS_LCA(DragInfo *, (___draginfo), A0), \
 			 AROS_LCA(ULONG, (___x), D0),             \
@@ -2849,7 +2850,7 @@
 			 /* s */)
 
 #define ShowProgressBar(___window, ___object, ___total, ___count) \
-	AROS_LC4(void,                                                \
+	AROS_VOID_LC4(                                                \
 			 ShowProgressBar,                                     \
 			 AROS_LCA(struct Window *, (___window), A0),          \
 			 AROS_LCA(GL_Object *, (___object), A1),              \
@@ -2861,7 +2862,7 @@
 			 /* s */)
 
 #define ShowProgressWindow(___prog, ___scr, ___win)   \
-	AROS_LC3(void,                                    \
+	AROS_VOID_LC3(                                    \
 			 ShowProgressWindow,                      \
 			 AROS_LCA(APTR, (___prog), A0),           \
 			 AROS_LCA(struct Screen *, (___scr), A1), \
@@ -2872,8 +2873,8 @@
 			 /* s */)
 
 #define ShowSemaphore(___sem)                                                                                          \
-	AROS_LC1(                                                                                                          \
-		void, ShowSemaphore, AROS_LCA(struct SignalSemaphore *, (___sem), A0), struct Library *, DOPUS_BASE_NAME, 225, \
+	AROS_VOID_LC1(                                                                                                          \
+		 ShowSemaphore, AROS_LCA(struct SignalSemaphore *, (___sem), A0), struct Library *, DOPUS_BASE_NAME, 225, \
 		/* s */)
 
 #define SimpleRequest(___parent, ___title, ___buttons, ___message, ___buffer, ___data, ___bufsize, ___flags) \
@@ -2901,7 +2902,7 @@
 #endif /* !NO_INLINE_STDARG */
 
 #define StampDragImage(___draginfo, ___x, ___y)       \
-	AROS_LC3(void,                                    \
+	AROS_VOID_LC3(                                    \
 			 StampDragImage,                          \
 			 AROS_LCA(DragInfo *, (___draginfo), A0), \
 			 AROS_LCA(ULONG, (___x), D0),             \
@@ -2912,7 +2913,7 @@
 			 /* s */)
 
 #define StartRefreshConfigWindow(___win, ___state)    \
-	AROS_LC2(void,                                    \
+	AROS_VOID_LC2(                                    \
 			 StartRefreshConfigWindow,                \
 			 AROS_LCA(struct Window *, (___win), A0), \
 			 AROS_LCA(long, (___state), D0),          \
@@ -2922,7 +2923,7 @@
 			 /* s */)
 
 #define StartTimer(___handle, ___secs, ___micro)       \
-	AROS_LC3(void,                                     \
+	AROS_VOID_LC3(                                     \
 			 StartTimer,                               \
 			 AROS_LCA(TimerHandle *, (___handle), A0), \
 			 AROS_LCA(ULONG, (___secs), D0),           \
@@ -2933,11 +2934,11 @@
 			 /* s */)
 
 #define StopTimer(___handle)                                                                                        \
-	AROS_LC1(void, StopTimer, AROS_LCA(TimerHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 22, /* s \
+	AROS_VOID_LC1( StopTimer, AROS_LCA(TimerHandle *, (___handle), A0), struct Library *, DOPUS_BASE_NAME, 22, /* s \
 																												*/)
 
 #define StoreGadgetValue(___list, ___msg)                   \
-	AROS_LC2(void,                                          \
+	AROS_VOID_LC2(                                          \
 			 StoreGadgetValue,                              \
 			 AROS_LCA(ObjectList *, (___list), A0),         \
 			 AROS_LCA(struct IntuiMessage *, (___msg), A1), \
@@ -2947,7 +2948,7 @@
 			 /* s */)
 
 #define StoreWindowDims(___window, ___dims)               \
-	AROS_LC2(void,                                        \
+	AROS_VOID_LC2(                                        \
 			 StoreWindowDims,                             \
 			 AROS_LCA(struct Window *, (___window), A0),  \
 			 AROS_LCA(WindowDimensions *, (___dims), A1), \
@@ -2980,7 +2981,7 @@
 			 /* s */)
 
 #define StripIntuiMessagesDopus(___window)               \
-	AROS_LC1(void,                                       \
+	AROS_VOID_LC1(                                       \
 			 StripIntuiMessagesDopus,                    \
 			 AROS_LCA(struct Window *, (___window), A0), \
 			 struct Library *,                           \
@@ -2989,7 +2990,7 @@
 			 /* s */)
 
 #define StripWindowMessages(___port, ___except)                \
-	AROS_LC2(void,                                             \
+	AROS_VOID_LC2(                                             \
 			 StripWindowMessages,                              \
 			 AROS_LCA(struct MsgPort *, (___port), A0),        \
 			 AROS_LCA(struct IntuiMessage *, (___except), A1), \
@@ -2999,7 +3000,7 @@
 			 /* s */)
 
 #define SwapListNodes(___list, ___s1, ___s2)         \
-	AROS_LC3(void,                                   \
+	AROS_VOID_LC3(                                   \
 			 SwapListNodes,                          \
 			 AROS_LCA(struct List *, (___list), A0), \
 			 AROS_LCA(struct Node *, (___s1), A1),   \
@@ -3013,24 +3014,24 @@
 	AROS_LC1(BOOL, TimerActive, AROS_LCA(TimerHandle *, (___timer), A0), struct Library *, DOPUS_BASE_NAME, 198, \
 			 /* s */)
 
-#define UnlockAppList() AROS_LC0(void, UnlockAppList, struct Library *, DOPUS_BASE_NAME, 186, /* s */)
+#define UnlockAppList() AROS_VOID_LC0( UnlockAppList, struct Library *, DOPUS_BASE_NAME, 186, /* s */)
 
 #define UnlockAttList(___list)                                                                                      \
-	AROS_LC1(void, UnlockAttList, AROS_LCA(Att_List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 215, /* s \
+	AROS_VOID_LC1( UnlockAttList, AROS_LCA(Att_List *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 215, /* s \
 																												*/)
 
-#define UnlockReqBackFill() AROS_LC0(void, UnlockReqBackFill, struct Library *, DOPUS_BASE_NAME, 356, /* s */)
+#define UnlockReqBackFill() AROS_VOID_LC0( UnlockReqBackFill, struct Library *, DOPUS_BASE_NAME, 356, /* s */)
 
 #define UpdateEnvironment(___env)                                                                                 \
-	AROS_LC1(void, UpdateEnvironment, AROS_LCA(CFG_ENVR *, (___env), A0), struct Library *, DOPUS_BASE_NAME, 366, \
+	AROS_VOID_LC1( UpdateEnvironment, AROS_LCA(CFG_ENVR *, (___env), A0), struct Library *, DOPUS_BASE_NAME, 366, \
 			 /* s */)
 
 #define UpdateGadgetList(___list)                                                                                   \
-	AROS_LC1(void, UpdateGadgetList, AROS_LCA(ObjectList *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 305, \
+	AROS_VOID_LC1( UpdateGadgetList, AROS_LCA(ObjectList *, (___list), A0), struct Library *, DOPUS_BASE_NAME, 305, \
 			 /* s */)
 
 #define UpdateGadgetValue(___list, ___msg, ___id)           \
-	AROS_LC3(void,                                          \
+	AROS_VOID_LC3(                                          \
 			 UpdateGadgetValue,                             \
 			 AROS_LCA(ObjectList *, (___list), A0),         \
 			 AROS_LCA(struct IntuiMessage *, (___msg), A1), \
@@ -3040,12 +3041,12 @@
 			 304,                                           \
 			 /* s */)
 
-#define UpdateMyPaths() AROS_LC0(void, UpdateMyPaths, struct Library *, DOPUS_BASE_NAME, 360, /* s */)
+#define UpdateMyPaths() AROS_VOID_LC0( UpdateMyPaths, struct Library *, DOPUS_BASE_NAME, 360, /* s */)
 
-#define UpdatePathList() AROS_LC0(void, UpdatePathList, struct Library *, DOPUS_BASE_NAME, 359, /* s */)
+#define UpdatePathList() AROS_VOID_LC0( UpdatePathList, struct Library *, DOPUS_BASE_NAME, 359, /* s */)
 
 #define UpdateStatusGraph(___window, ___text, ___total, ___count) \
-	AROS_LC4(void,                                                \
+	AROS_VOID_LC4(                                                \
 			 UpdateStatusGraph,                                   \
 			 AROS_LCA(struct Window *, (___window), A0),          \
 			 AROS_LCA(char *, (___text), A1),                     \
@@ -3120,7 +3121,7 @@
 			 181,                                        \
 			 /* s */)
 
-#define WB_Install_Patch() AROS_LC0(void, WB_Install_Patch, struct Library *, DOPUS_BASE_NAME, 177, /* s */)
+#define WB_Install_Patch() AROS_VOID_LC0( WB_Install_Patch, struct Library *, DOPUS_BASE_NAME, 177, /* s */)
 
 #define WB_Launch(___name, ___screen, ___wait)           \
 	AROS_LC3(BOOL,                                       \
@@ -3196,7 +3197,7 @@
 			 /* s */)
 
 #define WriteFileIcon(___source, ___dest)       \
-	AROS_LC2(void,                              \
+	AROS_VOID_LC2(                              \
 			 WriteFileIcon,                     \
 			 AROS_LCA(char *, (___source), A0), \
 			 AROS_LCA(char *, (___dest), A1),   \

--- a/source/Include/defines/multiuser.h
+++ b/source/Include/defines/multiuser.h
@@ -7,6 +7,8 @@
 	#include <aros/libcall.h>
 #endif /* !AROS_LIBCALL_H */
 
+#include <defines/aros_voidcall.h>
+
 #include <aros/preprocessor/variadic/cast2iptr.hpp>
 
 #ifndef MULTIUSER_BASE_NAME
@@ -38,12 +40,12 @@
 #endif /* !NO_INLINE_STDARG */
 
 #define muFreeExtOwner(___info)                                                                                        \
-	AROS_LC1(                                                                                                          \
-		void, muFreeExtOwner, AROS_LCA(struct muExtOwner *, (___info), A0), struct Library *, MULTIUSER_BASE_NAME, 22, \
+	AROS_VOID_LC1(                                                                                                          \
+		 muFreeExtOwner, AROS_LCA(struct muExtOwner *, (___info), A0), struct Library *, MULTIUSER_BASE_NAME, 22, \
 		/* s */)
 
 #define muFreeGroupInfo(___info)                            \
-	AROS_LC1(void,                                          \
+	AROS_VOID_LC1(                                          \
 			 muFreeGroupInfo,                               \
 			 AROS_LCA(struct muGroupInfo *, (___info), A0), \
 			 struct Library *,                              \
@@ -52,8 +54,8 @@
 			 /* s */)
 
 #define muFreeUserInfo(___info)                                                                                        \
-	AROS_LC1(                                                                                                          \
-		void, muFreeUserInfo, AROS_LCA(struct muUserInfo *, (___info), A0), struct Library *, MULTIUSER_BASE_NAME, 10, \
+	AROS_VOID_LC1(                                                                                                          \
+		 muFreeUserInfo, AROS_LCA(struct muUserInfo *, (___info), A0), struct Library *, MULTIUSER_BASE_NAME, 10, \
 		/* s */)
 
 #define muFreeze(___task)                                                                                            \
@@ -163,8 +165,8 @@
 			 /* s */)
 
 #define muRemMonitor(___monitor)                                                                                       \
-	AROS_LC1(                                                                                                          \
-		void, muRemMonitor, AROS_LCA(struct muMonitor *, (___monitor), A0), struct Library *, MULTIUSER_BASE_NAME, 29, \
+	AROS_VOID_LC1(                                                                                                          \
+		 muRemMonitor, AROS_LCA(struct muMonitor *, (___monitor), A0), struct Library *, MULTIUSER_BASE_NAME, 29, \
 		/* s */)
 
 #define muSetDefProtectionA(___taglist)                    \

--- a/source/Include/defines/music.h
+++ b/source/Include/defines/music.h
@@ -7,18 +7,20 @@
 	#include <aros/libcall.h>
 #endif /* !AROS_LIBCALL_H */
 
+#include <defines/aros_voidcall.h>
+
 #ifndef MUSIC_BASE_NAME
 	#define MUSIC_BASE_NAME MUSICBase
 #endif /* !MUSIC_BASE_NAME */
 
-#define ContModule() AROS_LC0(void, ContModule, struct Library *, MUSIC_BASE_NAME, 9, /* s */)
+#define ContModule() AROS_VOID_LC0( ContModule, struct Library *, MUSIC_BASE_NAME, 9, /* s */)
 
-#define FlushModule() AROS_LC0(void, FlushModule, struct Library *, MUSIC_BASE_NAME, 8, /* s */)
+#define FlushModule() AROS_VOID_LC0( FlushModule, struct Library *, MUSIC_BASE_NAME, 8, /* s */)
 
 #define IsModule(___name) \
 	AROS_LC1(WORD, IsModule, AROS_LCA(char *, (___name), A0), struct Library *, MUSIC_BASE_NAME, 7, /* s */)
 
-#define PlayFaster() AROS_LC0(void, PlayFaster, struct Library *, MUSIC_BASE_NAME, 11, /* s */)
+#define PlayFaster() AROS_VOID_LC0( PlayFaster, struct Library *, MUSIC_BASE_NAME, 11, /* s */)
 
 #define PlayModule(___name, ___foob)          \
 	AROS_LC2(WORD,                            \
@@ -30,13 +32,13 @@
 			 5,                               \
 			 /* s */)
 
-#define PlaySlower() AROS_LC0(void, PlaySlower, struct Library *, MUSIC_BASE_NAME, 12, /* s */)
+#define PlaySlower() AROS_VOID_LC0( PlaySlower, struct Library *, MUSIC_BASE_NAME, 12, /* s */)
 
 #define SetVolume(___volume) \
-	AROS_LC1(void, SetVolume, AROS_LCA(WORD, (___volume), D0), struct Library *, MUSIC_BASE_NAME, 10, /* s */)
+	AROS_VOID_LC1( SetVolume, AROS_LCA(WORD, (___volume), D0), struct Library *, MUSIC_BASE_NAME, 10, /* s */)
 
-#define StopModule() AROS_LC0(void, StopModule, struct Library *, MUSIC_BASE_NAME, 6, /* s */)
+#define StopModule() AROS_VOID_LC0( StopModule, struct Library *, MUSIC_BASE_NAME, 6, /* s */)
 
-#define TempoReset() AROS_LC0(void, TempoReset, struct Library *, MUSIC_BASE_NAME, 13, /* s */)
+#define TempoReset() AROS_VOID_LC0( TempoReset, struct Library *, MUSIC_BASE_NAME, 13, /* s */)
 
 #endif /* !_INLINE_MUSIC_H */

--- a/source/Include/defines/newicon.h
+++ b/source/Include/defines/newicon.h
@@ -7,12 +7,14 @@
 	#include <aros/libcall.h>
 #endif /* !AROS_LIBCALL_H */
 
+#include <defines/aros_voidcall.h>
+
 #ifndef NEWICON_BASE_NAME
 	#define NEWICON_BASE_NAME NewIconBase
 #endif /* !NEWICON_BASE_NAME */
 
 #define FreeNewDiskObject(___newdiskobj)                            \
-	AROS_LC1(void,                                                  \
+	AROS_VOID_LC1(                                                  \
 			 FreeNewDiskObject,                                     \
 			 AROS_LCA(struct NewDiskObject *, (___newdiskobj), A0), \
 			 struct Library *,                                      \
@@ -21,7 +23,7 @@
 			 /* s */)
 
 #define FreeRemappedImage(___image, ___screen)           \
-	AROS_LC2(void,                                       \
+	AROS_VOID_LC2(                                       \
 			 FreeRemappedImage,                          \
 			 AROS_LCA(struct Image *, (___image), A0),   \
 			 AROS_LCA(struct Screen *, (___screen), A1), \

--- a/source/Include/defines/patch_aros_voidcalls.py
+++ b/source/Include/defines/patch_aros_voidcalls.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Patch generated AROS inline headers for ABIv11 void-return calls."""
+
+from pathlib import Path
+import re
+
+
+DEFINE_DIR = Path(__file__).resolve().parent
+HEADERS = (
+    "dopus5.h",
+    "newicon.h",
+    "music.h",
+    "multiuser.h",
+    "SysInfo.h",
+)
+VOIDCALL_INCLUDE = "#include <defines/aros_voidcall.h>"
+
+
+def remove_dopus_local_helpers(text):
+    start = text.find("#define DOPUS_LC0NR")
+    if start == -1:
+        return text
+
+    end_marker = "#define ActivateStrGad"
+    end = text.find(end_marker, start)
+    if end == -1:
+        return text
+
+    return text[:start] + text[end:]
+
+
+def insert_voidcall_include(text):
+    if VOIDCALL_INCLUDE in text or "AROS_VOID_LC" not in text:
+        return text
+
+    cast_include = "#include <aros/preprocessor/variadic/cast2iptr.hpp>"
+    if cast_include in text:
+        return text.replace(cast_include, f"{cast_include}\n{VOIDCALL_INCLUDE}", 1)
+
+    libcall_guard = "#endif /* !AROS_LIBCALL_H */"
+    return text.replace(libcall_guard, f"{libcall_guard}\n\n{VOIDCALL_INCLUDE}", 1)
+
+
+def patch_header(path):
+    text = path.read_text(encoding="utf-8")
+    text = text.replace("\r\n", "\n")
+    text = remove_dopus_local_helpers(text)
+    text = re.sub(r"\bDOPUS_LC([0-9]+)NR\(", r"AROS_VOID_LC\1(", text)
+    text = re.sub(r"\bAROS_LC([0-9]+)\(\s*void\s*,\s*", r"AROS_VOID_LC\1(", text)
+    text = insert_voidcall_include(text)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def main():
+    for header in HEADERS:
+        patch_header(DEFINE_DIR / header)
+
+
+if __name__ == "__main__":
+    main()

--- a/source/Include/dopus/version.h
+++ b/source/Include/dopus/version.h
@@ -8,8 +8,8 @@
 // converts AROS archetecture into integer for conditional tests
 #undef i386
 #define i386 386
-#undef arm
-#define arm 603
+#undef x86_64
+#define x86_64 64
 
 //set the compile date from the makefile date definition
 #define DOPUSDATE STRI(COMPDATE)
@@ -38,9 +38,9 @@
 		#if ARCH == 386
 			#undef i386
 			#define PLATFORM [AROSdev-i386]
-		#elif ARCH == 603
-			#undef arm
-			#define PLATFORM [AROSdev-arm]
+		#elif ARCH == 64
+			#undef x86_64
+			#define PLATFORM [AROSdev-x86_64]
 		#else
 			#warning Unknown architecture!
 			#define PLATFORM [AROSdev]
@@ -59,9 +59,9 @@
 		#if ARCH == 386
 			#undef i386
 			#define PLATFORM [AROS-i386]
-		#elif ARCH == 603
-			#undef arm
-			#define PLATFORM [AROS-arm]
+		#elif ARCH == 64
+			#undef x86_64
+			#define PLATFORM [AROS-x86_64]
 		#else
 			#warning Unknown architecture!
 			#define PLATFORM [AROS]

--- a/source/Include/libraries/dopus5.h
+++ b/source/Include/libraries/dopus5.h
@@ -880,7 +880,7 @@ typedef struct _ObjectDef
 	UBYTE object_kind;
 	struct IBox char_dims;
 	struct IBox fine_dims;
-	ULONG gadget_text;
+	IPTR gadget_text;
 	ULONG flags;
 	UWORD gadgetid;
 	const struct TagItem *taglist;

--- a/source/Include/proto/Picasso96.h
+++ b/source/Include/proto/Picasso96.h
@@ -29,7 +29,7 @@
     #ifdef __GNUC__
         #ifndef __AROS__
             /* AROS uses native C calling conventions; the m68k-style inline
-             * wrappers below are wrong for i386-aros / arm-aros. AROS builds
+             * wrappers below are wrong for i386-aros / x86_64-aros. AROS builds
              * rely on the plain prototypes from <clib/Picasso96_protos.h>
              * together with whatever AROS-side Picasso96 implementation is
              * linked at build time. */

--- a/source/Library/dopusbase.h
+++ b/source/Library/dopusbase.h
@@ -809,7 +809,7 @@ typedef struct _ObjectDef
 	UBYTE object_kind;
 	struct IBox char_dims;
 	struct IBox fine_dims;
-	ULONG gadget_text;
+	IPTR gadget_text;
 	ULONG flags;
 	UWORD gadgetid;
 	const struct TagItem *taglist;

--- a/source/Library/libinit.c
+++ b/source/Library/libinit.c
@@ -119,13 +119,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -735,9 +735,7 @@ static struct MyLibrary *LIBFUNC LibInit(REG(d0, struct MyLibrary *base),
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		// cleanup the library header structure beginning with the
@@ -797,9 +795,7 @@ STATIC BPTR LibDelete(struct MyLibrary *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Library/wb.c
+++ b/source/Library/wb.c
@@ -88,6 +88,7 @@ static inline void atomic_dec(ULONG *counter)
 // so this can't be stored in wb_data, unless we introduce a global
 // pointer to it
 ULONG usecount[WB_PATCH_COUNT];
+static APTR old_findtask_function;
 
 //// AddAppWindow patch
 PATCHED_5(struct AppWindow *,
@@ -2126,11 +2127,23 @@ PATCHED_1(struct Task *, LIBFUNC L_PatchedFindTask, a1, char *, name)
 		struct LibData *data;
 		struct Task *task;
 
-		// This task?
+		// Preserve the native FindTask(NULL) path even when dopus5.library
+		// is unavailable during patch installation/removal.
 		if (!name)
 		{
+			if (old_findtask_function)
+			{
+				task = LIBCALL_1(struct Task *, old_findtask_function, SysBase, IExec, a1, NULL);
+				atomic_dec(&usecount[WB_PATCH_FINDTASK]);
+				return task;
+			}
+#ifndef __AROS__
 			atomic_dec(&usecount[WB_PATCH_FINDTASK]);
 			return ((struct ExecBase *)SysBase)->ThisTask;
+#else
+			atomic_dec(&usecount[WB_PATCH_FINDTASK]);
+			return NULL;
+#endif
 		}
 
 		// Get library pointer
@@ -2190,7 +2203,7 @@ PATCHED_2(struct Window *, LIBFUNC L_PatchedOpenWindowTags, a0, struct NewWindow
 		wb_data = &data->wb_data;
 
 		// Is window being opened by the kludge task?
-		if (data->open_window_kludge == (struct Process *)((struct ExecBase *)SysBase)->ThisTask)
+		if (data->open_window_kludge == (struct Process *)FindTask(NULL))
 
 		{
 			short x, y, w, h;
@@ -2543,6 +2556,8 @@ void LIBFUNC L_WB_Install_Patch(REG(a6, struct MyLibrary *libbase))
 					wb_data->old_function[patch] =
 						SetFunction(libptr, wb_patches[patch].offset, wb_patches[patch].function);
 #endif
+					if (patch == WB_PATCH_FINDTASK)
+						old_findtask_function = wb_data->old_function[patch];
 				}
 			}
 
@@ -2629,6 +2644,7 @@ BOOL LIBFUNC L_WB_Remove_Patch(REG(a6, struct MyLibrary *libbase))
 		}
 		FreeVec(wb_data->old_function);
 		wb_data->old_function = 0;
+		old_findtask_function = NULL;
 #else
 		// Try to remove patches
 		Forbid();
@@ -2695,6 +2711,7 @@ BOOL LIBFUNC L_WB_Remove_Patch(REG(a6, struct MyLibrary *libbase))
 		{
 			FreeVec(wb_data->old_function);
 			wb_data->old_function = 0;
+			old_findtask_function = NULL;
 		}
 
 		CacheClearU();

--- a/source/Misc/C/ViewFont/font_data.c
+++ b/source/Misc/C/ViewFont/font_data.c
@@ -21,7 +21,7 @@ const struct TagItem
 
 	font_display_tags[] = {{GTCustom_ThinBorders, TRUE}, {GTCustom_FrameFlags, AREAFLAG_RECESSED}, {TAG_END, 0}},
 
-	font_cycle_tags[] = {{GTCY_Labels, (ULONG)dummy_labels}, {TAG_END, 0}};
+	font_cycle_tags[] = {{GTCY_Labels, (IPTR)dummy_labels}, {TAG_END, 0}};
 
 const ObjectDef
 
@@ -62,7 +62,7 @@ const ObjectDef
 		 BUTTON_KIND,
 		 {POS_REL_RIGHT, 1, 2, 1},
 		 {0, 14, 4, 6},
-		 (ULONG) "_+",
+		 (IPTR) "_+",
 		 TEXTFLAG_TEXT_STRING,
 		 GAD_FONT_UP,
 		 0},
@@ -72,7 +72,7 @@ const ObjectDef
 		 BUTTON_KIND,
 		 {POS_REL_RIGHT, 1, 2, 1},
 		 {0, 14, 4, 6},
-		 (ULONG) "_-",
+		 (IPTR) "_-",
 		 TEXTFLAG_TEXT_STRING,
 		 GAD_FONT_DOWN,
 		 0},

--- a/source/Misc/C/makefile
+++ b/source/Misc/C/makefile
@@ -19,12 +19,12 @@ export arch
 # Compiles debug version of dopus5 components for OS3 & creates
 # release archive.
 
-# make i386-aros release debug=no
-# Compiles normal version of dopus5 components for i386-AROS & creates
+# make x86_64-aros release debug=no
+# Compiles normal version of dopus5 components for x86_64-AROS & creates
 # release archive.
 ###########################################################
 # Read platform arguments from the "Make" command line:
-# Acceptable platform arguments are os3, os4, mos, i386-aros or arm-aros.
+# Acceptable platform arguments are os3, os4, mos, i386-aros or x86_64-aros.
 PLATFORM:= none
 NAME:=
 ifeq ($(findstring os3, $(MAKECMDGOALS)),os3)
@@ -39,26 +39,26 @@ ifeq ($(findstring mos, $(MAKECMDGOALS)),mos)
 	PLATFORM:= mos
 	NAME:= $(PLATFORM) $(NAME)
 endif
-ifeq ($(findstring arm-aros, $(MAKECMDGOALS)),arm-aros)
-	PLATFORM:= aros
-	arch:= arm
-	NAME:= $(arch)-$(PLATFORM) $(NAME)
-endif
 ifeq ($(findstring i386-aros, $(MAKECMDGOALS)),i386-aros)
 	PLATFORM:= aros
 	arch:= i386
+	NAME:= $(arch)-$(PLATFORM) $(NAME)
+endif
+ifeq ($(findstring x86_64-aros, $(MAKECMDGOALS)),x86_64-aros)
+	PLATFORM:= aros
+	arch:= x86_64
 	NAME:= $(arch)-$(PLATFORM) $(NAME)
 endif
 NAME := $(strip $(NAME))
 
 # Generate error if no platform entered on "Make" command line.
 ifeq ($(PLATFORM), none)
-$(error Error: Enter a platform (os3, os4, mos, arm-aros or i386-aros).)
+$(error Error: Enter a platform (os3, os4, mos, i386-aros or x86_64-aros).)
 endif
 
 #Generate error if multiple platforms entered on "Make" command line.
 ifneq ($(words $(NAME)), 1)
-$(error Error: Enter only 1 platform (os3, os4, mos, arm-aros or i386-aros).)
+$(error Error: Enter only 1 platform (os3, os4, mos, i386-aros or x86_64-aros).)
 endif
 
 # Compile all if only a platform is entered on "Make" command line.
@@ -122,9 +122,9 @@ clean-viewfont:
 # commands when entered as a goal for "make"
 # on the command line (like: make os3).
 
-.PHONY : os3 os4 mos aros i386-aros arm-aros
+.PHONY : os3 os4 mos aros i386-aros x86_64-aros
 i386-aros: mos
-arm-aros: mos
+x86_64-aros: mos
 os3: mos
 os4: mos
 aros: mos

--- a/source/Modules/about/init/libinit.c
+++ b/source/Modules/about/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -579,9 +579,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		// cleanup the library header structure beginning with the
@@ -641,9 +639,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/cleanup/init/libinit.c
+++ b/source/Modules/cleanup/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -579,9 +579,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		// cleanup the library header structure beginning with the
@@ -641,9 +639,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/configopus/button_editor_data.c
+++ b/source/Modules/configopus/button_editor_data.c
@@ -36,21 +36,21 @@ const struct TagItem
 	_button_editor_functions[] = {{DLV_ShowSelected, TRUE},
 								  {DLV_DragNotify, 1},
 								  {DLV_ShowChecks, 2},
-								  {TAG_MORE, (ULONG)_button_editor_function_layout}},
+								  {TAG_MORE, (IPTR)_button_editor_function_layout}},
 
 	_button_editor_name[] = {{GTST_MaxChars, 255},
 							 {GTCustom_ThinBorders, TRUE},
-							 {TAG_MORE, (ULONG)_button_editor_function_layout}},
+							 {TAG_MORE, (IPTR)_button_editor_function_layout}},
 
 	_button_editor_label[] = {{GTST_MaxChars, 255},
-							  {GTCustom_CallBack, (ULONG)button_editor_task_callback},
-							  {GTCustom_CallBack, (ULONG)button_editor_bit_callback},
+							  {GTCustom_CallBack, (IPTR)button_editor_task_callback},
+							  {GTCustom_CallBack, (IPTR)button_editor_bit_callback},
 							  {GTCustom_ThinBorders, TRUE},
-							  {TAG_MORE, (ULONG)_button_editor_function_layout}},
+							  {TAG_MORE, (IPTR)_button_editor_function_layout}},
 
 	_button_editor_image[] = {{GTCustom_Control, GAD_BUTTONED_LABEL},
-							  {DFB_DefPath, (ULONG) "dopus5:images/"},
-							  {TAG_MORE, (ULONG)_button_editor_function_layout}};
+							  {DFB_DefPath, (IPTR) "dopus5:images/"},
+							  {TAG_MORE, (IPTR)_button_editor_function_layout}};
 
 // Button editor objects
 const ObjectDef _button_editor_objects[] =

--- a/source/Modules/configopus/config_buttons_data.c
+++ b/source/Modules/configopus/config_buttons_data.c
@@ -22,26 +22,26 @@ const struct TagItem _buttons_thin_tags[] = {{GTCustom_ThinBorders, TRUE}, {TAG_
 					 _buttons_relative_tags[] = {{GTCustom_LayoutRel, GAD_BUTTONS_LAYOUT_AREA}, {TAG_END}},
 
 					 _buttons_bank_layout[] = {{GTCustom_LayoutRel, GAD_BUTTONS_BANK_EDITING},
-											   {TAG_MORE, (ULONG)_buttons_thin_tags}},
+											   {TAG_MORE, (IPTR)_buttons_thin_tags}},
 
 					 _buttons_button_layout[] = {{GTCustom_LayoutRel, GAD_BUTTONS_BUTTON_EDITING},
-												 {TAG_MORE, (ULONG)_buttons_thin_tags}},
+												 {TAG_MORE, (IPTR)_buttons_thin_tags}},
 
 					 _buttons_visual_layout[] = {{GTCustom_LayoutRel, GAD_BUTTONS_VISUAL_DISPLAY},
-												 {TAG_MORE, (ULONG)_buttons_thin_tags}},
+												 {TAG_MORE, (IPTR)_buttons_thin_tags}},
 
-					 _buttons_name_tags[] = {{GTST_MaxChars, 31}, {TAG_MORE, (ULONG)_buttons_bank_layout}},
+					 _buttons_name_tags[] = {{GTST_MaxChars, 31}, {TAG_MORE, (IPTR)_buttons_bank_layout}},
 
-					 _buttons_fontname_tags[] = {{GTST_MaxChars, 50}, {TAG_MORE, (ULONG)_buttons_bank_layout}},
+					 _buttons_fontname_tags[] = {{GTST_MaxChars, 50}, {TAG_MORE, (IPTR)_buttons_bank_layout}},
 
 					 _buttons_fontsize_tags[] = {{GTIN_MaxChars, 2},
 												 {STRINGA_Justification, GACT_STRINGCENTER},
-												 {TAG_MORE, (ULONG)_buttons_bank_layout}},
+												 {TAG_MORE, (IPTR)_buttons_bank_layout}},
 
 					 _buttons_backpic_popup_tags[] = {{GTCustom_Control, GAD_BUTTONS_BACKPIC},
-													  {TAG_MORE, (ULONG)_buttons_bank_layout}},
+													  {TAG_MORE, (IPTR)_buttons_bank_layout}},
 
-					 _buttons_backpic_tags[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)_buttons_bank_layout}},
+					 _buttons_backpic_tags[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)_buttons_bank_layout}},
 
 					 _clipboard_scroller_tags[] = {{GTSC_Total, 1},
 												   {GA_Immediate, TRUE},
@@ -50,8 +50,8 @@ const struct TagItem _buttons_thin_tags[] = {{GTCustom_ThinBorders, TRUE}, {TAG_
 												   {PGA_Freedom, LORIENT_VERT},
 												   {TAG_END}},
 
-					 _buttons_dragbar_orientation[] = {{GTCustom_LocaleLabels, (ULONG)_buttons_dragbar_labels},
-													   {TAG_MORE, (ULONG)_buttons_visual_layout}};
+					 _buttons_dragbar_orientation[] = {{GTCustom_LocaleLabels, (IPTR)_buttons_dragbar_labels},
+													   {TAG_MORE, (IPTR)_buttons_visual_layout}};
 
 // Objects
 const ObjectDef _config_buttons_objects[] =

--- a/source/Modules/configopus/config_environment_data.c
+++ b/source/Modules/configopus/config_environment_data.c
@@ -95,190 +95,190 @@ const static struct TagItem
 	_environment_relative_taglist[] = {{GTCustom_LayoutRel, GAD_ENVIRONMENT_EDIT_AREA}, {TAG_END, 0}},
 
 	// Screenmode selector
-	_environment_screenmode_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_screenmode_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Screen colours taglist
 	_environment_colors_taglist[] = {{GA_RelVerify, TRUE},
 									 {GA_Immediate, TRUE},
 									 {GTSL_Min, 2},
-									 {TAG_MORE, (ULONG)_environment_relative_taglist}},
+									 {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	_environment_colors_display_taglist[] = {{GTCustom_Borderless, TRUE},
 											 {GTCustom_Justify, JUSTIFY_LEFT},
-											 {TAG_MORE, (ULONG)_environment_relative_taglist}},
+											 {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Palette colour selector
-	_environment_palette_taglist[] = {{TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_palette_taglist[] = {{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// RGB sliders
 	_environment_colour_slider_taglist[] = {{GA_RelVerify, TRUE},
 											{GA_Immediate, TRUE},
 											{GTSL_MaxLevelLen, 5},
-											{GTSL_LevelFormat, (ULONG) "%ld  "},
+											{GTSL_LevelFormat, (IPTR) "%ld  "},
 											{GTSL_LevelPlace, PLACETEXT_RIGHT},
-											{GTCustom_CallBack, (ULONG)&_palette_slider_callback},
-											{TAG_MORE, (ULONG)_environment_relative_taglist}},
+											{GTCustom_CallBack, (IPTR)&_palette_slider_callback},
+											{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Colour count slider
-	_environment_colour_count_taglist[] = {{GTSL_Max, 8}, {TAG_MORE, (ULONG)_environment_colour_slider_taglist}},
+	_environment_colour_count_taglist[] = {{GTSL_Max, 8}, {TAG_MORE, (IPTR)_environment_colour_slider_taglist}},
 
 	// Lister colour items
-	_environment_lister_colour_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_lister_colour_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Backdrop preferences
 	_environment_buttons[] = {{GTCustom_Control, GAD_ENVIRONMENT_MAIN_WINDOW_FIELD},
-							  {DFB_DefPath, (ULONG) "env:sys/WBPattern.prefs"},
-							  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+							  {DFB_DefPath, (IPTR) "env:sys/WBPattern.prefs"},
+							  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Backdrop prefs file
-	_environment_buttons_field[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_buttons_field[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Themes preferences
 	_environment_themes_location[] = {{GTCustom_Control, GAD_ENVIRONMENT_THEMES_FIELD},
-									  {DFB_DefPath, (ULONG) "DOpus5:Themes/"},
-									  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+									  {DFB_DefPath, (IPTR) "DOpus5:Themes/"},
+									  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Themes location field
-	_environment_themes_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_themes_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Set output window name
-	_environment_output_name_tags[] = {{GTST_MaxChars, 60}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_output_name_tags[] = {{GTST_MaxChars, 60}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Set default stack
-	_environment_stack_tags[] = {{GTIN_MaxChars, 7}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_stack_tags[] = {{GTIN_MaxChars, 7}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Command line length
-	_environment_cll_tags[] = {{GTIN_MaxChars, 4}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_cll_tags[] = {{GTIN_MaxChars, 4}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Status bar text
-	_environment_status_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_status_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Screen title text
 	_environment_screen_title_taglist[] =
 		{
 			//		{GTST_MaxChars,120},
 			{GTST_MaxChars, 188},
-			{TAG_MORE, (ULONG)_environment_relative_taglist}},
+			{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Screen font
 	_environment_font_taglist[] = {{GTCustom_Control, GAD_ENVIRONMENT_SCREENMODE_FONTNAME},
-								   {TAG_MORE, (ULONG)_environment_relative_taglist}},
+								   {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
-	_environment_fontname_taglist[] = {{GTST_MaxChars, 50}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_fontname_taglist[] = {{GTST_MaxChars, 50}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
-	_environment_fontsize_taglist[] = {{GTIN_MaxChars, 2}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_fontsize_taglist[] = {{GTIN_MaxChars, 2}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Hideen drives cycle
-	_environment_hidden_drives_cycle[] = {{GTCustom_LocaleLabels, (ULONG)_environment_hidden_labels},
-										  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_hidden_drives_cycle[] = {{GTCustom_LocaleLabels, (IPTR)_environment_hidden_labels},
+										  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Hidden drives lister
 	_environment_hidden_drives[] = {{DLV_MultiSelect, TRUE},
 									{DLV_TopJustify, 1},
-									{TAG_MORE, (ULONG)_environment_relative_taglist}},
+									{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Lister editing
-	_environment_listeredit_taglist[] = {{GTCustom_LocaleLabels, (ULONG)_environment_listeredit_labels},
-										 {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_listeredit_taglist[] = {{GTCustom_LocaleLabels, (IPTR)_environment_listeredit_labels},
+										 {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Lister font
 	_environment_lister_font_taglist[] = {{GTCustom_Control, GAD_ENVIRONMENT_LISTER_FONTNAME},
 										  //		{GTCustom_FixedWidthOnly,TRUE},
 										  {GTCustom_CopyTags, TRUE},
-										  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+										  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Desktop popup
 	_environment_desktop_popup[] = {{GTCustom_Control, GAD_ENVIRONMENT_DESKTOP_LOCATION},
-									{TAG_MORE, (ULONG)_environment_relative_taglist}},
+									{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Desktop folder location
-	_environment_desktop_folder[] = {{GTST_MaxChars, 240}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_desktop_folder[] = {{GTST_MaxChars, 240}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Default action
-	_environment_desktop_default[] = {{GTCustom_LocaleLabels, (ULONG)_environment_default_labels},
-									  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_desktop_default[] = {{GTCustom_LocaleLabels, (IPTR)_environment_default_labels},
+									  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Precision
-	_environment_precision_taglist[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_precision_taglist[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Desktop picture
 	_environment_desktop_picture[] = {{GTCustom_Control, GAD_ENVIRONMENT_PICTURE_DESK_FIELD},
-									  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+									  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Desktop picture field
-	_environment_desktop_picture_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_desktop_picture_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Lister picture
 	_environment_lister_picture[] = {{GTCustom_Control, GAD_ENVIRONMENT_PICTURE_LISTER_FIELD},
-									 {TAG_MORE, (ULONG)_environment_relative_taglist}},
+									 {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Lister picture field
-	_environment_lister_picture_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_lister_picture_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Requester picture
 	_environment_requester_picture[] = {{GTCustom_Control, GAD_ENVIRONMENT_PICTURE_REQ_FIELD},
-										{TAG_MORE, (ULONG)_environment_relative_taglist}},
+										{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Requester picture field
-	_environment_requester_picture_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_requester_picture_field[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Maximum number of cached directories
-	_environment_caching_buffers_taglist[] = {{GTIN_MaxChars, 5}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_caching_buffers_taglist[] = {{GTIN_MaxChars, 5}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Disable caching
 	_environment_disable_caching_taglist[] = {{GTCustom_Control, GAD_SETTINGS_CACHING_MAX_BUFFERS},
-											  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+											  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Date format
-	_environment_dateformat_taglist[] = {{GTCustom_LocaleLabels, (ULONG)_environment_dateformat_labels},
-										 {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_dateformat_taglist[] = {{GTCustom_LocaleLabels, (IPTR)_environment_dateformat_labels},
+										 {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Hide method
-	_environment_hide_taglist[] = {{GTCustom_LocaleLabels, (ULONG)_environment_hidemethod_labels},
-								   {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_hide_taglist[] = {{GTCustom_LocaleLabels, (IPTR)_environment_hidemethod_labels},
+								   {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Popkey
-	_environment_popkey_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_popkey_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Priority
 	_environment_priority_taglist[] = {{GTIN_MaxChars, 4},
 									   {GTCustom_MinMax, (127 << 16) | ((unsigned short)-128)},
-									   {TAG_MORE, (ULONG)_environment_relative_taglist}},
+									   {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Icon settings
-	_environment_icon_settings_taglist[] = {{DLV_MultiSelect, 1}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_icon_settings_taglist[] = {{DLV_MultiSelect, 1}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Path list
 	_environment_pathlist_taglist[] = {{DLV_ShowSelected, 0},
 									   {DLV_DragNotify, 2},
-									   {TAG_MORE, (ULONG)_environment_relative_taglist}},
+									   {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Sounds
-	_environment_soundlist_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_soundlist_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	_environment_soundlist_popup_taglist[] = {{GTCustom_Control, GAD_SETTINGS_SOUNDLIST_PATH},
-											  {DFB_DefPath, (ULONG) "DOpus5:Sounds/"},
-											  {TAG_MORE, (ULONG)_environment_relative_taglist}},
+											  {DFB_DefPath, (IPTR) "DOpus5:Sounds/"},
+											  {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
-	_environment_soundlist_path_taglist[] = {{GTST_MaxChars, 255}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_soundlist_path_taglist[] = {{GTST_MaxChars, 255}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
-	_environment_volume_taglist[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_volume_taglist[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	_environment_volslider_taglist[] = {{GA_RelVerify, TRUE},
 										{GA_Immediate, TRUE},
 										{GTSL_Max, 64},
-										{TAG_MORE, (ULONG)_environment_relative_taglist}},
+										{TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Path list popup
 	_environment_pathlist_popup_taglist[] = {{GTCustom_Control, GAD_SETTINGS_PATHLIST_PATH},
-											 {TAG_MORE, (ULONG)_environment_relative_taglist}},
+											 {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
 	// Path
-	_environment_pathlist_path_taglist[] = {{GTST_MaxChars, 255}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_pathlist_path_taglist[] = {{GTST_MaxChars, 255}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
-	_environment_max_openwith_taglist[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (ULONG)_environment_relative_taglist}},
+	_environment_max_openwith_taglist[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (IPTR)_environment_relative_taglist}},
 
-	_environment_popup_delay_taglist[] = {{GTIN_MaxChars, 2}, {TAG_MORE, (ULONG)_environment_relative_taglist}};
+	_environment_popup_delay_taglist[] = {{GTIN_MaxChars, 2}, {TAG_MORE, (IPTR)_environment_relative_taglist}};
 
 // Flags objects
 const ObjectDef _config_environment_objects[] =
@@ -1184,7 +1184,7 @@ const ObjectDef _config_environment_objects[] =
 						 BUTTON_KIND,
 						 {POS_RIGHT_JUSTIFY - 2, 1, 0, 1},
 						 {-8, 12, 26, 6},
-						 (ULONG) "?",
+						 (IPTR) "?",
 						 TEXTFLAG_TEXT_STRING | BUTTONFLAG_IMMEDIATE,
 						 GAD_ENVIRONMENT_PICTURE_DESK_PREFS,
 						 _environment_relative_taglist},
@@ -1214,7 +1214,7 @@ const ObjectDef _config_environment_objects[] =
 						 BUTTON_KIND,
 						 {POS_RIGHT_JUSTIFY - 2, 2, 0, 1},
 						 {-8, 20, 26, 6},
-						 (ULONG) "?",
+						 (IPTR) "?",
 						 TEXTFLAG_TEXT_STRING | BUTTONFLAG_IMMEDIATE,
 						 GAD_ENVIRONMENT_PICTURE_LISTER_PREFS,
 						 _environment_relative_taglist},
@@ -1244,7 +1244,7 @@ const ObjectDef _config_environment_objects[] =
 						 BUTTON_KIND,
 						 {POS_RIGHT_JUSTIFY - 2, 3, 0, 1},
 						 {-8, 28, 26, 6},
-						 (ULONG) "?",
+						 (IPTR) "?",
 						 TEXTFLAG_TEXT_STRING | BUTTONFLAG_IMMEDIATE,
 						 GAD_ENVIRONMENT_PICTURE_REQ_PREFS,
 						 _environment_relative_taglist},
@@ -1294,7 +1294,7 @@ const ObjectDef _config_environment_objects[] =
 						 BUTTON_KIND,
 						 {POS_RIGHT_JUSTIFY - 2, 7, 0, 1},
 						 {-8, 44, 26, 6},
-						 (ULONG) "_!",
+						 (IPTR) "_!",
 						 TEXTFLAG_TEXT_STRING,
 						 GAD_ENVIRONMENT_EDIT_PATTERN,
 						 _environment_relative_taglist},

--- a/source/Modules/configopus/config_filetypes_data.c
+++ b/source/Modules/configopus/config_filetypes_data.c
@@ -65,11 +65,11 @@ const struct TagItem
 
 	_filetype_action_list_tags[] = {{DLV_ShowChecks, 2},
 									{DLV_ShowSelected, 0},
-									{TAG_MORE, (ULONG)_filetype_function_rel}},
+									{TAG_MORE, (IPTR)_filetype_function_rel}},
 
 	_filetype_icon_menu_tags[] = {{DLV_ShowSelected, 1},
 								  {DLV_DragNotify, 1},
-								  {TAG_MORE, (ULONG)_filetype_function_rel}},
+								  {TAG_MORE, (IPTR)_filetype_function_rel}},
 
 	_classed_name_tags[] = {{GTST_MaxChars, 31}, {TAG_END}},
 

--- a/source/Modules/configopus/config_menus_data.c
+++ b/source/Modules/configopus/config_menus_data.c
@@ -9,20 +9,20 @@ struct TagItem config_menu_layout_tags[] = {{GTCustom_LayoutRel, GAD_MENUS_LAYOU
 			   config_menu_list_tags[] = {{DLV_ShowSelected, 0},
 										  {DLV_DragNotify, 2},
 										  {DLV_ShowSeparators, 1},
-										  {TAG_MORE, (ULONG)config_menu_layout_tags}},
+										  {TAG_MORE, (IPTR)config_menu_layout_tags}},
 
 			   config_menukeys_list_tags[] = {{DLV_ShowSelected, 0},
 											  {DLV_ShowSeparators, 1},
-											  {TAG_MORE, (ULONG)config_menu_layout_tags}},
+											  {TAG_MORE, (IPTR)config_menu_layout_tags}},
 
 			   config_menu_name_tags[] = {{GTST_MaxChars, 64},
 										  {GTCustom_NoSelectNext, TRUE},
-										  {TAG_MORE, (ULONG)config_menu_layout_tags}},
+										  {TAG_MORE, (IPTR)config_menu_layout_tags}},
 
 			   config_menu_key_tags[] = {{GTST_MaxChars, 1},
 										 {GTCustom_NoSelectNext, TRUE},
 										 {GTCustom_UpperCase, TRUE},
-										 {TAG_MORE, (ULONG)config_menu_layout_tags}};
+										 {TAG_MORE, (IPTR)config_menu_layout_tags}};
 
 ObjectDef config_menu_objects[] = {
 

--- a/source/Modules/configopus/config_settings_data.c
+++ b/source/Modules/configopus/config_settings_data.c
@@ -27,27 +27,27 @@ struct TagItem
 	_settings_relative_taglist[] = {{GTCustom_LayoutRel, GAD_SETTINGS_EDIT_AREA}, {TAG_END}},
 
 	// Maximum number of cached directories
-	_settings_caching_buffers_taglist[] = {{GTIN_MaxChars, 5}, {TAG_MORE, (ULONG)&_settings_relative_taglist}},
+	_settings_caching_buffers_taglist[] = {{GTIN_MaxChars, 5}, {TAG_MORE, (IPTR)&_settings_relative_taglist}},
 
 	// Disable caching
 	_settings_disable_caching_taglist[] = {{GTCustom_Control, GAD_SETTINGS_CACHING_MAX_BUFFERS},
-										   {TAG_MORE, (ULONG)&_settings_relative_taglist}},
+										   {TAG_MORE, (IPTR)&_settings_relative_taglist}},
 
 	// Date format
-	_settings_dateformat_taglist[] = {{GTCustom_LocaleLabels, (ULONG)_settings_dateformat_labels},
-									  {TAG_MORE, (ULONG)&_settings_relative_taglist}},
+	_settings_dateformat_taglist[] = {{GTCustom_LocaleLabels, (IPTR)_settings_dateformat_labels},
+									  {TAG_MORE, (IPTR)&_settings_relative_taglist}},
 
 	// Hide method
-	_settings_hide_taglist[] = {{GTCustom_LocaleLabels, (ULONG)_settings_hidemethod_labels},
-								{TAG_MORE, (ULONG)&_settings_relative_taglist}},
+	_settings_hide_taglist[] = {{GTCustom_LocaleLabels, (IPTR)_settings_hidemethod_labels},
+								{TAG_MORE, (IPTR)&_settings_relative_taglist}},
 
 	// Popkey
-	_settings_popkey_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)&_settings_relative_taglist}},
+	_settings_popkey_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)&_settings_relative_taglist}},
 
 	// Priority
 	_settings_priority_taglist[] = {{GTIN_MaxChars, 4},
 									{GTCustom_MinMax, (127 << 16) | ((unsigned short)-128)},
-									{TAG_MORE, (ULONG)&_settings_relative_taglist}};
+									{TAG_MORE, (IPTR)&_settings_relative_taglist}};
 
 // Settings objects
 ObjectDef

--- a/source/Modules/configopus/function_editor_data.c
+++ b/source/Modules/configopus/function_editor_data.c
@@ -25,23 +25,23 @@ struct TagItem
 
 	_function_key_taglist[] = {{GTST_MaxChars, 80},
 							   {GTCustom_NoSelectNext, TRUE},
-							   {TAG_MORE, (ULONG)_function_edit_layout}},
+							   {TAG_MORE, (IPTR)_function_edit_layout}},
 
-	_function_type_taglist[] = {{GTCustom_LocaleLabels, (ULONG)_function_type_labels},
-								{TAG_MORE, (ULONG)_function_edit_layout}},
+	_function_type_taglist[] = {{GTCustom_LocaleLabels, (IPTR)_function_type_labels},
+								{TAG_MORE, (IPTR)_function_edit_layout}},
 
-	_function_lister_taglist[] = {{DLV_ShowSelected, 0}, {DLV_DragNotify, 2}, {TAG_MORE, (ULONG)_function_edit_layout}},
+	_function_lister_taglist[] = {{DLV_ShowSelected, 0}, {DLV_DragNotify, 2}, {TAG_MORE, (IPTR)_function_edit_layout}},
 
 	_function_flags_lister_taglist[] = {{DLV_MultiSelect, 1},
 										{DLV_Flags, PLACETEXT_LEFT},
-										{TAG_MORE, (ULONG)_function_edit_layout}},
+										{TAG_MORE, (IPTR)_function_edit_layout}},
 
 	_function_edit_taglist[] = {{GTST_MaxChars, 255},
 								{GTCustom_NoSelectNext, TRUE},
-								{TAG_MORE, (ULONG)_function_edit_layout}},
+								{TAG_MORE, (IPTR)_function_edit_layout}},
 
 	_function_editor_image[] = {{GTCustom_Control, GAD_FUNCED_LABEL},
-								{DFB_DefPath, (ULONG) "dopus5:images/"},
+								{DFB_DefPath, (IPTR) "dopus5:images/"},
 								{GTCustom_LayoutRel, GAD_FUNCED_LAYOUT_1},
 								{TAG_END}};
 
@@ -189,7 +189,7 @@ ObjectDef _function_editor_label_objects[] =
 				   BUTTON_KIND,
 				   {POS_RIGHT_JUSTIFY, 5, 0, 1},
 				   {-4, 9, 28, 6},
-				   (ULONG) "{ }",
+				   (IPTR) "{ }",
 				   TEXTFLAG_TEXT_STRING,
 				   GAD_FUNCED_EDIT_ARGUMENT,
 				   _function_edit_layout},

--- a/source/Modules/configopus/init/libinit.c
+++ b/source/Modules/configopus/init/libinit.c
@@ -102,13 +102,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -583,9 +583,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -651,9 +649,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/configopus/lister_buttons_data.c
+++ b/source/Modules/configopus/lister_buttons_data.c
@@ -9,7 +9,7 @@ struct TagItem
 	_lister_buttons_scroller[] = {{GA_RelVerify, TRUE},
 								  {GA_Immediate, TRUE},
 								  {GTSC_Arrows, 14},
-								  {TAG_MORE, (ULONG)_lister_buttons_layout}};
+								  {TAG_MORE, (IPTR)_lister_buttons_layout}};
 
 ObjectDef _lister_buttons_objects[] = {
 

--- a/source/Modules/configopus/lister_menu_data.c
+++ b/source/Modules/configopus/lister_menu_data.c
@@ -10,11 +10,11 @@ struct TagItem _lister_menu_layout[] = {{GTCustom_CopyTags, 1},
 
 			   _lister_menu_items[] = {{DLV_ShowSelected, 0},
 									   {DLV_DragNotify, 2},
-									   {TAG_MORE, (ULONG)&_lister_menu_layout}},
+									   {TAG_MORE, (IPTR)&_lister_menu_layout}},
 
-			   script_list_items[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)&_lister_menu_layout}},
+			   script_list_items[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)&_lister_menu_layout}},
 
-			   _lister_menu_name[] = {{GTST_MaxChars, 64}, {TAG_MORE, (ULONG)&_lister_menu_layout}};
+			   _lister_menu_name[] = {{GTST_MaxChars, 64}, {TAG_MORE, (IPTR)&_lister_menu_layout}};
 
 ObjectDef hotkeys_objects[] =
 	{

--- a/source/Modules/configopus/select_colours_data.c
+++ b/source/Modules/configopus/select_colours_data.c
@@ -10,7 +10,7 @@ struct TagItem _palette_box_tags[] = {{GTCustom_LayoutRel, GAD_PALETTE_LAYOUT}, 
 
 			   _palette_slider_tags[] = {{GA_RelVerify, TRUE},
 										 {GA_Immediate, TRUE},
-										 {TAG_MORE, (ULONG)_palette_box_tags}};
+										 {TAG_MORE, (IPTR)_palette_box_tags}};
 
 // Palette box objects
 ObjectDef

--- a/source/Modules/diskcopy/diskcopy_data.c
+++ b/source/Modules/diskcopy/diskcopy_data.c
@@ -32,9 +32,9 @@ struct TagItem
 
 	diskcopy_layout_tags[] = {{GTCustom_LayoutRel, GAD_DISKCOPY_LAYOUT}, {TAG_DONE}},
 
-	diskcopy_source_tags[] = {{DLV_ShowSelected, 0}, {DLV_Check, 1}, {TAG_MORE, (ULONG)&diskcopy_layout_tags}},
+	diskcopy_source_tags[] = {{DLV_ShowSelected, 0}, {DLV_Check, 1}, {TAG_MORE, (IPTR)&diskcopy_layout_tags}},
 
-	diskcopy_dest_tags[] = {{DLV_MultiSelect, 1}, {TAG_MORE, (ULONG)&diskcopy_layout_tags}};
+	diskcopy_dest_tags[] = {{DLV_MultiSelect, 1}, {TAG_MORE, (IPTR)&diskcopy_layout_tags}};
 
 ObjectDef diskcopy_objects[] = {
 

--- a/source/Modules/diskcopy/init/libinit.c
+++ b/source/Modules/diskcopy/init/libinit.c
@@ -103,13 +103,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -578,9 +578,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -646,9 +644,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/diskinfo/diskinfo_data.c
+++ b/source/Modules/diskinfo/diskinfo_data.c
@@ -36,27 +36,27 @@ struct TagItem diskinfo_layout[] = {{GTCustom_LayoutRel, DISKINFO_LAYOUT}, {TAG_
 
 			   button_tags[] = {{GTCustom_ThinBorders, TRUE}, {TAG_END}},
 
-			   name_tags[] = {{GTST_MaxChars, 31}, {GTCustom_PathFilter, 1}, {TAG_MORE, (ULONG)diskinfo_layout}},
+			   name_tags[] = {{GTST_MaxChars, 31}, {GTCustom_PathFilter, 1}, {TAG_MORE, (IPTR)diskinfo_layout}},
 
-			   key_tags[] = {{GTCustom_LayoutPos, GAD_NAME}, {TAG_MORE, (ULONG)diskinfo_layout}},
+			   key_tags[] = {{GTCustom_LayoutPos, GAD_NAME}, {TAG_MORE, (IPTR)diskinfo_layout}},
 
 			   handler_tags[] = {{GTCustom_Borderless, TRUE},
 								 {GTCustom_Justify, JUSTIFY_LEFT},
-								 {TAG_MORE, (ULONG)key_tags}},
+								 {TAG_MORE, (IPTR)key_tags}},
 
 			   space_tags[] = {{GTCustom_Borderless, TRUE},
 							   {GTCustom_Justify, JUSTIFY_RIGHT},
-							   {TAG_MORE, (ULONG)key_tags}},
+							   {TAG_MORE, (IPTR)key_tags}},
 
 			   errors_tags[] = {{GTCustom_Borderless, TRUE},
 								{GTCustom_Justify, JUSTIFY_RIGHT},
-								{TAG_MORE, (ULONG)diskinfo_layout}},
+								{TAG_MORE, (IPTR)diskinfo_layout}},
 
-			   used_mb_tags[] = {{GTCustom_LayoutPos, GAD_USED}, {TAG_MORE, (ULONG)errors_tags}},
+			   used_mb_tags[] = {{GTCustom_LayoutPos, GAD_USED}, {TAG_MORE, (IPTR)errors_tags}},
 
-			   free_mb_tags[] = {{GTCustom_LayoutPos, GAD_FREE}, {TAG_MORE, (ULONG)errors_tags}},
+			   free_mb_tags[] = {{GTCustom_LayoutPos, GAD_FREE}, {TAG_MORE, (IPTR)errors_tags}},
 
-			   capacity_mb_tags[] = {{GTCustom_LayoutPos, GAD_CAPACITY}, {TAG_MORE, (ULONG)errors_tags}};
+			   capacity_mb_tags[] = {{GTCustom_LayoutPos, GAD_CAPACITY}, {TAG_MORE, (IPTR)errors_tags}};
 
 // Disk info objects
 ObjectDef diskinfo_objects[] = {

--- a/source/Modules/diskinfo/init/libinit.c
+++ b/source/Modules/diskinfo/init/libinit.c
@@ -100,13 +100,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -166,7 +166,7 @@ extern struct Library *MathIeeeDoubTransBase;
 	#endif
 #endif
 
-#if defined(__amigaos4__) || defined(__MORPHOS__)
+#if defined(__amigaos4__) || defined(__MORPHOS__) || defined(__AROS__)
 struct Library *MathIeeeSingBasBase = NULL;
 struct Library *MathIeeeSingTransBase = NULL;
 struct Library *MathIeeeDoubBasBase = NULL;
@@ -588,9 +588,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -656,9 +654,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/filetype/filetype_data.c
+++ b/source/Modules/filetype/filetype_data.c
@@ -64,7 +64,7 @@ struct TagItem
 	finder_listview_tags[] = {{DLV_ShowSelected, 0},
 							  {DLV_ShowChecks, 2},
 							  {DLV_ReadOnly, 1},
-							  {TAG_MORE, (ULONG)finder_layout}};
+							  {TAG_MORE, (IPTR)finder_layout}};
 
 ConfigWindow _finder_window = {{POS_CENTER, POS_CENTER, FWINW1, FWINH1}, {0, 0, FWINW2, FWINH2}};
 
@@ -246,13 +246,13 @@ struct TagItem
 
 	creator_layout[] = {{GTCustom_LayoutRel, GAD_CREATE_LAYOUT}, {TAG_END}},
 
-	creator_listview_tags[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)creator_layout}},
+	creator_listview_tags[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)creator_layout}},
 
-	creator_cycle_tags[] = {{GTCustom_LocaleLabels, (ULONG)creator_cycle_labels}, {TAG_MORE, (ULONG)creator_layout}},
+	creator_cycle_tags[] = {{GTCustom_LocaleLabels, (IPTR)creator_cycle_labels}, {TAG_MORE, (IPTR)creator_layout}},
 
 	creator_filetype_name_tags[] = {{GTST_MaxChars, FILETYPE_MAXLEN},
-									{GTST_String, (ULONG) "Untitled"},
-									{TAG_MORE, (ULONG)creator_layout}};
+									{GTST_String, (IPTR) "Untitled"},
+									{TAG_MORE, (IPTR)creator_layout}};
 
 ConfigWindow _creator_window = {{POS_CENTER, POS_CENTER, LISTVIEW_W1 * 3, 8},
 								{0,

--- a/source/Modules/filetype/init/libinit.c
+++ b/source/Modules/filetype/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -579,9 +579,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -647,9 +645,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/fixicons/init/libinit.c
+++ b/source/Modules/fixicons/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -579,9 +579,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -647,9 +645,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/format/format_data.c
+++ b/source/Modules/format/format_data.c
@@ -32,9 +32,9 @@ struct TagItem
 
 	format_layout_tags[] = {{GTCustom_LayoutRel, GAD_FORMAT_LAYOUT}, {TAG_DONE}},
 
-	format_devices_tags[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)&format_layout_tags}},
+	format_devices_tags[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)&format_layout_tags}},
 
-	format_name_tags[] = {{GTST_MaxChars, 30}, {TAG_MORE, (ULONG)&format_layout_tags}};
+	format_name_tags[] = {{GTST_MaxChars, 30}, {TAG_MORE, (IPTR)&format_layout_tags}};
 
 ObjectDef format_objects[] = {
 

--- a/source/Modules/format/init/libinit.c
+++ b/source/Modules/format/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -579,9 +579,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -647,9 +645,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/ftp/ftp.h
+++ b/source/Modules/ftp/ftp.h
@@ -36,11 +36,43 @@ For more information on Directory Opus for Windows please see:
 #include <proto/socket.h>
 #undef __NOGLOBALIFACE__
 #undef __NOLIBBASE__
-#include <netinet/in_systm.h>
+#if !defined(__has_include) || __has_include(<netinet/in_systm.h>)
+	#include <netinet/in_systm.h>
+#endif
 #include <netinet/in.h>
+#ifdef __AROS__
+	#include <endian.h>
+	#ifndef BYTE_ORDER
+		#define BYTE_ORDER _BYTE_ORDER
+	#endif
+#endif
+#if !defined(__has_include) || __has_include(<netinet/ip.h>)
 #include <netinet/ip.h>
+#endif
+#ifndef IPTOS_LOWDELAY
+#define IPTOS_LOWDELAY 0x10
+#endif
+#ifndef IPTOS_THROUGHPUT
+#define IPTOS_THROUGHPUT 0x08
+#endif
+#if !defined(__has_include) || __has_include(<arpa/ftp.h>)
 #include <arpa/ftp.h>
+#endif
+#ifndef PRELIM
+#define PRELIM 1
+#define COMPLETE 2
+#define CONTINUE 3
+#define TRANSIENT 4
+#define ERROR 5
+#endif
+#if !defined(__has_include) || __has_include(<arpa/telnet.h>)
 #include <arpa/telnet.h>
+#endif
+#ifndef IAC
+#define DM 242
+#define IP 244
+#define IAC 255
+#endif
 #include <netdb.h>
 #include <time.h>
 

--- a/source/Modules/ftp/ftp_data.c
+++ b/source/Modules/ftp/ftp_data.c
@@ -48,16 +48,16 @@ struct TagItem
 						// The docs say 1 for drag in all directions, 2 for sideways only
 						// In reality, it's the other way around
 						{DLV_DragNotify, 2},
-						{TAG_MORE, (ULONG)ftp_main_layout_tags}},
+						{TAG_MORE, (IPTR)ftp_main_layout_tags}},
 
 	ftp_rhs_layout_tags[] = {{GTCustom_LayoutRel, GAD_FTP_SITE_LAYOUT}, {GTCustom_CopyTags, TRUE}, {TAG_DONE}},
 
 	ftp_anon_tags[] = {{GA_Disabled, TRUE},
 					   {GTCustom_NoGhost, TRUE},
 					   {GTCustom_Recessed, TRUE},
-					   {TAG_MORE, (ULONG)ftp_rhs_layout_tags}},
+					   {TAG_MORE, (IPTR)ftp_rhs_layout_tags}},
 
-	ftp_port_tags[] = {{GTCustom_Justify, JUSTIFY_CENTER}, {TAG_MORE, (ULONG)ftp_rhs_layout_tags}},
+	ftp_port_tags[] = {{GTCustom_Justify, JUSTIFY_CENTER}, {TAG_MORE, (IPTR)ftp_rhs_layout_tags}},
 
 	ftp_custom_relative_tags[] = {{GTCustom_LayoutRel, GAD_FTP_CUSTOM_LAYOUT}, {GTCustom_CopyTags, TRUE}, {TAG_DONE}},
 
@@ -65,7 +65,7 @@ struct TagItem
 	ftp_customs_options_taglist[] = {{GA_Disabled, TRUE},
 									 {GTCustom_NoGhost, TRUE},
 									 {GTCustom_Recessed, TRUE},
-									 {TAG_MORE, (ULONG)ftp_custom_relative_tags}};
+									 {TAG_MORE, (IPTR)ftp_custom_relative_tags}};
 
 #define STRHGT 6
 #define CHECKBOX_HGT 4
@@ -282,39 +282,39 @@ static struct TagItem
 	// Relative to area tags[]={
 	ftp_relative_taglist[] = {{GTCustom_LayoutRel, GAD_ENV_EDIT_AREA}, {TAG_END, 0}},
 
-	ftp_options_anon_tags[] = {{GTST_MaxChars, PASSWORDLEN}, {TAG_MORE, (ULONG)ftp_relative_taglist}},
+	ftp_options_anon_tags[] = {{GTST_MaxChars, PASSWORDLEN}, {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	ftp_options_log_tags[] = {{GTST_MaxChars, LOGNAMELEN}, {TAG_MORE, (ULONG)ftp_relative_taglist}},
+	ftp_options_log_tags[] = {{GTST_MaxChars, LOGNAMELEN}, {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
 	// string gadget for 4 chars
-	ftp_integer_field_4[] = {{GTIN_MaxChars, 4}, {TAG_MORE, (ULONG)ftp_relative_taglist}},
+	ftp_integer_field_4[] = {{GTIN_MaxChars, 4}, {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	ftp_text_field_256[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)ftp_relative_taglist}},
+	ftp_text_field_256[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	allow_resume_taglist[] = {{GTCustom_LocaleLabels, (ULONG)allow_resume_labels},
+	allow_resume_taglist[] = {{GTCustom_LocaleLabels, (IPTR)allow_resume_labels},
 							  {GTCustom_CopyTags, TRUE},
-							  {TAG_MORE, (ULONG)ftp_relative_taglist}},
+							  {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	copy_type_taglist[] = {{GTCustom_LocaleLabels, (ULONG)copy_type_labels},
+	copy_type_taglist[] = {{GTCustom_LocaleLabels, (IPTR)copy_type_labels},
 						   {GTCustom_CopyTags, TRUE},
-						   {TAG_MORE, (ULONG)ftp_relative_taglist}},
+						   {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	tls_mode_taglist[] = {{GTCustom_LocaleLabels, (ULONG)tls_mode_labels},
+	tls_mode_taglist[] = {{GTCustom_LocaleLabels, (IPTR)tls_mode_labels},
 						  {GTCustom_CopyTags, TRUE},
-						  {TAG_MORE, (ULONG)ftp_relative_taglist}},
+						  {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	unklinks_taglist[] = {{GTCustom_LocaleLabels, (ULONG)unklinks_labels},
+	unklinks_taglist[] = {{GTCustom_LocaleLabels, (IPTR)unklinks_labels},
 						  {GTCustom_CopyTags, TRUE},
-						  {TAG_MORE, (ULONG)ftp_relative_taglist}},
+						  {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
-	addr_dc_taglist[] = {{GTCustom_LocaleLabels, (ULONG)addr_dc_labels},
+	addr_dc_taglist[] = {{GTCustom_LocaleLabels, (IPTR)addr_dc_labels},
 						 {GTCustom_CopyTags, TRUE},
-						 {TAG_MORE, (ULONG)ftp_relative_taglist}},
+						 {TAG_MORE, (IPTR)ftp_relative_taglist}},
 
 	ftp_custom_format_taglist[] = {{GA_Disabled, TRUE},
 								   {GTCustom_NoGhost, TRUE},
 								   {GTCustom_Recessed, TRUE},
-								   {TAG_MORE, (ULONG)ftp_relative_taglist}};
+								   {TAG_MORE, (IPTR)ftp_relative_taglist}};
 
 #define LEFT_EDGE_GAD 10
 
@@ -958,23 +958,23 @@ static struct TagItem
 
 	ftp_connect_layout_tags[] = {{GTCustom_LayoutRel, GAD_CONNECT_LAYOUT}, {GTCustom_CopyTags, TRUE}, {TAG_DONE}},
 
-	ftp_connection_tags[] = {{GTCustom_LocaleLabels, (ULONG)connection_labels},
+	ftp_connection_tags[] = {{GTCustom_LocaleLabels, (IPTR)connection_labels},
 							 {GTCustom_CopyTags, TRUE},
-							 {TAG_MORE, (ULONG)ftp_connect_layout_tags}},
+							 {TAG_MORE, (IPTR)ftp_connect_layout_tags}},
 
-	ftp_connect_name_tags[] = {{GTST_MaxChars, HOSTNAMELEN}, {TAG_MORE, (ULONG)ftp_connect_layout_tags}},
+	ftp_connect_name_tags[] = {{GTST_MaxChars, HOSTNAMELEN}, {TAG_MORE, (IPTR)ftp_connect_layout_tags}},
 
 	ftp_connect_port_tags[] = {{GTIN_MaxChars, 5},
 							   {GTCustom_Justify, JUSTIFY_CENTER},
-							   {TAG_MORE, (ULONG)ftp_connect_layout_tags}},
+							   {TAG_MORE, (IPTR)ftp_connect_layout_tags}},
 
-	ftp_connect_user_tags[] = {{GTST_MaxChars, USERNAMELEN}, {TAG_MORE, (ULONG)ftp_connect_layout_tags}},
+	ftp_connect_user_tags[] = {{GTST_MaxChars, USERNAMELEN}, {TAG_MORE, (IPTR)ftp_connect_layout_tags}},
 
 	ftp_connect_pass_tags[] = {{GTST_MaxChars, PASSWORDLEN},
 							   {GTCustom_Secure, TRUE},
-							   {TAG_MORE, (ULONG)ftp_connect_layout_tags}},
+							   {TAG_MORE, (IPTR)ftp_connect_layout_tags}},
 
-	ftp_connect_dir_tags[] = {{GTST_MaxChars, PATHLEN}, {TAG_MORE, (ULONG)ftp_connect_layout_tags}};
+	ftp_connect_dir_tags[] = {{GTST_MaxChars, PATHLEN}, {TAG_MORE, (IPTR)ftp_connect_layout_tags}};
 
 ObjectDef
 
@@ -1127,9 +1127,9 @@ static struct TagItem
 	edit_custom_relative_tags[] = {{GTCustom_LayoutRel, GAD_EDIT_CUSTOM_LAYOUT}, {GTCustom_CopyTags, TRUE}, {TAG_DONE}},
 
 	//
-	edit_custom_options_taglist[] = {{GTCustom_LocaleLabels, (ULONG)custom_options_labels},
+	edit_custom_options_taglist[] = {{GTCustom_LocaleLabels, (IPTR)custom_options_labels},
 									 {GTCustom_CopyTags, TRUE},
-									 {TAG_MORE, (ULONG)edit_custom_relative_tags}};
+									 {TAG_MORE, (IPTR)edit_custom_relative_tags}};
 
 ObjectDef
 

--- a/source/Modules/ftp/init/libinit.c
+++ b/source/Modules/ftp/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -583,9 +583,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -651,9 +649,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/icon/icon_data.c
+++ b/source/Modules/icon/icon_data.c
@@ -42,22 +42,22 @@ ConfigWindow icon_disk_window = {{POS_CENTER, POS_CENTER, 62, 9}, {0, 0, 12, 38}
 
 struct TagItem icon_layout[] = {{GTCustom_CopyTags, 1}, {GTCustom_LayoutRel, GAD_ICON_LAYOUT_AREA}, {TAG_END}},
 
-			   icon_stack_tags[] = {{GTIN_MaxChars, 10}, {TAG_MORE, (ULONG)icon_layout}},
+			   icon_stack_tags[] = {{GTIN_MaxChars, 10}, {TAG_MORE, (IPTR)icon_layout}},
 
-			   icon_protection_tags[] = {{DLV_MultiSelect, 1}, {DLV_NoScroller, 1}, {TAG_MORE, (ULONG)icon_layout}},
+			   icon_protection_tags[] = {{DLV_MultiSelect, 1}, {DLV_NoScroller, 1}, {TAG_MORE, (IPTR)icon_layout}},
 
-			   icon_comment_tags[] = {{GTST_MaxChars, 79}, {TAG_MORE, (ULONG)icon_layout}},
+			   icon_comment_tags[] = {{GTST_MaxChars, 79}, {TAG_MORE, (IPTR)icon_layout}},
 
 			   icon_tooltypes_tags[] = {{DLV_ShowSelected, 0},
 										{DLV_Flags, PLACETEXT_LEFT},
 										{DLV_DragNotify, 2},
 										{GTST_MaxChars, 255},
 										{GTCustom_NoSelectNext, TRUE},
-										{TAG_MORE, (ULONG)icon_layout}},
+										{TAG_MORE, (IPTR)icon_layout}},
 
-			   icon_default_tool_tags[] = {{GTST_MaxChars, 255}, {TAG_MORE, (ULONG)icon_layout}},
+			   icon_default_tool_tags[] = {{GTST_MaxChars, 255}, {TAG_MORE, (IPTR)icon_layout}},
 
-			   icon_location_tags[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)icon_layout}};
+			   icon_location_tags[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)icon_layout}};
 
 ObjectDef
 

--- a/source/Modules/icon/init/libinit.c
+++ b/source/Modules/icon/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -585,9 +585,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -653,9 +651,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/join/init/libinit.c
+++ b/source/Modules/join/init/libinit.c
@@ -106,13 +106,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -581,9 +581,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -649,9 +647,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/join/join_data.c
+++ b/source/Modules/join/join_data.c
@@ -54,23 +54,23 @@ struct TagItem
 
 	join_layout_tags[] = {{GTCustom_LayoutRel, GAD_JOIN_LAYOUT}, {GTCustom_CopyTags, TRUE}, {TAG_END}},
 
-	join_lister_tags[] = {{DLV_ShowSelected, 0}, {DLV_ShowFilenames, 1}, {TAG_MORE, (ULONG)join_layout_tags}},
+	join_lister_tags[] = {{DLV_ShowSelected, 0}, {DLV_ShowFilenames, 1}, {TAG_MORE, (IPTR)join_layout_tags}},
 
 	join_popup_tags[] = {{GTCustom_Control, GAD_JOIN_TO_FIELD},
-						 {DFB_DefPath, (ULONG) "ram:"},
-						 {TAG_MORE, (ULONG)join_layout_tags}},
+						 {DFB_DefPath, (IPTR) "ram:"},
+						 {TAG_MORE, (IPTR)join_layout_tags}},
 
-	join_to_tags[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)join_layout_tags}},
+	join_to_tags[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)join_layout_tags}},
 
-	split_from_popup_tags[] = {{GTCustom_Control, GAD_SPLIT_FROM}, {TAG_MORE, (ULONG)join_layout_tags}},
+	split_from_popup_tags[] = {{GTCustom_Control, GAD_SPLIT_FROM}, {TAG_MORE, (IPTR)join_layout_tags}},
 
-	split_to_popup_tags[] = {{GTCustom_Control, GAD_SPLIT_TO}, {TAG_MORE, (ULONG)join_layout_tags}},
+	split_to_popup_tags[] = {{GTCustom_Control, GAD_SPLIT_TO}, {TAG_MORE, (IPTR)join_layout_tags}},
 
-	split_stem_tags[] = {{GTST_MaxChars, 27}, {TAG_MORE, (ULONG)join_layout_tags}},
+	split_stem_tags[] = {{GTST_MaxChars, 27}, {TAG_MORE, (IPTR)join_layout_tags}},
 
-	split_into_tags[] = {{GTIN_MaxChars, 5}, {TAG_MORE, (ULONG)join_layout_tags}},
+	split_into_tags[] = {{GTIN_MaxChars, 5}, {TAG_MORE, (IPTR)join_layout_tags}},
 
-	split_sizes_tags[] = {{GTCustom_LocaleLabels, (ULONG)chunk_labels}, {TAG_MORE, (ULONG)join_layout_tags}};
+	split_sizes_tags[] = {{GTCustom_LocaleLabels, (IPTR)chunk_labels}, {TAG_MORE, (IPTR)join_layout_tags}};
 
 ObjectDef
 	join_objects[] =

--- a/source/Modules/listerformat/init/libinit.c
+++ b/source/Modules/listerformat/init/libinit.c
@@ -106,13 +106,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -581,9 +581,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -649,9 +647,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/listerformat/listerformat_data.c
+++ b/source/Modules/listerformat/listerformat_data.c
@@ -48,17 +48,17 @@ struct TagItem
 	lister_selitems_taglist[] = {{DLV_ShowSelected, 0},
 								 {DLV_Check, 1},
 								 {DLV_DragNotify, 2},
-								 {TAG_MORE, (ULONG)lister_relative_taglist}},
+								 {TAG_MORE, (IPTR)lister_relative_taglist}},
 
 	// Available display items lister
-	lister_items_taglist[] = {{DLV_DragNotify, 2}, {TAG_MORE, (ULONG)lister_relative_taglist}},
+	lister_items_taglist[] = {{DLV_DragNotify, 2}, {TAG_MORE, (IPTR)lister_relative_taglist}},
 
 	// Filter
-	lister_filter_taglist[] = {{GTST_MaxChars, 39}, {TAG_MORE, (ULONG)lister_relative_taglist}},
+	lister_filter_taglist[] = {{GTST_MaxChars, 39}, {TAG_MORE, (IPTR)lister_relative_taglist}},
 
 	// Separation method
-	lister_separation_taglist[] = {{GTCustom_LocaleLabels, (ULONG)lister_separation_labels},
-								   {TAG_MORE, (ULONG)lister_relative_taglist}};
+	lister_separation_taglist[] = {{GTCustom_LocaleLabels, (IPTR)lister_separation_labels},
+								   {TAG_MORE, (IPTR)lister_relative_taglist}};
 
 // Lister window gadgets
 ObjectDef listformat_objects[] =

--- a/source/Modules/makefile
+++ b/source/Modules/makefile
@@ -19,12 +19,12 @@ export arch
 # Compiles debug version of dopus5 components for OS3 & creates
 # release archive.
 
-# make i386-aros release debug=no
-# Compiles normal version of dopus5 components for i386-AROS & creates
+# make x86_64-aros release debug=no
+# Compiles normal version of dopus5 components for x86_64-AROS & creates
 # release archive.
 ###########################################################
 # Read platform arguments from the "Make" command line:
-# Acceptable platform arguments are os3, os4, mos, i386-aros or arm-aros.
+# Acceptable platform arguments are os3, os4, mos, i386-aros or x86_64-aros.
 PLATFORM:= none
 NAME:=
 ifeq ($(findstring os3, $(MAKECMDGOALS)),os3)
@@ -39,26 +39,26 @@ ifeq ($(findstring mos, $(MAKECMDGOALS)),mos)
 	PLATFORM:= mos
 	NAME:= $(PLATFORM) $(NAME)
 endif
-ifeq ($(findstring arm-aros, $(MAKECMDGOALS)),arm-aros)
-	PLATFORM:= aros
-	arch:= arm
-	NAME:= $(arch)-$(PLATFORM) $(NAME)
-endif
 ifeq ($(findstring i386-aros, $(MAKECMDGOALS)),i386-aros)
 	PLATFORM:= aros
 	arch:= i386
+	NAME:= $(arch)-$(PLATFORM) $(NAME)
+endif
+ifeq ($(findstring x86_64-aros, $(MAKECMDGOALS)),x86_64-aros)
+	PLATFORM:= aros
+	arch:= x86_64
 	NAME:= $(arch)-$(PLATFORM) $(NAME)
 endif
 NAME := $(strip $(NAME))
 
 # Generate error if no platform entered on "Make" command line.
 ifeq ($(PLATFORM), none)
-$(error Error: Enter a platform (os3, os4, mos, arm-aros or i386-aros).)
+$(error Error: Enter a platform (os3, os4, mos, i386-aros or x86_64-aros).)
 endif
 
 #Generate error if multiple platforms entered on "Make" command line.
 ifneq ($(words $(NAME)), 1)
-$(error Error: Enter only 1 platform (os3, os4, mos, arm-aros or i386-aros).)
+$(error Error: Enter only 1 platform (os3, os4, mos, i386-aros or x86_64-aros).)
 endif
 
 # Compile all if only a platform is entered on "Make" command line.
@@ -68,10 +68,15 @@ endif
 ###########################################################
 
 
-.PHONY : all
-all: about cleanup configopus diskcopy diskinfo filetype fixicons \
+MODULES := about cleanup configopus diskcopy diskinfo filetype fixicons \
      format ftp icon join listerformat misc pathformat play print \
-     read show themes xadopus
+     read show themes
+ifneq ($(PLATFORM), aros)
+MODULES += xadopus
+endif
+
+.PHONY : all
+all: $(MODULES)
 	@echo " "
 
 .PHONY : about
@@ -332,9 +337,9 @@ clean-xadopus:
 # commands when entered as a goal for "make"
 # on the command line (like: make os3).
 
-.PHONY : os3 os4 mos i386-aros arm-aros
+.PHONY : os3 os4 mos i386-aros x86_64-aros
 i386-aros: mos
-arm-aros: mos
+x86_64-aros: mos
 os3: mos
 os4: mos
 aros: mos

--- a/source/Modules/misc/init/libinit.c
+++ b/source/Modules/misc/init/libinit.c
@@ -96,13 +96,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -571,9 +571,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -639,9 +637,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/pathformat/init/libinit.c
+++ b/source/Modules/pathformat/init/libinit.c
@@ -96,13 +96,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -573,9 +573,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -641,9 +639,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/pathformat/pathformat_data.c
+++ b/source/Modules/pathformat/pathformat_data.c
@@ -38,19 +38,19 @@ struct TagItem
 	path_relative_taglist[] = {{GTCustom_LayoutRel, GAD_PATHFORMAT_LAYOUT}, {TAG_END, 0}},
 
 	// Path lister
-	path_lister_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (ULONG)path_relative_taglist}},
+	path_lister_taglist[] = {{DLV_ShowSelected, 0}, {TAG_MORE, (IPTR)path_relative_taglist}},
 
 	// Path folder
-	path_folder_taglist[] = {{GTCustom_Control, GAD_PATHFORMAT_PATH}, {TAG_MORE, (ULONG)path_relative_taglist}},
+	path_folder_taglist[] = {{GTCustom_Control, GAD_PATHFORMAT_PATH}, {TAG_MORE, (IPTR)path_relative_taglist}},
 
 	// Key
-	path_key_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)path_relative_taglist}},
+	path_key_taglist[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)path_relative_taglist}},
 
 	// Path
-	path_path_taglist[] = {{GTST_MaxChars, 256}, {TAG_MORE, (ULONG)path_relative_taglist}},
+	path_path_taglist[] = {{GTST_MaxChars, 256}, {TAG_MORE, (IPTR)path_relative_taglist}},
 
 	// Mode
-	path_mode_taglist[] = {{GTCustom_LocaleLabels, (ULONG)mode_labels}, {TAG_MORE, (ULONG)path_relative_taglist}};
+	path_mode_taglist[] = {{GTCustom_LocaleLabels, (IPTR)mode_labels}, {TAG_MORE, (IPTR)path_relative_taglist}};
 
 // Path window gadgets
 ObjectDef pathformat_objects[] = {

--- a/source/Modules/play/init/libinit.c
+++ b/source/Modules/play/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -579,9 +579,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -647,9 +645,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/print/init/libinit.c
+++ b/source/Modules/print/init/libinit.c
@@ -106,13 +106,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -581,9 +581,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -649,9 +647,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/print/print_data.c
+++ b/source/Modules/print/print_data.c
@@ -51,24 +51,24 @@ static struct TagItem
 
 	header_layout[] = {{GTCustom_LayoutRel, GAD_PRINT_HEADER_LAYOUT}, {TAG_END}},
 
-	print_quality[] = {{GTCustom_LocaleLabels, (ULONG)print_quality_labels}, {TAG_MORE, (ULONG)text_layout}},
+	print_quality[] = {{GTCustom_LocaleLabels, (IPTR)print_quality_labels}, {TAG_MORE, (IPTR)text_layout}},
 
-	print_spacing[] = {{GTCustom_LocaleLabels, (ULONG)print_spacing_labels}, {TAG_MORE, (ULONG)text_layout}},
+	print_spacing[] = {{GTCustom_LocaleLabels, (IPTR)print_spacing_labels}, {TAG_MORE, (IPTR)text_layout}},
 
-	print_pitch[] = {{GTCustom_LocaleLabels, (ULONG)print_pitch_labels}, {TAG_MORE, (ULONG)text_layout}},
+	print_pitch[] = {{GTCustom_LocaleLabels, (IPTR)print_pitch_labels}, {TAG_MORE, (IPTR)text_layout}},
 
-	print_margin[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (ULONG)text_layout}},
+	print_margin[] = {{GTIN_MaxChars, 3}, {TAG_MORE, (IPTR)text_layout}},
 
-	print_tab_size[] = {{GTIN_MaxChars, 1}, {TAG_MORE, (ULONG)text_layout}},
+	print_tab_size[] = {{GTIN_MaxChars, 1}, {TAG_MORE, (IPTR)text_layout}},
 
-	print_output[] = {{GTCustom_LocaleLabels, (ULONG)print_output_labels}, {TAG_MORE, (ULONG)text_layout}},
+	print_output[] = {{GTCustom_LocaleLabels, (IPTR)print_output_labels}, {TAG_MORE, (IPTR)text_layout}},
 
-	print_header_footer_tags[] = {{GTCustom_LocaleLabels, (ULONG)print_header_footer_labels},
-								  {TAG_MORE, (ULONG)header_layout}},
+	print_header_footer_tags[] = {{GTCustom_LocaleLabels, (IPTR)print_header_footer_labels},
+								  {TAG_MORE, (IPTR)header_layout}},
 
-	print_title[] = {{GTST_MaxChars, 40}, {TAG_MORE, (ULONG)header_layout}},
+	print_title[] = {{GTST_MaxChars, 40}, {TAG_MORE, (IPTR)header_layout}},
 
-	print_style[] = {{GTCustom_LocaleLabels, (ULONG)print_style_labels}, {TAG_MORE, (ULONG)header_layout}};
+	print_style[] = {{GTCustom_LocaleLabels, (IPTR)print_style_labels}, {TAG_MORE, (IPTR)header_layout}};
 
 ObjectDef print_objects[] = {
 

--- a/source/Modules/read/init/libinit.c
+++ b/source/Modules/read/init/libinit.c
@@ -106,13 +106,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -581,9 +581,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -649,9 +647,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/read/read_data.c
+++ b/source/Modules/read/read_data.c
@@ -74,7 +74,7 @@ const ConfigWindow search_window = {{POS_CENTER, POS_CENTER, 48, 5}, {0, 0, 0, 4
 
 const struct TagItem search_layout[] = {{GTCustom_LayoutRel, GAD_SEARCH_LAYOUT}, {TAG_DONE}},
 
-					 search_text_tags[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)search_layout}};
+					 search_text_tags[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)search_layout}};
 
 const ObjectDef search_objects[] = {
 

--- a/source/Modules/show/init/libinit.c
+++ b/source/Modules/show/init/libinit.c
@@ -106,13 +106,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -581,9 +581,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -649,9 +647,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/show/show_data.c
+++ b/source/Modules/show/show_data.c
@@ -42,17 +42,17 @@ struct TagItem info_layout[] = {{GTCustom_LayoutRel, GAD_INFO_AREA}, {TAG_END}},
 
 			   print_layout[] = {{GTCustom_LayoutRel, GAD_PRINT_AREA}, {TAG_END}},
 
-			   print_aspect_tags[] = {{GTCustom_LocaleLabels, (ULONG)print_aspect_labels},
-									  {TAG_MORE, (ULONG)print_layout}},
+			   print_aspect_tags[] = {{GTCustom_LocaleLabels, (IPTR)print_aspect_labels},
+									  {TAG_MORE, (IPTR)print_layout}},
 
-			   print_image_tags[] = {{GTCustom_LocaleLabels, (ULONG)print_image_labels},
-									 {TAG_MORE, (ULONG)print_layout}},
+			   print_image_tags[] = {{GTCustom_LocaleLabels, (IPTR)print_image_labels},
+									 {TAG_MORE, (IPTR)print_layout}},
 
-			   print_shade_tags[] = {{GTCustom_LocaleLabels, (ULONG)print_shade_labels},
-									 {TAG_MORE, (ULONG)print_layout}},
+			   print_shade_tags[] = {{GTCustom_LocaleLabels, (IPTR)print_shade_labels},
+									 {TAG_MORE, (IPTR)print_layout}},
 
-			   print_placement_tags[] = {{GTCustom_LocaleLabels, (ULONG)print_placement_labels},
-										 {TAG_MORE, (ULONG)print_layout}};
+			   print_placement_tags[] = {{GTCustom_LocaleLabels, (IPTR)print_placement_labels},
+										 {TAG_MORE, (IPTR)print_layout}};
 
 ObjectDef
 	picture_info_objects[] =

--- a/source/Modules/themes/init/libinit.c
+++ b/source/Modules/themes/init/libinit.c
@@ -106,13 +106,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -580,9 +580,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -648,9 +646,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Modules/xadopus/init/libinit.c
+++ b/source/Modules/xadopus/init/libinit.c
@@ -104,13 +104,13 @@ struct ExecBase *SysBase = NULL;
 
 #ifdef __AROS__
 struct Library *aroscbase = NULL;
-	//#ifdef __arm__
 	#include <aros/symbolsets.h>
 THIS_PROGRAM_HANDLES_SYMBOLSET(INIT)
 THIS_PROGRAM_HANDLES_SYMBOLSET(EXIT)
+THIS_PROGRAM_HANDLES_SYMBOLSET(LIBS)
 DEFINESET(INIT)
 DEFINESET(EXIT)
-//#endif
+DEFINESET(LIBS)
 #endif
 
 /* reorganize it to match necessary declarations for MORPHOS and AROS */
@@ -590,9 +590,7 @@ static struct LibraryHeader *LIBFUNC LibInit(REG(d0, struct LibraryHeader *base)
 #ifdef __AROS__
 		if (!(aroscbase = OpenLibrary("arosc.library", 41)))
 			return (NULL);
-	//#ifdef __arm__
 	if (set_call_funcs(SETNAME(INIT), 1, 1))
-//#endif
 #endif
 	{
 		/***    #if defined(DEBUG)
@@ -658,9 +656,7 @@ STATIC BPTR LibDelete(struct LibraryHeader *base)
 	}
 #endif
 #ifdef __AROS__
-	//#ifdef __arm__
 	set_call_funcs(SETNAME(EXIT), -1, 0);
-	//#endif
 	if (aroscbase)
 	{
 		CloseLibrary(aroscbase);

--- a/source/Program/callback_main.c
+++ b/source/Program/callback_main.c
@@ -25,7 +25,7 @@ For more information on Directory Opus for Windows please see:
 
 #include "callback_main.h"
 
-STATIC CONST ULONG HookTable[DOPUS_HOOK_COUNT] = {
+STATIC CONST APTR HookTable[DOPUS_HOOK_COUNT] = {
 	GET_DOPUS_CALLBACK(HookCreateFileEntry), GET_DOPUS_CALLBACK(HookFileSet),
 	GET_DOPUS_CALLBACK(HookSortFileList),	 GET_DOPUS_CALLBACK(HookAddFileEntry),
 	GET_DOPUS_CALLBACK(HookResortLister),	 GET_DOPUS_CALLBACK(HookRefreshLister),
@@ -56,14 +56,14 @@ STATIC CONST ULONG HookTable[DOPUS_HOOK_COUNT] = {
 
 long HookInitHooks(DOpusCallbackInfo *info)
 {
-	ULONG *srcptr, *dstptr;
+	APTR *srcptr, *dstptr;
 	short num;
 
 	// Get pointer to start of function table
-	srcptr = (ULONG *)HookTable;
+	srcptr = (APTR *)HookTable;
 
 	// Get pointer to storage space in structure
-	dstptr = (ULONG *)&info->dc_CreateFileEntry;
+	dstptr = (APTR *)&info->dc_CreateFileEntry;
 
 	// Fill it out, up to count entries
 	for (num = 0; num < info->dc_Count; num++, srcptr++, dstptr++)

--- a/source/Program/callback_main.h
+++ b/source/Program/callback_main.h
@@ -84,10 +84,10 @@
 		}                                                                                                             \
 		static struct EmulLibEntry name##_trap = {TRAP_LIB, 0, (APTR)&name##_stubs};
 
-	#define GET_DOPUS_CALLBACK(name) (ULONG) & name##_trap
+	#define GET_DOPUS_CALLBACK(name) (APTR)&name##_trap
 
 #else
-	#define GET_DOPUS_CALLBACK(name) (ULONG) & name
+	#define GET_DOPUS_CALLBACK(name) (APTR)&name
 #endif
 
 //#if defined(__amigaos4__) || defined(__MORPHOS__)

--- a/source/Program/function_select_data.c
+++ b/source/Program/function_select_data.c
@@ -34,13 +34,13 @@ _select_cycle_labels[] = {MSG_SELECT_IGNORE, MSG_SELECT_MATCH, MSG_SELECT_NOMATC
 
 struct TagItem _select_name_tags[] = {{GTST_MaxChars, 59}, {GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA}, {TAG_END}},
 
-			   _select_cycle_tags[] = {{GTCustom_LocaleLabels, (ULONG)_select_cycle_labels},
+			   _select_cycle_tags[] = {{GTCustom_LocaleLabels, (IPTR)_select_cycle_labels},
 									   {GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA},
 									   {TAG_END}},
 
 			   _select_date_tags[] = {{GTST_MaxChars, 9}, {GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA}, {TAG_END}},
 
-			   _select_compare_tags[] = {{GTCustom_LocaleLabels, (ULONG)_select_compare_labels},
+			   _select_compare_tags[] = {{GTCustom_LocaleLabels, (IPTR)_select_compare_labels},
 										 {GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA},
 										 {TAG_END}},
 
@@ -48,11 +48,11 @@ struct TagItem _select_name_tags[] = {{GTST_MaxChars, 59}, {GTCustom_LayoutRel, 
 
 			   _select_layout_tags[] = {{GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA}, {TAG_END}},
 
-			   _select_include_tags[] = {{GTCustom_LocaleLabels, (ULONG)_select_include_labels},
+			   _select_include_tags[] = {{GTCustom_LocaleLabels, (IPTR)_select_include_labels},
 										 {GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA},
 										 {TAG_END, 0}},
 
-			   _select_entry_type_tags[] = {{GTCustom_LocaleLabels, (ULONG)_select_entry_type_labels},
+			   _select_entry_type_tags[] = {{GTCustom_LocaleLabels, (IPTR)_select_entry_type_labels},
 											{GTCustom_LayoutRel, GAD_SELECT_LAYOUT_AREA},
 											{TAG_END}};
 

--- a/source/Program/search_data.c
+++ b/source/Program/search_data.c
@@ -32,9 +32,9 @@ search_labels[] = {MSG_SEARCH_PROMPT, MSG_SEARCH_LEAVE_SELECTED, MSG_SEARCH_OUTP
 // Tags
 struct TagItem search_layout[] = {{GTCustom_LayoutRel, GAD_SEARCH_LAYOUT}, {TAG_DONE}},
 
-			   search_text_tags[] = {{GTST_MaxChars, 80}, {TAG_MORE, (ULONG)search_layout}},
+			   search_text_tags[] = {{GTST_MaxChars, 80}, {TAG_MORE, (IPTR)search_layout}},
 
-			   search_result_tags[] = {{GTCustom_LocaleLabels, (ULONG)search_labels}, {TAG_MORE, (ULONG)search_layout}};
+			   search_result_tags[] = {{GTCustom_LocaleLabels, (IPTR)search_labels}, {TAG_MORE, (IPTR)search_layout}};
 
 // Search objects
 ObjectDef search_objects[] = {

--- a/source/makefile
+++ b/source/makefile
@@ -11,6 +11,7 @@ export debug
 ###########################################################
 # Export arch to select the AROS architecture
 export arch
+PYTHON ?= python3
 ###########################################################
 # Example Commands:
 
@@ -24,12 +25,12 @@ export arch
 # Compiles debug version of dopus5 components for OS3 & creates
 # release archive.
 
-# make i386-aros release debug=no
-# Compiles normal version of dopus5 components for i386-AROS & creates
+# make x86_64-aros release debug=no
+# Compiles normal version of dopus5 components for x86_64-AROS & creates
 # release archive.
 ###########################################################
 # Read platform arguments from the "Make" command line:
-# Acceptable platform arguments are os3, os4, mos, i386-aros or arm-aros.
+# Acceptable platform arguments are os3, os4, mos, i386-aros or x86_64-aros.
 PLATFORM:= none
 NAME:=
 ifeq ($(findstring os3, $(MAKECMDGOALS)),os3)
@@ -44,26 +45,26 @@ ifeq ($(findstring mos, $(MAKECMDGOALS)),mos)
 	PLATFORM:= mos
 	NAME:= $(PLATFORM) $(NAME)
 endif
-ifeq ($(findstring arm, $(MAKECMDGOALS)),arm)
-	PLATFORM:= aros
-	arch:= arm
-	NAME:= $(arch)-$(PLATFORM) $(NAME)
-endif
 ifeq ($(findstring i386-aros, $(MAKECMDGOALS)),i386-aros)
 	PLATFORM:= aros
 	arch:= i386
+	NAME:= $(arch)-$(PLATFORM) $(NAME)
+endif
+ifeq ($(findstring x86_64-aros, $(MAKECMDGOALS)),x86_64-aros)
+	PLATFORM:= aros
+	arch:= x86_64
 	NAME:= $(arch)-$(PLATFORM) $(NAME)
 endif
 NAME := $(strip $(NAME))
 
 # Generate error if no platform entered on "Make" command line.
 ifeq ($(PLATFORM), none)
-$(error Error: Enter a platform (os3, os4, mos, arm-aros or i386-aros).)
+$(error Error: Enter a platform (os3, os4, mos, i386-aros or x86_64-aros).)
 endif
 
 #Generate error if multiple platforms entered on "Make" command line.
 ifneq ($(words $(NAME)), 1)
-$(error Error: Enter only 1 platform (os3, os4, mos, arm-aros or i386-aros).)
+$(error Error: Enter only 1 platform (os3, os4, mos, i386-aros or x86_64-aros).)
 endif
 
 # Compile all if only a platform is entered on "Make" command line.
@@ -193,7 +194,10 @@ clean-commands:
 ###########################################################
 
 .PHONY : release
-release: all
+release: all release-package
+
+.PHONY : release-package
+release-package:
 	@echo " "
 	@echo ">>>>>Creating release archive: Dopus5$(VERSION)$(NAME)$(TYPE).lha"
 	@$(REMOVE) $(RELEASE_DIR)
@@ -246,14 +250,18 @@ clean-release: cleanall
 # commands when entered as a goal for "make"
 # on the command line (like: make os3).
 
-.PHONY : os3 os4 mos aros i386-aros arm-aros
+.PHONY : os3 os4 mos aros i386-aros x86_64-aros
 i386-aros: mos
-arm-aros: mos
+x86_64-aros: mos
 os3: mos
 os4: mos
 aros: mos
 mos:
 	-@sh -c "echo -n"
+
+.PHONY: aros-void-headers
+aros-void-headers:
+	$(PYTHON) Include/defines/patch_aros_voidcalls.py
 
 .PHONY: Include/inline/dopus5.h
 
@@ -267,5 +275,5 @@ Include/inline/configopus.h: Include/fd/configopus.fd Include/clib/configopus_pr
 		fd2sfd Include/fd/configopus.fd Include/clib/configopus_protos.h Include/fd/configopus.sfd
 		sfdc --output=Include/inline/configopus.h --target=m68k-amigaos --mode=macros Include/fd/configopus.sfd
 
-headers: Include/inline/dopus5.h Include/inline/configopus.h
+headers: Include/inline/dopus5.h Include/inline/configopus.h aros-void-headers
 


### PR DESCRIPTION
## Summary
- add AROS i386 ABIv0 and x86_64 ABIv11 targets to makefiles and CI
- split release packaging so AROS builds run in AROS compiler images and LHA packaging runs in an image with archive creation support
- add ABIv11 build fixes for AROS inline void calls, pointer-width data initializers, symbol sets, FTP SDK header gaps, and Workbench FindTask(NULL) handling

## Validation
- docker run --rm -v <repo>:/work midwan/aros-compiler:i386-aros sh -c "cd /work/source && make i386-aros cleanall all debug=no"
- docker run --rm -v <repo>:/work midwan/aros-compiler:x86_64-aros sh -c "cd /work/source && make x86_64-aros cleanall all debug=no"
- docker run --rm -v <repo>:/work sacredbanana/amiga-compiler:m68k-amigaos sh -c "cd /work/source && make i386-aros release-package debug=no"
- docker run --rm -v <repo>:/work sacredbanana/amiga-compiler:m68k-amigaos sh -c "cd /work/source && make x86_64-aros release-package debug=no"
- git diff --check
- checked no remaining AROS_LC*(void, ...) or DOPUS_LC*NR usages in source/Include/defines/*.h
- checked patch_aros_voidcalls.py is idempotent