### PR TITLE
configopus: fix DOpus 4 import mapping buttons -> menus -> drives

### DIFF
--- a/source/Modules/configopus/enums.h
+++ b/source/Modules/configopus/enums.h
@@ -121,7 +121,12 @@ enum {
 	GAD_BUTTONED_CANCEL,
 	GAD_CONVERT_LAYOUT,
 	GAD_CONVERT_ENVIRONMENT,
-	GAD_CONVERT_SETTINGS,
+	/* GAD_CONVERT_SETTINGS removed: was a leftover for an "Options" checkbox
+	 * that no longer exists in the dialog (see config_convert_data.c). Keeping
+	 * it in the enum shifted GAD_CONVERT_BUTTONS..HOTKEYS one slot up relative
+	 * to the CONVERT_* bit enum used in config_convert.c, so the loop
+	 *   convert |= 1 << (a - GAD_CONVERT_ENVIRONMENT);
+	 * mapped BUTTONS->CONVERT_MENUS, MENUS->CONVERT_DRIVES, etc. (issue #29). */
 	GAD_CONVERT_BUTTONS,
 	GAD_CONVERT_MENUS,
 	GAD_CONVERT_DRIVES,


### PR DESCRIPTION
## Summary

Fix #29: importing a DirOpus 4 configuration imported buttons as menus, menus as drives, and (depending on which checkboxes were ticked) silently dropped drives, filetypes and hotkeys.

## Root cause

The convert dialog in <ref_file file="source/Modules/configopus/config_convert.c" /> builds the convert bitmap with:

\`\`\`c
for (a = GAD_CONVERT_ENVIRONMENT; a <= GAD_CONVERT_HOTKEYS; a++)
    if (GetGadgetValue(objlist, a))
        convert |= 1 << (a - GAD_CONVERT_ENVIRONMENT);
\`\`\`

That assumes the \`GAD_CONVERT_*\` ids and the \`CONVERT_*\` bit positions line up 1:1, but a leftover \`GAD_CONVERT_SETTINGS\` enum entry sits between \`ENVIRONMENT\` and \`BUTTONS\` in <ref_file file="source/Modules/configopus/enums.h" />. The corresponding "Options" checkbox was removed from the dialog long ago (no entry in \`config_convert_data.c\`, just an empty row in the layout) but the enum entry was left in place. The loop walks straight through that gap:

| GAD_CONVERT_* | Loop offset | Bit set | Means in CONVERT_* enum |
|--|--|--|--|
| ENVIRONMENT | 0 | bit 0 | CONVERT_ENVIRONMENT  |
| SETTINGS (no gadget) | 1 | – | (returns 0, skipped) |
| BUTTONS | 2 | bit 2 | **CONVERT_MENUS** |
| MENUS | 3 | bit 3 | **CONVERT_DRIVES** |
| DRIVES | 4 | bit 4 | **CONVERT_FILETYPES** |
| FILETYPES | 5 | bit 5 | **CONVERT_HOTKEYS** |
| HOTKEYS | 6 | bit 6 | (out of range, lost) |

Which matches the bug report exactly: buttons get imported as menus, menus as drives, drives selection does nothing useful, and so on.

## Fix

Drop \`GAD_CONVERT_SETTINGS\` from the enum so the gadget IDs walked by the loop again line up with the \`CONVERT_*\` bit numbers. Verified the symbol is only ever used as a gadget identifier in this one dialog and is referenced nowhere else (\`grep GAD_CONVERT_SETTINGS\` across the whole tree). The catalog string \`MSG_CONVERT_SETTINGS\` is unused dead text and is left in place to avoid catalog-version churn.

## Test plan

- [x] Builds cleanly for AmigaOS 3 (sacredbanana/amiga-compiler:m68k-amigaos)
- [x] Builds cleanly for AmigaOS 4 (sacredbanana/amiga-compiler:ppc-amigaos)
- [x] Builds cleanly for MorphOS (sacredbanana/amiga-compiler:ppc-morphos)
- [ ] AROS not verified locally (xadmaster SDK absent from those Docker images, pre-existing limitation - module change is enum-only and platform-agnostic)
- [ ] Manual test on target: load an Environment + select a DirOpus 4 cfg file, confirm buttons go to dopus5:Buttons/, menus go to dopus5:Menus/, drives go to dopus5:Drives/

Closes #29