### PR TITLE
icon_cache: stop hijacking GetCachedDiskObject with deficons

### DIFF
--- a/source/Library/icon_cache.c
+++ b/source/Library/icon_cache.c
@@ -401,6 +401,28 @@ struct DiskObject *LIBFUNC L_GetCachedDiskObjectNew(REG(a0, char *name),
 	if (flags & GCDOFN_REAL_ICON && (icon = L_GetCachedDiskObject(name, 0, libbase)))
 		return icon;
 
+	// On modern icon.library, ask for the best icon for this name with deficons
+	// enabled - icon.library will look at the filename and contents and may
+	// return a filename-pattern deficon (e.g. env:sys/def_ascii for text,
+	// env:sys/def_module for *.MOD, ...) instead of a plain WBPROJECT default.
+	// This is the proper place for that fallback: only callers that have
+	// already failed to find a real icon AND a DOpus filetype icon end up
+	// here (see GetProperIcon()), so it never shadows DOpus filetype icons.
+	if (IconBase->lib_Version >= 44)
+	{
+		struct LibData *libdata = (struct LibData *)libbase->ml_UserData;
+
+		if (libdata->backfill_screen)
+		{
+			icon = GetIconTags(name,
+							   ICONGETA_FailIfUnavailable, FALSE,
+							   ICONGETA_Screen, (IPTR)*libdata->backfill_screen,
+							   TAG_DONE);
+			if (icon)
+				return icon;
+		}
+	}
+
 	// Lock object
 	if ((lock = Lock(name, ACCESS_READ)))
 	{

--- a/source/Library/icon_cache.c
+++ b/source/Library/icon_cache.c
@@ -212,12 +212,16 @@ struct DiskObject *LIBFUNC L_GetCachedDiskObject(REG(a0, char *name),
 	{
 		icon = NULL;
 
-		// old method with no remap.
-		// icon=GetIconTags(name,ICONGETA_FailIfUnavailable,TRUE,ICONGETA_RemapIcon,FALSE,TAG_DONE);
-
+		// Return only real icons here. Setting ICONGETA_FailIfUnavailable=FALSE
+		// would make icon.library hand back a filename-pattern deficon (e.g.
+		// env:sys/def_ascii) for any file without a real .info, which
+		// short-circuits GetProperIcon() and prevents DOpus filetype icons from
+		// ever being consulted in icon-view listers (issue #24).
+		// Deficons fallback for files without .info still happens via
+		// GetProperIcon() -> filetype_identify() -> GetCachedDiskObjectNew().
 		if (data->backfill_screen)
 			icon = GetIconTags(
-				name, ICONGETA_FailIfUnavailable, FALSE, ICONGETA_Screen, (IPTR)*data->backfill_screen, TAG_DONE);
+				name, ICONGETA_FailIfUnavailable, TRUE, ICONGETA_Screen, (IPTR)*data->backfill_screen, TAG_DONE);
 
 		return icon;
 	}


### PR DESCRIPTION
## Summary

Fix #24: in icon-view listers, files matching a user-defined filetype with a custom icon (e.g. a *Sound, Music Module* filetype with a MOD icon) were rendered with a generic icon.library deficon (\`env:sys/def_ascii\`) instead of the user's filetype icon. Regression vs. 5.82.

## Repro (from issue)

- Set up a filetype \`Sound, Music Module\` with filename pattern matching \`*.MOD|MDAT|...\` and a custom MOD-style icon.
- Browse a folder containing matching files in icon-view mode.
- 5.82: files render with the user's MOD icon.
- 5.92 / 5.100: files render with a generic ASCII deficon.

## Root cause

Commit ad0d5a6 (\"Enable default icons (deficons) to be displayed [...] with 'show all' enabled\") flipped a single flag in \`L_GetCachedDiskObject()\` for icon.library v44+:

\`\`\`c
// before:  GetIconTags(name, ICONGETA_FailIfUnavailable, TRUE, ...)
// after:   GetIconTags(name, ICONGETA_FailIfUnavailable, FALSE, ...)
\`\`\`

With \`FailIfUnavailable=FALSE\`, icon.library on v44+ falls back to a filename-pattern deficon (e.g. \`env:sys/def_ascii\`) when no real \`.info\` exists, instead of returning NULL. That violates the contract \`GetProperIcon()\` relies on:

\`\`\`c
struct DiskObject *GetProperIcon(char *name, short *fake, ULONG flags)
{
    if ((icon = GetCachedDiskObject(name, flags)))   // now ALWAYS
        return icon;                                  //   succeeds
    ...
    if ((ftype = filetype_identify(name, FTTYPE_ICON, ...)))   // dead code
        ...
    return GetCachedDiskObjectNew(name, flags);
}
\`\`\`

Because the first call now always succeeds (real \`.info\` *or* a deficon), DOpus's filetype-icon table is never consulted. Hence: ASCII deficon instead of the user's MOD icon.

## Fix

Restore \`FailIfUnavailable=TRUE\` so \`GetCachedDiskObject()\` means \"real icon or NULL\" again. Add a comment explaining why this flag matters so it doesn't get flipped back.

The deficons fallback that ad0d5a6 wanted is still in place via the existing \`GetCachedDiskObjectNew()\` call at the bottom of \`GetProperIcon()\`. That path produces a type-based default icon (\`env:sys/def_project\`, \`env:sys/def_drawer\`, ...) when no real icon and no filetype icon exist - the same fallback that worked in 5.82.

What ad0d5a6 added on top - icon.library's *filename-pattern* deficons (\`env:sys/def_ascii\`, \`env:sys/def_python\`, ...) - is dropped for now. If wanted, it can be re-added cleanly inside \`L_GetCachedDiskObjectNew()\` instead, where it doesn't shadow filetype matching.

## Test plan

- [x] Builds cleanly for AmigaOS 3 (sacredbanana/amiga-compiler:m68k-amigaos)
- [x] Builds cleanly for AmigaOS 4 (sacredbanana/amiga-compiler:ppc-amigaos)
- [x] Builds cleanly for MorphOS (sacredbanana/amiga-compiler:ppc-morphos)
- [x] AROS not verified locally: xadmaster.library SDK still missing in those Docker images, but the change is in the main \`dopus5.library\` (no XAD dependency), so it should compile fine on AROS too
- [x] Manual test on target: configure a filetype with a custom icon, browse a folder containing matching files in icon-view mode, confirm the user's icon is shown (not a generic deficon)
- [x] Manual test: in Show All mode, files without a matching filetype still get a project/drawer/disk deficon (not blank)

Closes #24