### PR TITLE
Enable off-screen dragging on custom screens

### DIFF
--- a/source/Program/display.c
+++ b/source/Program/display.c
@@ -107,6 +107,16 @@ BOOL display_open(long flags)
 			0,
 			SA_LikeWorkbench,
 			TRUE,
+#if defined(SA_OffscreenDragging)
+			SA_OffscreenDragging,
+			TRUE,
+#elif defined(SA_OFFSCREENDRAGGING)
+			SA_OFFSCREENDRAGGING,
+			TRUE,
+#elif defined(SA_OffScreenDragging)
+			SA_OffScreenDragging,
+			TRUE,
+#endif
 			SA_Width,
 			(environment->env->screen_flags & SCRFLAGS_DEFWIDTH) ? STDSCREENWIDTH : environment->env->screen_width,
 			SA_Height,


### PR DESCRIPTION
## Summary
- enable Intuition v45+ off-screen window dragging when DOpus opens its own custom screen
- guard the screen tag by SDK-defined names so older OS3.1, OS4, MorphOS, and AROS builds are unchanged

Closes #20

## Testing
- docker run --rm -v ${PWD}:/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 program debug=no
- docker run --rm -v ${PWD}:/work -w /work/source sacredbanana/amiga-compiler:ppc-amigaos make os4 program debug=no
- docker run --rm -v ${PWD}:/work -w /work/source sacredbanana/amiga-compiler:ppc-morphos make mos program debug=no
- docker run --rm -v ${PWD}:/work -w /work/source midwan/aros-compiler:i386-aros make i386-aros program debug=no
- docker run --rm -v ${PWD}:/work -w /work/source midwan/aros-compiler:x86_64-aros make x86_64-aros program debug=no
- OS3 compile syntax-check with synthetic SA_OffscreenDragging define
- runtime smoke test: works normally