### PR TITLE
xadopus: unstick lister after view/doubleclick commands

### DIFF
--- a/source/Modules/xadopus/XADopus.c
+++ b/source/Modules/xadopus/XADopus.c
@@ -391,37 +391,37 @@ void RemoveTemp(struct xoData *data)
 void LaunchCommand(struct xoData *data, char *cmd, char *name, char *qual)
 {
 	DOpusCallbackInfo *infoptr = &data->hook;
-	ULONG sigMask, cmdSig, timeoutTicks;
 
+	/* Dispatch the command asynchronously.
+	 *
+	 * We used to send "command wait ..." here, which blocked this task until
+	 * the launched command completed. For view commands (Read/Play/Show/...)
+	 * and DoubleClick that frequently means blocking until the user closes a
+	 * viewer, leaving the lister stuck in the "busy" state (see issue #27).
+	 *
+	 * A later attempt wrapped an async "command ..." call in a Wait()/Delay()
+	 * loop on data->mp, but that port only receives trap messages from DOpus -
+	 * the command itself never signals completion there - so Wait() blocked
+	 * forever (never reaching the decrement path) and any trap events that did
+	 * arrive were silently consumed instead of being handled by the main event
+	 * loop, leaving the lister permanently busy.
+	 *
+	 * The temp trap removal and the brief busy toggle are still useful to
+	 * avoid re-entering the same handler while DOpus dispatches the command,
+	 * so keep those, but drop the broken wait entirely and let DOpus run the
+	 * command in the background. */
 	sprintf(data->buf, "lister set %s busy on wait", data->lists);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
+
 	sprintf(data->buf, "dopus remtrap %s %s", cmd, data->mp_name);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
 
 	sprintf(data->buf, "command %s %s %s", cmd, qual, name);
-	sigMask = 1L << data->mp->mp_SigBit;
-	timeoutTicks = 30;
-
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
-
-	while (timeoutTicks > 0)
-	{
-		cmdSig = Wait(sigMask | SIGBREAKF_CTRL_C);
-		if (cmdSig & sigMask)
-		{
-			struct Message *msg;
-			while ((msg = GetMsg(data->mp)))
-				ReplyMsg(msg);
-			break;
-		}
-		if (cmdSig & SIGBREAKF_CTRL_C)
-			break;
-		timeoutTicks--;
-		Delay(50);
-	}
 
 	sprintf(data->buf, "dopus addtrap %s %s", cmd, data->mp_name);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
+
 	sprintf(data->buf, "lister set %s busy off wait", data->lists);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
 }


### PR DESCRIPTION
## Summary

Fix #27: opening a file inside an xadopen lister (e.g. reading a text file inside an archive) left the lister permanently busy - it could not be closed or interacted with.

## Root cause

`LaunchCommand()` was dispatching the view/doubleclick command asynchronously and then gating a 30-tick timeout with `Wait(sigMask | SIGBREAKF_CTRL_C)`:

```c
sprintf(data->buf, "command %s %s %s", cmd, qual, name);
sigMask = 1L << data->mp->mp_SigBit;
timeoutTicks = 30;
DC_CALL4(... data->buf ...);   /* fire-and-forget, no "wait" keyword */

while (timeoutTicks > 0)
{
    cmdSig = Wait(sigMask | SIGBREAKF_CTRL_C);   /* BLOCKS FOREVER */
    if (cmdSig & sigMask) { ... break; }
    if (cmdSig & SIGBREAKF_CTRL_C) break;
    timeoutTicks--;
    Delay(50);
}
```

Two things break this loop:

1. The async `command ...` (no `wait` keyword) never replies on `data->mp` - that port only receives trap messages from DOpus, not command-completion replies. The user's task also doesn't normally receive `SIGBREAKF_CTRL_C`. So `Wait()` blocks indefinitely and the `timeoutTicks--; Delay(50);` decrement path is unreachable.
2. Because `LaunchCommand` never returns, the trailing `lister set ... busy off wait` is never sent, and the lister stays stuck.

As a bonus, if any real trap event (user action on the lister) did manage to arrive, the loop would consume and discard it via `ReplyMsg()` instead of letting the main event loop in `Module_Entry` process it.

## Fix

Drop the broken wait entirely and let DOpus run the command in the background. The brief busy toggle and the temporary trap removal around the dispatch are kept to prevent re-entering the same handler while DOpus dispatches the command.

This matches how the other async dispatches in this module already work (`_scandir`, `_cd`, `_root`), and it matches the intent of 81ffc29 ("xadopus: fix hangs on archive drag/copy operations") which switched away from `command wait ...` specifically to avoid blocking the module while a viewer was open.

## Test plan

- [x] Builds cleanly for AmigaOS 3 (sacredbanana/amiga-compiler:m68k-amigaos)
- [x] Builds cleanly for AmigaOS 4 (sacredbanana/amiga-compiler:ppc-amigaos)
- [x] Builds cleanly for MorphOS (sacredbanana/amiga-compiler:ppc-morphos)
- [ ] AROS build not verified: xadmaster.library SDK headers are not present in either AROS Docker image (pre-existing limitation on master - same failure reproduces on plain master)
- [x] Manual test: open an archive in an xadopen lister, Read a text file inside it, confirm the lister returns to idle and can be closed after the reader opens
- [x] Manual test: verify DoubleClick, Play, Show, HexRead, AnsiRead, IconInfo behave the same way

Closes #27