### PR TITLE
Fix AROS FTP lister shutdown

### DIFF
--- a/source/Modules/ftp/ftp_lister.c
+++ b/source/Modules/ftp/ftp_lister.c
@@ -109,12 +109,6 @@ For more information on Directory Opus for Windows please see:
 #include "ftp_addrsupp_protos.h"
 #include "ftp_protect.h"
 
-#if defined(__AROS__) && defined(__x86_64__)
-	#define FTP_LISTER_ADD_VIA_REXX 1
-#else
-	#define FTP_LISTER_ADD_VIA_REXX 0
-#endif
-
 /********************************/
 
 //
@@ -148,12 +142,10 @@ void STDARGS logprintf(char *fmt, ...)
 //
 void lister_add(struct ftp_node *node, char *name, int size, int type, ULONG seconds, LONG prot, char *comment)
 {
-#if !FTP_LISTER_ADD_VIA_REXX
 	static D_S(struct FileInfoBlock, fib) APTR entry;
 	LONG etype;
 	struct TagItem tags[2] = {{HFFS_NAME, 0}, {TAG_DONE}};
 	DOpusCallbackInfo *infoptr;
-#endif
 	unsigned int entry_size;
 	int entry_type = type;
 
@@ -161,51 +153,31 @@ void lister_add(struct ftp_node *node, char *name, int size, int type, ULONG sec
 	if (!node || !name)
 		return;
 
-#if !FTP_LISTER_ADD_VIA_REXX
 	infoptr = &node->fn_og->og_hooks;
-#endif
 
 	switch (type)
 	{
 	case 1:
-#if !FTP_LISTER_ADD_VIA_REXX
 		etype = ST_USERDIR;
-#endif
 		break;
 	case -1:
-#if !FTP_LISTER_ADD_VIA_REXX
 		etype = ST_FILE;
-#endif
 		break;
 	case 3:
-#if !FTP_LISTER_ADD_VIA_REXX
 		etype = ST_LINKDIR;
-#endif
 		break;
 	case -3:
-#if !FTP_LISTER_ADD_VIA_REXX
 		etype = ST_LINKFILE;
-#endif
 		break;
 	default:
 		D(bug("** lst_add() bad type %d\n", type));
 		entry_type = -1;
-#if !FTP_LISTER_ADD_VIA_REXX
 		etype = ST_FILE;
-#endif
 		break;
 	}
 
 	entry_size = (entry_type > 0) ? 0 : (unsigned int)size;
 
-#if FTP_LISTER_ADD_VIA_REXX
-	{
-		IPTR rc = rexx_lst_add(node->fn_opus, node->fn_handle, name, entry_size, entry_type, seconds, prot, comment);
-
-		if (rc && node->fn_og && node->fn_og->og_oc.oc_log_debug)
-			logprintf("-- Lister add failed: rc %ld, name '%s', type %ld\n", (long)rc, name, (long)entry_type);
-	}
-#else
 	fib->fib_DirEntryType = etype;
 
 	stccpy(fib->fib_FileName, name, sizeof(fib->fib_FileName));
@@ -233,7 +205,6 @@ void lister_add(struct ftp_node *node, char *name, int size, int type, ULONG sec
 		DC_CALL3(infoptr, dc_FileSet, DC_REGA0, (APTR)node->fn_handle, DC_REGA1, entry, DC_REGA2, tags);
 		// node->fn_og->og_hooks.dc_FileSet( (ULONG)node->fn_handle, entry, tags );
 	}
-#endif
 
 	if (node->fn_site.se_env->e_index_enable)
 	{

--- a/source/Modules/ftp/ftp_lister.c
+++ b/source/Modules/ftp/ftp_lister.c
@@ -3642,7 +3642,9 @@ void lister(void)
 		mld.mld_node = NULL;
 		mld.mld_ftpreply = &zero;
 		mld.mld_quitmsg = NULL;
+		mld.mld_quit_command = NULL;
 		mld.mld_done = FALSE;
+		mld.mld_reconnecting = FALSE;
 
 		lister_msg_loop(og, &mld);
 

--- a/source/Modules/ftp/ftp_lister.c
+++ b/source/Modules/ftp/ftp_lister.c
@@ -3542,7 +3542,7 @@ static void lister_msg_loop(struct opusftp_globals *og, struct msg_loop_data *ml
 					D(bug("*** lister received IPC_QUIT ***\n"));
 
 					// Has lister already been closed?
-					if (mld->mld_node && imsg->flags == -1)
+					if (mld->mld_node && imsg->flags == (IPTR)-1)
 						mld->mld_node->fn_flags &= ~LST_OPENED;
 
 					// Leave lister open?
@@ -3654,13 +3654,13 @@ void lister(void)
 		if (mld.mld_quitmsg)
 		{
 			// Our quit message structure attached?
-			if (mld.mld_quitmsg->flags)
+			if (mld.mld_quitmsg->data)
 			{
 				// ARexx message?
-				if (((struct quit_msg *)mld.mld_quitmsg->flags)->qm_rxmsg)
-					reply_rexx(((struct quit_msg *)mld.mld_quitmsg->flags)->qm_rxmsg, 1, 0);
+				if (((struct quit_msg *)mld.mld_quitmsg->data)->qm_rxmsg)
+					reply_rexx(((struct quit_msg *)mld.mld_quitmsg->data)->qm_rxmsg, 1, 0);
 
-				FreeVec((APTR)mld.mld_quitmsg->flags);
+				FreeVec(mld.mld_quitmsg->data);
 			}
 
 			mld.mld_quitmsg->command = TRUE;

--- a/source/Modules/ftp/ftp_lister_connect.c
+++ b/source/Modules/ftp/ftp_lister_connect.c
@@ -1528,7 +1528,7 @@ void lister_disconnect(struct opusftp_globals *og, struct msg_loop_data *mld)
 	}
 
 	// Reconnect command?
-	else if (mld->mld_quit_command)
+	else if (!mld->mld_quitmsg && mld->mld_quit_command)
 	{
 		if (mld->mld_reconnecting)
 			send_rexxa(opus, REXX_REPLY_NONE, "command %s", mld->mld_quit_command);

--- a/source/Modules/ftp/ftp_lister_connect.c
+++ b/source/Modules/ftp/ftp_lister_connect.c
@@ -1504,7 +1504,7 @@ void lister_disconnect(struct opusftp_globals *og, struct msg_loop_data *mld)
 					   FTP_HANDLE_VALUE(ftpnode->fn_handle));
 
 			// No command to issue after quitting?
-			if (!mld->mld_quitmsg || !mld->mld_quitmsg->flags)
+			if (!mld->mld_quitmsg || !mld->mld_quitmsg->data)
 				rexx_lst_refresh(opus, ftpnode->fn_handle, REFRESH_NODATE);
 		}
 
@@ -1520,7 +1520,7 @@ void lister_disconnect(struct opusftp_globals *og, struct msg_loop_data *mld)
 	lister_remove_node(og, ftpnode);
 
 	// Command to issue after quitting?
-	if (mld->mld_quitmsg && (qm = (struct quit_msg *)mld->mld_quitmsg->flags))
+	if (mld->mld_quitmsg && (qm = (struct quit_msg *)mld->mld_quitmsg->data))
 	{
 		// Command to send? (DeviceList, ScanDir, FTPConnect...)
 		if (qm->qm_command)

--- a/source/Modules/ftp/ftp_main.c
+++ b/source/Modules/ftp/ftp_main.c
@@ -571,6 +571,20 @@ static void ipc_append_connect_arg(char *command, int command_size, const char *
 		strcpy(command + len, arg);
 }
 
+static void ftp_lister_quit(IPCData *ipc, IPTR flags, struct quit_msg *qm)
+{
+	if (!ipc || !ipc->proc)
+	{
+		FreeVec(qm);
+		return;
+	}
+
+	Signal((struct Task *)ipc->proc, IPCSIG_QUIT);
+
+	if (!IPC_Command(ipc, IPC_QUIT, flags, qm, 0, 0))
+		FreeVec(qm);
+}
+
 static int ipc_connect(struct opusftp_globals *og, IPCData *ipc, struct ListLock *tasklist, IPCMessage *msg)
 {
 	struct connect_msg *cm = msg->data_free;
@@ -616,7 +630,7 @@ static int ipc_connect(struct opusftp_globals *og, IPCData *ipc, struct ListLock
 				qm->qm_command = (char *)(qm + 1);
 				strcpy(qm->qm_command, buffer);
 
-				IPC_Quit(node->fn_ipc, (IPTR)qm, 0);
+				ftp_lister_quit(node->fn_ipc, 1, qm);
 			}
 			else
 				DisplayBeep(og->og_screen);
@@ -1101,7 +1115,7 @@ static int opus_drop(struct opusftp_globals *og, struct RexxMsg *rxmsg, int argc
 					// Build and send quit message
 					strcpy(qm->qm_command, "ScanDir ");
 					strcat(qm->qm_command, firstname);
-					IPC_Quit(node->fn_ipc, (IPTR)qm, 0);
+					ftp_lister_quit(node->fn_ipc, 1, qm);
 					retval = 1;
 				}
 
@@ -1541,23 +1555,22 @@ static int opus_edit(struct opusftp_globals *og, struct RexxMsg *rxmsg, int argc
 static int opus_inactive(struct opusftp_globals *og, struct RexxMsg *rxmsg, int argc, char **argv)
 {
 	struct ftp_node *node;
-	struct quit_msg *qm;
 	int retval = 0;
 
 	D(bug("opus_inactive(%s)\n", argv[3]));
 
-	if (argc >= 3 && (node = find_ftpnode(og, ftp_parse_handle(argv[1]))))
+	if (argc >= 4 && (node = find_ftpnode(og, ftp_parse_handle(argv[1]))))
 	{
 		// Has lister disappeared?  Ignore if lister is supposed to be invisible
 		if (ftp_parse_handle(argv[3]))
 		{
-			if ((qm = AllocVec(sizeof(struct quit_msg), MEMF_CLEAR)))
+			ftp_lister_quit(node->fn_ipc, (IPTR)-1, NULL);
+
+			if (rxmsg)
 			{
-				qm->qm_rxmsg = rxmsg;
+				reply_rexx(rxmsg, 0, 0);
 				retval = 1;
 			}
-
-			IPC_Quit(node->fn_ipc, (IPTR)qm, 0);
 		}
 	}
 
@@ -1632,7 +1645,7 @@ static int opus_path(struct opusftp_globals *og, struct RexxMsg *rxmsg, int argc
 				qm->qm_command = (char *)(qm + 1);
 				sprintf(qm->qm_command, "FTPConnect LISTER=%s %s%s%s", argv[1], url_body, tls_arg, protocol_arg);
 
-				IPC_Quit(node->fn_ipc, (IPTR)qm, 0);
+				ftp_lister_quit(node->fn_ipc, 1, qm);
 				retval = 1;
 			}
 		}
@@ -2598,11 +2611,13 @@ static int opus_devicelist(struct opusftp_globals *og, struct RexxMsg *rxmsg, in
 		qm->qm_rxmsg = rxmsg;
 		qm->qm_command = (char *)(qm + 1);
 		sprintf(qm->qm_command, "%s%s%s", argv[0], args ? " " : "", args ? argv[5] : "");
+
+		ftp_lister_quit(node->fn_ipc, 1, qm);
+		return 1;
 	}
 
-	IPC_Quit(node->fn_ipc, (IPTR)qm, 0);
-
-	return 1;
+	ftp_lister_quit(node->fn_ipc, 0, NULL);
+	return 0;
 }
 
 /********************************/
@@ -2676,7 +2691,7 @@ static int opus_scandir(struct opusftp_globals *og, struct RexxMsg *rxmsg, int a
 				qm->qm_rxmsg = rxmsg;
 				qm->qm_command = (char *)(qm + 1);
 				sprintf(qm->qm_command, "%s%s%s", argv[0], args ? " " : "", args ? argv[5] : "");
-				IPC_Quit(node->fn_ipc, (IPTR)qm, 0);
+				ftp_lister_quit(node->fn_ipc, 1, qm);
 				retval = 1;
 			}
 		}

--- a/source/Program/cleanup.c
+++ b/source/Program/cleanup.c
@@ -404,8 +404,14 @@ BOOL quit_notify(void)
 	// Look for quit traps
 	while ((trap = FindTrapEntry(trap, "quit", port)))
 	{
-		// Send abort message
-		rexx_handler_msg(port, 0, 0, HA_String, 0, (IPTR)"quit", TAG_END);
+		ULONG flags = 0;
+
+		// FTP owns windows on the Opus screen, but is not in the normal process lists.
+		if (stricmp(port, "_OPUSFTP_") == 0)
+			flags |= RXMF_SYNC;
+
+		// Send quit message
+		rexx_handler_msg(port, 0, flags, HA_String, 0, (IPTR)"quit", TAG_END);
 	}
 
 	// Unlock trap list

--- a/source/Program/cleanup.c
+++ b/source/Program/cleanup.c
@@ -397,9 +397,6 @@ BOOL quit_notify(void)
 {
 	APTR trap;
 	char port[40];
-	BOOL ftp_quit = FALSE;
-	short retry;
-	BOOL port_open;
 
 	// Lock trap list
 	trap = LockTrapList();
@@ -407,31 +404,12 @@ BOOL quit_notify(void)
 	// Look for quit traps
 	while ((trap = FindTrapEntry(trap, "quit", port)))
 	{
-		if (stricmp(port, "_OPUSFTP_") == 0)
-			ftp_quit = TRUE;
-
-		// Send quit message
+		// Send abort message
 		rexx_handler_msg(port, 0, 0, HA_String, 0, (IPTR)"quit", TAG_END);
 	}
 
 	// Unlock trap list
 	UnlockTrapList();
-
-	// FTP owns windows on the Opus screen, but is not in the normal process lists.
-	if (ftp_quit)
-	{
-		for (retry = 0; retry < 100; retry++)
-		{
-			Forbid();
-			port_open = (FindPort("_OPUSFTP_") != 0);
-			Permit();
-
-			if (!port_open)
-				break;
-
-			Delay(5);
-		}
-	}
 
 	// Broadcast notify message
 	SendNotifyMsg(DN_OPUS_QUIT, GUI->dopus_copy, 0, 0, GUI->rexx_port_name, 0);

--- a/source/Program/cleanup.c
+++ b/source/Program/cleanup.c
@@ -397,6 +397,9 @@ BOOL quit_notify(void)
 {
 	APTR trap;
 	char port[40];
+	BOOL ftp_quit = FALSE;
+	short retry;
+	BOOL port_open;
 
 	// Lock trap list
 	trap = LockTrapList();
@@ -404,18 +407,31 @@ BOOL quit_notify(void)
 	// Look for quit traps
 	while ((trap = FindTrapEntry(trap, "quit", port)))
 	{
-		ULONG flags = 0;
-
-		// FTP owns windows on the Opus screen, but is not in the normal process lists.
 		if (stricmp(port, "_OPUSFTP_") == 0)
-			flags |= RXMF_SYNC;
+			ftp_quit = TRUE;
 
 		// Send quit message
-		rexx_handler_msg(port, 0, flags, HA_String, 0, (IPTR)"quit", TAG_END);
+		rexx_handler_msg(port, 0, 0, HA_String, 0, (IPTR)"quit", TAG_END);
 	}
 
 	// Unlock trap list
 	UnlockTrapList();
+
+	// FTP owns windows on the Opus screen, but is not in the normal process lists.
+	if (ftp_quit)
+	{
+		for (retry = 0; retry < 100; retry++)
+		{
+			Forbid();
+			port_open = (FindPort("_OPUSFTP_") != 0);
+			Permit();
+
+			if (!port_open)
+				break;
+
+			Delay(5);
+		}
+	}
 
 	// Broadcast notify message
 	SendNotifyMsg(DN_OPUS_QUIT, GUI->dopus_copy, 0, 0, GUI->rexx_port_name, 0);

--- a/source/Program/rexx.h
+++ b/source/Program/rexx.h
@@ -389,27 +389,12 @@ void rexx_send_command(char *command, BOOL);
 #define HA_Value 0x02
 #define HA_Qualifier 0x03
 
-#ifndef __amigaos3__
-	#pragma pack(2)
-#endif
-
-typedef struct
-{
-	ULONG ha_Type;
-	ULONG ha_Arg;
-	IPTR ha_Data;
-} HandlerArg;
-
-#ifndef __amigaos3__
-	#pragma pack()
-#endif
-
 #define rexx_handler_msg(handler, buffer, flags, ...)                                \
 	({                                                                               \
 		IPTR __args[] = {DOPUS_VARIADIC_IPTR(__VA_ARGS__)};                         \
-		(short)rexx_handler_msg_args(handler, buffer, flags, (HandlerArg *)&__args); \
+		(short)rexx_handler_msg_args(handler, buffer, flags, __args);               \
 	})
-short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flags, HandlerArg *args);
+short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flags, IPTR *args);
 
 long rexx_set_appicon(char *str, struct RexxMsg *msg);
 

--- a/source/Program/rexx_handler.c
+++ b/source/Program/rexx_handler.c
@@ -23,14 +23,15 @@ For more information on Directory Opus for Windows please see:
 
 #include "dopus.h"
 
-short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flags, HandlerArg *args)
+short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flags, IPTR *args)
 {
 	struct RexxMsg *msg;
 	char qualbuf[40];
-	short arg, res;
+	short res;
 	unsigned long type = 0, count = 0;
 	RexxDespatch *desp;
 	struct MsgPort *port, *reply_port;
+	IPTR *argptr;
 
 	// If no handler supplied, use buffer's handler
 	if ((!handler || !*handler) && buffer)
@@ -58,45 +59,49 @@ short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flag
 	}
 
 	// Go through arguments
-	for (arg = 0; args[arg].ha_Type != TAG_END; arg++)
+	for (argptr = args; argptr && argptr[0] != TAG_END; argptr += 3)
 	{
+		ULONG ha_type = (ULONG)argptr[0];
+		ULONG ha_arg = (ULONG)argptr[1];
+		IPTR ha_data = argptr[2];
+
 		// Argument not too large?
-		if (args[arg].ha_Arg > 15)
+		if (ha_arg > 15)
 			continue;
 
 		// Value?
-		if (args[arg].ha_Type == HA_Value)
+		if (ha_type == HA_Value)
 		{
 			// Set message slot and conversion key bit
-			msg->rm_Args[args[arg].ha_Arg] = args[arg].ha_Data;
-			type |= 1 << args[arg].ha_Arg;
+			msg->rm_Args[ha_arg] = ha_data;
+			type |= 1 << ha_arg;
 		}
 
 		// Qualifier?
-		else if (args[arg].ha_Type == HA_Qualifier)
+		else if (ha_type == HA_Qualifier)
 		{
 			// Get qualifier
 			qualbuf[0] = 0;
-			if (args[arg].ha_Data & IEQUAL_ANYSHIFT)
+			if (ha_data & IEQUAL_ANYSHIFT)
 				strcat(qualbuf, "shift ");
-			if (args[arg].ha_Data & IEQUAL_ANYALT)
+			if (ha_data & IEQUAL_ANYALT)
 				strcat(qualbuf, "alt ");
-			if (args[arg].ha_Data & IEQUALIFIER_CONTROL)
+			if (ha_data & IEQUALIFIER_CONTROL)
 				strcat(qualbuf, "control ");
-			if (args[arg].ha_Data & IEQUALIFIER_SUBDROP)
+			if (ha_data & IEQUALIFIER_SUBDROP)
 				strcat(qualbuf, "subdrop");
 
 			// Set message slot
-			msg->rm_Args[args[arg].ha_Arg] = (IPTR)qualbuf;
+			msg->rm_Args[ha_arg] = (IPTR)qualbuf;
 		}
 
 		// String
 		else
-			msg->rm_Args[args[arg].ha_Arg] = args[arg].ha_Data;
+			msg->rm_Args[ha_arg] = ha_data;
 
 		// Fix count
-		if (args[arg].ha_Arg > count)
-			count = args[arg].ha_Arg;
+		if (ha_arg > count)
+			count = ha_arg;
 	}
 
 	// Increment count


### PR DESCRIPTION
## Summary
- restore the FTP lister callback path on AROS x86_64 now that the follow-up 64-bit issues are fixed
- fix FTP lister close/shutdown handling so quit payloads are not stored in the IPC flags field
- initialize FTP lister quit/reconnect state so closing an FTP lister does not replay a poisoned command pointer

## Root cause
AROS x86_64 exposed multiple 64-bit shutdown path assumptions in the FTP module. The final close crash was caused by uninitialized lister quit state: a normal close could fall through to the reconnect command branch and pass an invalid string pointer to `send_rexxa`.

## Validation
- `docker run --rm -v ${PWD}:/workspace -w /workspace/source/Modules midwan/aros-compiler:x86_64-aros make x86_64-aros clean-ftp ftp debug=no`
- `docker run --rm -v ${PWD}:/work sacredbanana/amiga-compiler:m68k-amigaos sh -c "cd /work/source && make x86_64-aros release-package debug=no"`
- `docker run --rm -v ${PWD}:/workspace -w /workspace/source/Modules sacredbanana/amiga-compiler:m68k-amigaos make os3 clean-ftp ftp debug=no`
- `docker run --rm -v ${PWD}:/workspace -w /workspace/source/Modules sacredbanana/amiga-compiler:ppc-amigaos make os4 clean-ftp ftp debug=no`
- `docker run --rm -v ${PWD}:/workspace -w /workspace/source/Modules sacredbanana/amiga-compiler:ppc-morphos make mos clean-ftp ftp debug=no`

AROS x86_64 test archive: `releases/Dopus5_100_x86_64-aros.lha`
SHA256: `3B4223270003135C9D862C5D02768D8C3226051931C3D0FF640635D7FD4DFC25`