### PR TITLE
Fix lister free space display and Edit menu behaviour

### DIFF
--- a/source/Program/function_readdir.c
+++ b/source/Program/function_readdir.c
@@ -620,15 +620,7 @@ void readdir_check_format(Lister *lister, char *path, ListFormat *format, BOOL s
 		// Use current format from lister
 		*format = lister->format;
 
-		// Don't inherit format?
-		if (!(lister->format.flags & LFORMATF_INHERIT))
-		{
-			// Get space gauge setting from default format
-			if (environment->env->list_format.flags & LFORMATF_GAUGE)
-				format->flags |= LFORMATF_GAUGE;
-			else
-				format->flags &= ~LFORMATF_GAUGE;
-		}
+		// Gauge flag is preserved from lister->format as-is (already copied above)
 	}
 
 	// Is the lister in icon mode?

--- a/source/Program/lister_buffers.c
+++ b/source/Program/lister_buffers.c
@@ -444,6 +444,9 @@ void lister_show_buffer(Lister *lister, DirBuffer *buffer, int show, BOOL active
 		else
 			lister_show_name(lister);
 
+		// Re-evaluate gauge visibility (e.g. returning to root from a subdir)
+		lister_set_gauge(lister, TRUE);
+
 		// Not showing icons?
 		if (!(lister->flags & LISTERF_VIEW_ICONS) || lister->flags & LISTERF_ICON_ACTION)
 		{

--- a/source/Program/lister_dir.c
+++ b/source/Program/lister_dir.c
@@ -35,6 +35,12 @@ void lister_configure(Lister *lister)
 	if (lister->more_flags & LISTERF_CONFIGURE)
 		return;
 
+	// Not available when showing a device/cache list or in icon action mode
+	if (lister->cur_buffer->more_flags & (DWF_DEVICE_LIST | DWF_CACHE_LIST))
+		return;
+	if ((lister->flags & LISTERF_VIEW_ICONS) && (lister->flags & LISTERF_ICON_ACTION))
+		return;
+
 	// Run configure function
 	function_launch_quick(FUNCTION_RUN_FUNCTION, def_function_configure, lister);
 }

--- a/source/Program/lister_display.c
+++ b/source/Program/lister_display.c
@@ -301,6 +301,11 @@ void lister_refresh(Lister *lister, unsigned short mode)
 	// Viewing icons?
 	if (lister->flags & LISTERF_VIEW_ICONS)
 	{
+		// Full refresh with layout change (e.g. gauge added/removed)?
+		// Clear old icon positions before recalculating to avoid ghost images
+		if (mode & LREFRESH_FULL_ICON)
+			backdrop_show_objects(lister->backdrop_info, BDSF_CLEAR | BDSF_CLEAR_ONLY);
+
 		// Full refresh?
 		if (mode & LREFRESH_FULL)
 			backdrop_show_objects(lister->backdrop_info, BDSF_RECALC);

--- a/source/Program/lister_menus.c
+++ b/source/Program/lister_menus.c
@@ -47,7 +47,7 @@ void lister_fix_menus(Lister *lister, BOOL sel_only)
 {
 	struct MenuItem *item;
 	struct Menu *menu;
-	BOOL busy = 0, icon = 0, action = 0, sel = 0;
+	BOOL busy = 0, icon = 0, action = 0, sel = 0, special = 0;
 	short a;
 
 	// Get menu pointer
@@ -64,6 +64,8 @@ void lister_fix_menus(Lister *lister, BOOL sel_only)
 		icon = 1;
 	if (lister->flags & LISTERF_ICON_ACTION)
 		action = 1;
+	if (lister->cur_buffer->more_flags & (DWF_DEVICE_LIST | DWF_CACHE_LIST))
+		special = 1;
 
 	// In icon mode?
 	if (icon)
@@ -143,10 +145,10 @@ void lister_fix_menus(Lister *lister, BOOL sel_only)
 			}
 		}
 
-		// Edit (disabled when busy or in icon mode)
+		// Edit (disabled when busy, in icon action mode, or showing device/cache list)
 		if ((item = find_menu_item(menu, MENU_EDIT_LISTER)))
 		{
-			off_item(item, busy || icon);
+			off_item(item, busy || (icon && action) || special);
 		}
 
 		// New drawer (disabled when busy)

--- a/source/Program/lister_title.c
+++ b/source/Program/lister_title.c
@@ -102,8 +102,9 @@ void lister_show_name(Lister *lister)
 			}
 		}
 
-		// Displaying free space?
-		if (buffer->buf_TotalDiskSpace > 0 && !(lister->more_flags & LISTERF_TITLEBARRED))
+		// Displaying free space? Only at root of a volume (path ends with ':')
+		if (buffer->buf_TotalDiskSpace > 0 && !(lister->more_flags & LISTERF_TITLEBARRED) &&
+			strlen(buffer->buf_Path) > 0 && buffer->buf_Path[strlen(buffer->buf_Path) - 1] == ':')
 		{
 			char space_buf[50], *ptr;
 


### PR DESCRIPTION
## Summary

- Free space gauge: preserve `LFORMATF_GAUGE` across directory reads — `readdir_check_format()` was unconditionally overriding the gauge flag from the global env when `LFORMATF_INHERIT` was not set, causing the gauge to vanish after any navigation
- Free space gauge: call `lister_set_gauge()` in `lister_show_buffer()` so gauge visibility is re-evaluated when switching buffers
- Free space gauge: clear icon ghost images when gauge is added/removed in an icon lister (`BDSF_CLEAR` pass before layout recalculation)
- Title bar: show free space only at root of a volume (path ends with `:`), reducing clutter for subdirectory listers
- Edit menu: not ghosted for icon listers unless in icon-action mode; ghosted (and non-functional) for Device List / Cache List buffers
- `lister_dir`: guard `lister_open_edit()` against device/cache list buffers

Closes #10