### PR TITLE
Fix #36: normalise DOpus5: path casing across hardcoded literals

### DIFF
--- a/source/Library/config_open.c
+++ b/source/Library/config_open.c
@@ -243,7 +243,7 @@ Cfg_ButtonBank *LIBFUNC L_OpenButtonBank(REG(a0, char *name))
 	// It doesn't
 	if (!ok)
 	{
-		char *drawers[] = {"PROGDIR:Buttons", "dopus5:buttons", "dopus5:Buttons", 0};
+		char *drawers[] = {"PROGDIR:Buttons", "DOpus5:Buttons", 0};
 		short a;
 
 		// Get filename only

--- a/source/Library/config_save.c
+++ b/source/Library/config_save.c
@@ -99,7 +99,7 @@ int LIBFUNC L_SaveSettings(REG(a0, CFG_SETS *settings), REG(a1, char *name), REG
 			if ((GetVar("dopus/dopus", buf, sizeof(buf), GVF_GLOBAL_ONLY) > 0) && strstr(buf, "-icons-"))
 			{
 				// Write icon file
-				L_WriteFileIcon("dopus5:icons/Settings", name, libbase);
+				L_WriteFileIcon("DOpus5:Icons/Settings", name, libbase);
 			}
 		}
 	}
@@ -274,7 +274,7 @@ int LIBFUNC L_SaveButtonBank(REG(a0, Cfg_ButtonBank *bank), REG(a1, char *name),
 		if ((GetVar("dopus/dopus", buf, sizeof(buf), GVF_GLOBAL_ONLY) > 0) && strstr(buf, "-icons-"))
 		{
 			// Write icon file
-			L_WriteFileIcon("dopus5:icons/Buttons", name, libbase);
+			L_WriteFileIcon("DOpus5:Icons/Buttons", name, libbase);
 		}
 		break;
 	}
@@ -364,7 +364,7 @@ int LIBFUNC L_SaveFiletypeList(REG(a0, Cfg_FiletypeList *list), REG(a1, char *na
 		if ((GetVar("dopus/dopus", buf, sizeof(buf), GVF_GLOBAL_ONLY) > 0) && strstr(buf, "-icons-"))
 		{
 			// Write icon file
-			L_WriteFileIcon("dopus5:icons/Filetype", name, libbase);
+			L_WriteFileIcon("DOpus5:Icons/Filetype", name, libbase);
 		}
 		break;
 	}

--- a/source/Library/filetypes.c
+++ b/source/Library/filetypes.c
@@ -791,7 +791,7 @@ BOOL LIBFUNC L_MatchFiletype(REG(a0, MatchHandle *handle), REG(a1, Cfg_Filetype 
 					struct Library *MUSICBase;
 
 					// Open music library?
-					if ((MUSICBase = OpenLibrary("dopus5:libs/inovamusic.library", 0)))
+					if ((MUSICBase = OpenLibrary("DOpus5:Libs/inovamusic.library", 0)))
 					{
 						short ret;
 

--- a/source/Library/images.c
+++ b/source/Library/images.c
@@ -1095,15 +1095,15 @@ static Image_Data *aros_read_image_fallback(char *name, OpenImageInfo *info)
 	if (info || !name || !name[0])
 		return 0;
 
-	if (strnicmp(name, "dopus5:images/", 14) == 0 || strnicmp(name, "dopus5:Images/", 14) == 0)
+	if (strnicmp(name, "DOpus5:Images/", 14) == 0)
 		leaf = name + 14;
-	else if (strnicmp(name, "PROGDIR:images/", 15) == 0 || strnicmp(name, "PROGDIR:Images/", 15) == 0)
+	else if (strnicmp(name, "PROGDIR:Images/", 15) == 0)
 		leaf = name + 15;
 
 	if (!leaf || !leaf[0])
 		return 0;
 
-	if ((image = aros_try_image_path("dopus5:Images/", leaf)))
+	if ((image = aros_try_image_path("DOpus5:Images/", leaf)))
 		return image;
 
 	return aros_try_image_path("PROGDIR:Images/", leaf);

--- a/source/Library/wb.c
+++ b/source/Library/wb.c
@@ -2001,10 +2001,10 @@ PATCHED_3(ULONG, LIBFUNC L_PatchedWBInfo, a0, BPTR, lock, a1, char *, name, a2, 
 			struct ModuleIFace *IModule = NULL;
 
 			// Open the icon.module
-			if ((ModuleBase = OpenLibrary("dopus5:modules/icon.module", LIB_VERSION)) &&
+			if ((ModuleBase = OpenLibrary("DOpus5:Modules/icon.module", LIB_VERSION)) &&
 				((IModule = (APTR)GetInterface((struct Library *)ModuleBase, "main", 1L, NULL))))
 #else
-			if ((ModuleBase = OpenLibrary("dopus5:modules/icon.module", LIB_VERSION)))
+			if ((ModuleBase = OpenLibrary("DOpus5:Modules/icon.module", LIB_VERSION)))
 #endif
 			{
 				BPTR old;

--- a/source/Misc/C/ViewFont/font.c
+++ b/source/Misc/C/ViewFont/font.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
 
 	// Need dopus library
 	if (!(DOpusBase = OpenLibrary("dopus5.library", LIB_VERSION)))
-		if (!(DOpusBase = OpenLibrary("dopus5:libs/dopus5.library", 55)))
+		if (!(DOpusBase = OpenLibrary("DOpus5:Libs/dopus5.library", 55)))
 			return (10);
 #ifdef __amigaos4__
 	if (!(IDOpus = (struct DOpusIFace *)GetInterface(DOpusBase, "main", 1, NULL)))
@@ -78,8 +78,8 @@ int main(int argc, char **argv)
 	{
 		BPTR lock;
 
-		// Change PROGDIR: to dopus5:, save old PROGDIR for restore on exit
-		if ((lock = Lock("dopus5:", ACCESS_READ)))
+		// Change PROGDIR: to DOpus5:, save old PROGDIR for restore on exit
+		if ((lock = Lock("DOpus5:", ACCESS_READ)))
 			data->lock = SetProgramDir(lock);
 
 		// Initialise
@@ -457,7 +457,7 @@ void font_free(font_data *data)
 			CloseCatalog(data->locale.li_Catalog);
 		}
 
-		// Restore PROGDIR: and unlock our dopus5: lock
+		// Restore PROGDIR: and unlock our DOpus5: lock
 		if (data->lock)
 			UnLock(SetProgramDir(data->lock));
 

--- a/source/Misc/C/dopusrt/dopusrt.c
+++ b/source/Misc/C/dopusrt/dopusrt.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 		sprintf(buffer, "\"%s\" \"%s\"", argv[1], argv[2]);
 
 	// Open dopus library
-	if (!(DOpusBase = OpenLibrary("dopus5:libs/dopus5.library", LIB_VERSION)))
+	if (!(DOpusBase = OpenLibrary("DOpus5:Libs/dopus5.library", LIB_VERSION)))
 		return (RETURN_ERROR);
 
 #ifdef __amigaos4__

--- a/source/Misc/C/loadwb/loaddb.c
+++ b/source/Misc/C/loadwb/loaddb.c
@@ -91,7 +91,7 @@ int main(int argc, char **arg_string)
 		if (FindPort("Directory Opus"))
 		{
 			// Open library
-			if ((DOpusBase = OpenLibrary("dopus5:libs/dopus5.library", LIB_VERSION)))
+			if ((DOpusBase = OpenLibrary("DOpus5:Libs/dopus5.library", LIB_VERSION)))
 			{
 #ifdef __amigaos4__
 				IDOpus = (struct DOpusIFace *)GetInterface(DOpusBase, "main", 1, NULL);
@@ -191,7 +191,7 @@ int main(int argc, char **arg_string)
 			UnLock(lock);
 
 			// Open library
-			// if ((DOpusBase=OpenLibrary("dopus5:libs/dopus5.library",0)))
+			// if ((DOpusBase=OpenLibrary("DOpus5:Libs/dopus5.library",0)))
 			{
 				/*#ifdef __amigaos4__
 				IDOpus = (struct DOpusIFace *)GetInterface(DOpusBase, "main", 1, NULL);

--- a/source/Modules/cleanup/cleanup.c
+++ b/source/Modules/cleanup/cleanup.c
@@ -55,7 +55,7 @@ int LIBFUNC L_Module_Entry(REG(a0, struct List *files),
 		APTR iff;
 
 		// Open position info file
-		if ((iff = IFFOpen("dopus5:system/position-info", IFF_READ, ID_OPUS)))
+		if ((iff = IFFOpen("DOpus5:System/position-info", IFF_READ, ID_OPUS)))
 		{
 			ULONG id;
 			BOOL ok = 1;
@@ -147,7 +147,7 @@ int LIBFUNC L_Module_Entry(REG(a0, struct List *files),
 				ok = 0;
 
 			// Re-open file
-			if (ok && (iff = IFFOpen("dopus5:system/position-info", IFF_WRITE | IFF_SAFE, ID_OPUS)))
+			if (ok && (iff = IFFOpen("DOpus5:System/position-info", IFF_WRITE | IFF_SAFE, ID_OPUS)))
 			{
 				struct Node *node;
 

--- a/source/Modules/configopus/button_editor_data.c
+++ b/source/Modules/configopus/button_editor_data.c
@@ -49,7 +49,7 @@ const struct TagItem
 							  {TAG_MORE, (IPTR)_button_editor_function_layout}},
 
 	_button_editor_image[] = {{GTCustom_Control, GAD_BUTTONED_LABEL},
-							  {DFB_DefPath, (IPTR) "dopus5:images/"},
+							  {DFB_DefPath, (IPTR) "DOpus5:Images/"},
 							  {TAG_MORE, (IPTR)_button_editor_function_layout}};
 
 // Button editor objects

--- a/source/Modules/configopus/config_convert.c
+++ b/source/Modules/configopus/config_convert.c
@@ -143,7 +143,7 @@ BOOL LIBFUNC L_ConvertConfig(REG(a0, char *name), REG(a1, struct Screen *parent)
 			// Send name back
 			if (convert & (1 << CONVERT_ENVIRONMENT) && basename[0])
 			{
-				lsprintf(name, "dopus5:environment/%s", basename);
+				lsprintf(name, "DOpus5:Environment/%s", basename);
 				success = 1;
 			}
 
@@ -429,7 +429,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 #endif
 
 			// Build filename
-			lsprintf(buffer, "dopus5:environment/%s", basename);
+			lsprintf(buffer, "DOpus5:Environment/%s", basename);
 
 			// Try to open file to write
 			while ((iff = IFFOpen(buffer, MODE_NEWFILE, ID_EPUS)))
@@ -444,7 +444,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 				// Write hotkeys file name
 				if (convert & (1 << CONVERT_HOTKEYS))
 				{
-					lsprintf(buffer, "dopus5:buttons/%s_hotkeys", basename);
+					lsprintf(buffer, "DOpus5:Buttons/%s_hotkeys", basename);
 					if (!(IFFWriteChunk(iff, buffer, ID_HKEY, strlen(buffer) + 1)))
 						break;
 				}
@@ -452,7 +452,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 				// Write menus file name
 				if (convert & (1 << CONVERT_MENUS))
 				{
-					lsprintf(buffer, "dopus5:buttons/%s_menu", basename);
+					lsprintf(buffer, "DOpus5:Buttons/%s_menu", basename);
 					if (!(IFFWriteChunk(iff, buffer, ID_UMEN, strlen(buffer) + 1)))
 						break;
 				}
@@ -497,7 +497,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 						break;
 
 					// Write bank path
-					lsprintf(buffer, "dopus5:buttons/%s", basename);
+					lsprintf(buffer, "DOpus5:Buttons/%s", basename);
 					if (!(IFFWriteChunkBytes(iff, buffer, strlen(buffer) + 1)) || !(IFFPopChunk(iff)))
 						break;
 				}
@@ -530,9 +530,9 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 			{
 				// Build name to save
 				if (count == 0)
-					lsprintf(buffer, "dopus5:buttons/%s", basename);
+					lsprintf(buffer, "DOpus5:Buttons/%s", basename);
 				else
-					lsprintf(buffer, "dopus5:buttons/%s.%ld", basename, count + 1);
+					lsprintf(buffer, "DOpus5:Buttons/%s.%ld", basename, count + 1);
 
 				// Save bank
 				if (SaveButtonBank(new_bank, buffer))
@@ -632,7 +632,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 				bank->window.rows = 1;
 
 			// Build name to save
-			lsprintf(buffer, "dopus5:buttons/%s_drives", basename);
+			lsprintf(buffer, "DOpus5:Buttons/%s_drives", basename);
 
 			// Save bank
 			if (SaveButtonBank(bank, buffer))
@@ -795,7 +795,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 				bank->window.rows = 1;
 
 			// Build name to save
-			lsprintf(buffer, "dopus5:buttons/%s_menu", basename);
+			lsprintf(buffer, "DOpus5:Buttons/%s_menu", basename);
 
 			// Save bank
 			if (SaveButtonBank(bank, buffer))
@@ -823,7 +823,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 			list.flags = 0;
 
 			// Build filetype path
-			lsprintf(buffer, "dopus5:filetypes/%s", oldtype->type);
+			lsprintf(buffer, "DOpus5:Filetypes/%s", oldtype->type);
 
 			// Check that it doesn't exist
 			if (!(lock = Lock(buffer, ACCESS_READ)))
@@ -965,7 +965,7 @@ short convert_config(ConfigStuff *cstuff, short convert, char *basename)
 				bank->window.rows = 1;
 
 			// Build name to save
-			lsprintf(buffer, "dopus5:buttons/%s_hotkeys", basename);
+			lsprintf(buffer, "DOpus5:Buttons/%s_hotkeys", basename);
 
 			// Save bank
 			if (SaveButtonBank(bank, buffer))

--- a/source/Modules/configopus/config_environment.c
+++ b/source/Modules/configopus/config_environment.c
@@ -688,7 +688,7 @@ unsigned long LIBFUNC L_Config_Environment(REG(a0, Cfg_Environment *env),
 						SetWindowBusy(data->window);
 
 						// Get lister format module
-						if ((ModuleBase = OpenLibrary("dopus5:modules/listerformat.module", LIB_VERSION)) &&
+						if ((ModuleBase = OpenLibrary("DOpus5:Modules/listerformat.module", LIB_VERSION)) &&
 							GETINTERFACE(IModule, ModuleBase))
 						{
 							// Edit format
@@ -2789,7 +2789,7 @@ void config_env_load(config_env_data *data, UWORD id)
 		// If new, clear filename
 		if (id == BUTTONEDIT_MENU_NEW)
 		{
-			strcpy(path, "dopus5:environment/");
+			strcpy(path, "DOpus5:Environment/");
 			strcat(path, GetString(locale, MSG_UNTITLED));
 		}
 		ret = READCFG_OK;
@@ -2832,7 +2832,7 @@ void config_env_load(config_env_data *data, UWORD id)
 			struct OpenEnvironmentData *opendata;
 
 			// Get filename
-			if (ask && !(config_filereq(data->window, MSG_ENVIRONMENT_OPEN, path, "dopus5:environment/", 0)))
+			if (ask && !(config_filereq(data->window, MSG_ENVIRONMENT_OPEN, path, "DOpus5:Environment/", 0)))
 				break;
 
 			// Initialise open structure
@@ -2991,7 +2991,7 @@ BOOL config_env_save(config_env_data *data, short saveas)
 		if (retry || saveas || !config_valid_path(path))
 		{
 			// Get filename
-			if (!config_filereq(data->window, MSG_ENVIRONMENT_SAVE, path, "dopus5:environment/", 1))
+			if (!config_filereq(data->window, MSG_ENVIRONMENT_SAVE, path, "DOpus5:Environment/", 1))
 				break;
 		}
 

--- a/source/Modules/configopus/config_environment_sounds.c
+++ b/source/Modules/configopus/config_environment_sounds.c
@@ -82,7 +82,7 @@ void config_env_test_sound(config_env_data *data)
 	SetWindowBusy(data->window);
 
 	// Open play.module
-	if ((ModuleBase = OpenLibrary("dopus5:modules/play.module", LIB_VERSION)) && GETINTERFACE(IModule, ModuleBase))
+	if ((ModuleBase = OpenLibrary("DOpus5:Modules/play.module", LIB_VERSION)) && GETINTERFACE(IModule, ModuleBase))
 	{
 		short num;
 		Cfg_SoundEntry *sound;

--- a/source/Modules/configopus/config_filetypes.c
+++ b/source/Modules/configopus/config_filetypes.c
@@ -425,7 +425,7 @@ void filetype_read_list(APTR memory, struct List *main_list)
 	anchor->ap_Flags = APF_DOWILD;
 
 	// Search for filetypes
-	error = MatchFirst("dopus5:filetypes/~(#?.info)", anchor);
+	error = MatchFirst("DOpus5:Filetypes/~(#?.info)", anchor);
 
 	// Continue while there's files
 	while (!error)
@@ -772,9 +772,9 @@ short filetype_save(config_filetypes_data *data)
 
 					// Storage or normal?
 					if (list->flags & FTLISTF_STORE)
-						strcpy(list->path, "dopus5:Filetypes/Storage/");
+						strcpy(list->path, "DOpus5:Filetypes/Storage/");
 					else
-						strcpy(list->path, "dopus5:Filetypes/");
+						strcpy(list->path, "DOpus5:Filetypes/");
 
 					// Check name for / characters
 					for (ptr = type->type.name; *ptr; ptr++)
@@ -791,7 +791,7 @@ short filetype_save(config_filetypes_data *data)
 					char buf[256];
 
 					// Build storage filename
-					lsprintf(buf, "dopus5:Storage/Filetypes/%s", FilePart(list->path));
+					lsprintf(buf, "DOpus5:Storage/Filetypes/%s", FilePart(list->path));
 
 					// Delete existing stored filetype
 					DeleteFile(buf);
@@ -894,7 +894,7 @@ void filetype_edit_name(config_filetypes_data *data, char *name)
 			AddTail(&data->list_list, &list->node);
 
 			// Fix list path and flags
-			strcpy(list->path, "dopus5:filetypes/");
+			strcpy(list->path, "DOpus5:Filetypes/");
 			strcat(list->path, name);
 			list->flags = FTLISTF_CHANGED;
 

--- a/source/Modules/configopus/config_menus_data.c
+++ b/source/Modules/configopus/config_menus_data.c
@@ -363,7 +363,7 @@ long config_menus_title[] = {MSG_MENUS_TITLE,
 							 MSG_MENUS_START_TITLE,
 							 MSG_START_DEF_TITLE};
 
-char *config_menus_default[] = {"dopus5:buttons/user menu_default",
-								"dopus5:buttons/lister menu_default",
-								"dopus5:system/menu keys_default",
-								"dopus5:buttons/start menu_default"};
+char *config_menus_default[] = {"DOpus5:Buttons/user menu_default",
+								"DOpus5:Buttons/lister menu_default",
+								"DOpus5:System/menu keys_default",
+								"DOpus5:Buttons/start menu_default"};

--- a/source/Modules/configopus/config_menus_io.c
+++ b/source/Modules/configopus/config_menus_io.c
@@ -30,7 +30,7 @@ BOOL config_menus_save(config_menus_data *data, BOOL save_as)
 
 			// No path given?
 			if (!*path)
-				strcpy(path, "dopus5:buttons/");
+				strcpy(path, "DOpus5:Buttons/");
 
 			// Get filename
 			else if ((ptr = FilePart(path)))
@@ -164,7 +164,7 @@ void config_menus_load(config_menus_data *data, short type)
 
 		// If no path specified, use default
 		if (!*path)
-			strcpy(path, "dopus5:buttons/");
+			strcpy(path, "DOpus5:Buttons/");
 
 		// Display file requester
 		if (AslRequestTags(DATA(data->window)->request,

--- a/source/Modules/configopus/filetype_editor.c
+++ b/source/Modules/configopus/filetype_editor.c
@@ -949,7 +949,7 @@ BOOL filetypeed_pick_icon(filetype_ed_data *data)
 	}
 
 	if (!path[0])
-		strcpy(path, "Dopus5:");
+		strcpy(path, "DOpus5:");
 
 	// Build pattern
 	ParsePatternNoCase("#?.info", pattern, 18);
@@ -982,8 +982,9 @@ BOOL filetypeed_pick_icon(filetype_ed_data *data)
 		// Build new path
 		if (reqpath[0] && (lock = Lock(reqpath, ACCESS_READ)))
 		{
-			// Copy drawer path if it's in Dopus5 dir
-			if (strstr(reqpath, "Dopus5:") && !strstr(reqpath, ":/"))
+			// Copy drawer path if it's in DOpus5: tree (case-insensitive,
+			// since the assign is registered as "DOPUS5")
+			if (strnicmp(reqpath, "DOpus5:", 7) == 0 && !strstr(reqpath, ":/"))
 				strcpy(path, reqpath);
 			// Get absolute path to avoid relative paths
 			else if (!(NameFromLock(lock, path, sizeof(path))))

--- a/source/Modules/configopus/function_editor_data.c
+++ b/source/Modules/configopus/function_editor_data.c
@@ -41,7 +41,7 @@ struct TagItem
 								{TAG_MORE, (IPTR)_function_edit_layout}},
 
 	_function_editor_image[] = {{GTCustom_Control, GAD_FUNCED_LABEL},
-								{DFB_DefPath, (IPTR) "dopus5:images/"},
+								{DFB_DefPath, (IPTR) "DOpus5:Images/"},
 								{GTCustom_LayoutRel, GAD_FUNCED_LAYOUT_1},
 								{TAG_END}};
 

--- a/source/Modules/configopus/lister_menu.c
+++ b/source/Modules/configopus/lister_menu.c
@@ -1202,7 +1202,7 @@ BOOL lister_menu_save(lister_menu_data *data, unsigned short gadgetid)
 
 			// Invalid path?
 			if (!path[0])
-				strcpy(path, "dopus5:buttons/");
+				strcpy(path, "DOpus5:Buttons/");
 
 			// Get filename
 			else if ((ptr = FilePart(path)))
@@ -1326,7 +1326,7 @@ BOOL lister_menu_load(lister_menu_data *data, short new)
 	else if (new == -2)
 	{
 		// Default name
-		strcpy(path, "dopus5:buttons/");
+		strcpy(path, "DOpus5:Buttons/");
 		strcat(path, data->default_name);
 		strcat(path, "_default");
 	}
@@ -1354,7 +1354,7 @@ BOOL lister_menu_load(lister_menu_data *data, short new)
 
 		// Invalid path?
 		if (!path[0])
-			strcpy(path, "dopus5:buttons/");
+			strcpy(path, "DOpus5:Buttons/");
 
 		// Display file requester
 		if ((ok = AslRequestTags(
@@ -1838,7 +1838,7 @@ void scripts_check_bank(lister_menu_data *data)
 	}
 
 	// Default name
-	strcpy(data->menu_name, "dopus5:Buttons/Scripts");
+	strcpy(data->menu_name, "DOpus5:Buttons/Scripts");
 }
 
 // Fix colours in function list

--- a/source/Modules/filetype/filetype.c
+++ b/source/Modules/filetype/filetype.c
@@ -834,7 +834,7 @@ void SAVEDS finder_editor_proc_code(void)
 
 	IPC_ProcStartup((IPTR *)&data, (APTR)&finder_editor_proc_init);
 
-	if (data->best_installed_ft && (ConfigOpusBase = OpenLibrary("Dopus5:Modules/configopus.module", LIB_VERSION)) &&
+	if (data->best_installed_ft && (ConfigOpusBase = OpenLibrary("DOpus5:Modules/configopus.module", LIB_VERSION)) &&
 		GETINTERFACE(IConfigOpus, ConfigOpusBase))
 	{
 		if ((edited_filetype =
@@ -2273,7 +2273,7 @@ void SAVEDS creator_editor_proc_code(void)
 	if (!data->filetype || !data->edited)
 		creator_create_filetype(data);
 
-	if (data->filetype && (ConfigOpusBase = OpenLibrary("Dopus5:Modules/configopus.module", LIB_VERSION)) &&
+	if (data->filetype && (ConfigOpusBase = OpenLibrary("DOpus5:Modules/configopus.module", LIB_VERSION)) &&
 		GETINTERFACE(IConfigOpus, ConfigOpusBase))
 	{
 		DisableObject(data->list, GAD_CREATE_LISTVIEW, TRUE);

--- a/source/Modules/ftp/ftp_addressbook.c
+++ b/source/Modules/ftp/ftp_addressbook.c
@@ -3521,7 +3521,7 @@ static void add_to_main_list(struct display_globals *dg, Att_List *atlist)
 /***************************************************
  *
  * User gets a new toolbar file
- * remove dopus5:system if selected path
+ * remove DOpus5:System if selected path
  * defaults to "toolbar_ftp"
  *
  */
@@ -3569,7 +3569,7 @@ static BOOL get_toolbar(struct window_params *wp, char *filename)
 	{
 		// Get new path
 
-		if (stricmp("DOpus5:buttons", DATA(wp->wp_win)->request->fr_Drawer))
+		if (stricmp("DOpus5:Buttons", DATA(wp->wp_win)->request->fr_Drawer))
 		{
 			strcpy(filename, DATA(wp->wp_win)->request->fr_Drawer);
 			AddPart(filename, DATA(wp->wp_win)->request->fr_File, 256);

--- a/source/Modules/ftp/ftp_addressbook.h
+++ b/source/Modules/ftp/ftp_addressbook.h
@@ -25,7 +25,7 @@ For more information on Directory Opus for Windows please see:
 #define _addressbook_h
 
 /*
- *	09-04-96	Changed CONFIGFILE from "Dopus5:FTP/ftp.config" to "Dopus5:System/ftp.config"
+ *	09-04-96	Changed CONFIGFILE from "DOpus5:FTP/ftp.config" to "DOpus5:System/ftp.config"
  */
 
 #include "ftp_opusftp.h"

--- a/source/Modules/ftp/ftp_addrformat.c
+++ b/source/Modules/ftp/ftp_addrformat.c
@@ -152,7 +152,7 @@ static void format_code(void)
 			function_no = 3;
 
 		// Get lister format module
-		if ((ModuleBase = OpenLibrary("dopus5:modules/listerformat.module", LIB_VERSION)) &&
+		if ((ModuleBase = OpenLibrary("DOpus5:Modules/listerformat.module", LIB_VERSION)) &&
 			GETINTERFACE(IModule, ModuleBase))
 		{
 			// Edit format

--- a/source/Modules/ftp/ftp_main.c
+++ b/source/Modules/ftp/ftp_main.c
@@ -3174,7 +3174,7 @@ void dopus_ftp(void)
 	// Open our module so we can't be expunged
 	if (!(ourbase = OpenLibrary("ftp.module", 0)))
 		if (!(ourbase = OpenLibrary("PROGDIR:Modules/ftp.module", 0)))
-			ourbase = OpenLibrary("dopus5:modules/ftp.module", 0);
+			ourbase = OpenLibrary("DOpus5:Modules/ftp.module", 0);
 
 	if (ourbase && GETINTERFACE(IModule, ourbase))
 	{

--- a/source/Modules/ftp/ftp_module.c
+++ b/source/Modules/ftp/ftp_module.c
@@ -588,7 +588,7 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 	// Screen pointer should not be global to support multiple Opuses
 	og.og_screen = screen;
 
-	/*if	((DOpusBase = OpenLibrary( "dopus5:libs/dopus5.library", VERSION_DOPUSLIB )))
+	/*if	((DOpusBase = OpenLibrary( "DOpus5:Libs/dopus5.library", VERSION_DOPUSLIB )))
 		{
 		#ifdef __amigaos4__
 		IDOpus = (struct DOpusIFace *)GetInterface(DOpusBase, "main", 1, NULL);

--- a/source/Modules/pathformat/pathformat.c
+++ b/source/Modules/pathformat/pathformat.c
@@ -753,7 +753,7 @@ void config_paths_edit(config_path_data *data)
 		SetWindowBusy(data->window);
 
 		// Get lister format module
-		if ((ModuleBase = OpenLibrary("dopus5:modules/listerformat.module", LIB_VERSION)) &&
+		if ((ModuleBase = OpenLibrary("DOpus5:Modules/listerformat.module", LIB_VERSION)) &&
 			GETINTERFACE(IModule, ModuleBase))
 		{
 			// Convert ListFormatStorage to ListFormat

--- a/source/Modules/play/play.c
+++ b/source/Modules/play/play.c
@@ -243,7 +243,7 @@ BOOL play_file(play_data *data)
 	else
 	{
 		// Open music library
-		if (!MUSICBase && !(MUSICBase = OpenLibrary("dopus5:libs/inovamusic.library", 0)))
+		if (!MUSICBase && !(MUSICBase = OpenLibrary("DOpus5:Libs/inovamusic.library", 0)))
 			MUSICBase = OpenLibrary("inovamusic.library", 0);
 
 		// Try for module
@@ -476,7 +476,7 @@ void play_iconify(play_data *data)
 		return;
 
 	// No icon yet?
-	if (!data->icon && !(data->icon = GetDiskObject("dopus5:icons/play")) &&
+	if (!data->icon && !(data->icon = GetDiskObject("DOpus5:Icons/play")) &&
 		!(data->icon = GetDefDiskObject(WBPROJECT)))
 		return;
 

--- a/source/Modules/read/read.c
+++ b/source/Modules/read/read.c
@@ -1311,7 +1311,7 @@ BOOL read_view(read_data *data)
 						struct TagItem tags[3];
 
 						// No icon yet?
-						if (!data->app_diskobj && !(data->app_diskobj = GetDiskObject("dopus5:icons/read")) &&
+						if (!data->app_diskobj && !(data->app_diskobj = GetDiskObject("DOpus5:Icons/read")) &&
 							!(data->app_diskobj = GetDefDiskObject(WBPROJECT)))
 							break;
 
@@ -3961,7 +3961,7 @@ void read_print(read_data *data)
 	SetBusyPointer(data->window);
 
 	// Get print module
-	if ((ModuleBase = OpenLibrary("dopus5:modules/print.module", LIB_VERSION)) && GETINTERFACE(IModule, ModuleBase))
+	if ((ModuleBase = OpenLibrary("DOpus5:Modules/print.module", LIB_VERSION)) && GETINTERFACE(IModule, ModuleBase))
 	{
 		struct List list;
 		struct Node node;

--- a/source/Program/about.c
+++ b/source/Program/about.c
@@ -75,9 +75,9 @@ void show_about(struct Screen *screen, IPCData *ipc)
 
 	// Try for external about library
 #ifdef __amigaos4__
-	if (OpenLibIFace("dopus5:modules/about.module", (APTR)&ModuleBase, (APTR)&IModule, LIB_VERSION))
+	if (OpenLibIFace("DOpus5:Modules/about.module", (APTR)&ModuleBase, (APTR)&IModule, LIB_VERSION))
 #else
-	if ((ModuleBase = OpenLibrary("dopus5:modules/about.module", LIB_VERSION)))
+	if ((ModuleBase = OpenLibrary("DOpus5:Modules/about.module", LIB_VERSION)))
 #endif
 	{
 		short ret;

--- a/source/Program/backdrop_groups.c
+++ b/source/Program/backdrop_groups.c
@@ -41,7 +41,7 @@ void backdrop_read_groups(BackdropInfo *info)
 	anchor->ap_Strlen = 256;
 
 	// Search for icons
-	error = MatchFirst("dopus5:groups/#?.info", anchor);
+	error = MatchFirst("DOpus5:Groups/#?.info", anchor);
 
 	// Continue while there's files
 	while (!error)
@@ -880,7 +880,7 @@ void backdrop_read_group_objects(GroupData *group)
 		return;
 
 	// Get path to search
-	lsprintf(buffer, "dopus5:groups/%s", group->name);
+	lsprintf(buffer, "DOpus5:Groups/%s", group->name);
 
 	// Lock path
 	if ((lock = Lock(buffer, ACCESS_READ)))
@@ -1016,7 +1016,7 @@ void backdrop_group_add_object(char *groupname, BackdropInfo *info, char *path, 
 	filename = FilePart(path);
 
 	// Check an object of this name isn't already in the group
-	lsprintf(buffer, "dopus5:groups/%s/%s", groupname, filename);
+	lsprintf(buffer, "DOpus5:Groups/%s/%s", groupname, filename);
 	if ((lock = Lock(buffer, ACCESS_READ)))
 	{
 		// Already exists
@@ -1077,7 +1077,7 @@ void backdrop_delete_group(BackdropInfo *info, BackdropObject *object)
 	BPTR lock, old, dir;
 
 	// Lock group path
-	if (!(lock = Lock("dopus5:groups", ACCESS_READ)))
+	if (!(lock = Lock("DOpus5:Groups", ACCESS_READ)))
 		return;
 
 	// CD to directory
@@ -1146,7 +1146,7 @@ void backdrop_remove_group_objects(GroupData *data, BackdropObject *only_one)
 	char buf[80];
 
 	// CD to group directory
-	lsprintf(buf, "dopus5:groups/%s", data->name);
+	lsprintf(buf, "DOpus5:Groups/%s", data->name);
 	if (!(lock = Lock(buf, ACCESS_READ)))
 		return;
 	old = CurrentDir(lock);
@@ -1269,7 +1269,7 @@ BOOL backdrop_group_do_function(GroupData *group, IPTR id, struct MenuItem *item
 			backdrop_snapshot(group->info, 0, 1, 0);
 
 		// Snapshot owner
-		lsprintf(buf, "dopus5:groups/%s", group->name);
+		lsprintf(buf, "DOpus5:Groups/%s", group->name);
 		backdrop_snapshot_group(group->info, buf);
 
 		// Clear busy pointer

--- a/source/Program/backdrop_popup.c
+++ b/source/Program/backdrop_popup.c
@@ -1093,7 +1093,7 @@ void popup_build_copyto(PopUpHandle *menu, PopUpItem *item)
 	menu->ph_List = list;
 
 	// Try and lock CopyTo directory
-	if ((lock = Lock("dopus5:system/CopyTo", ACCESS_READ)))
+	if ((lock = Lock("DOpus5:System/CopyTo", ACCESS_READ)))
 	{
 		D_S(struct FileInfoBlock, fib)
 
@@ -1140,7 +1140,7 @@ void popup_build_copyto(PopUpHandle *menu, PopUpItem *item)
 							if ((name = AllocMemH(menu->ph_Memory, strlen(fib->fib_FileName) + 23)))
 							{
 								// Build full name of script
-								strcpy(name + 1, "dopus5:System/CopyTo/");
+								strcpy(name + 1, "DOpus5:System/CopyTo/");
 								strcat(name + 1, fib->fib_FileName);
 								new->data = name;
 							}

--- a/source/Program/buttons_function.c
+++ b/source/Program/buttons_function.c
@@ -193,9 +193,9 @@ void buttons_new_bank(Buttons *buttons, short func, Cfg_ButtonBank *use_bank)
 			"PROGDIR:Buttons/Toolbar",
 			"PROGDIR:Buttons/Toolbar.default",
 			"PROGDIR:Buttons/toolbar_default",
-			"dopus5:Buttons/Toolbar",
-			"dopus5:Buttons/Toolbar.default",
-			"dopus5:Buttons/toolbar_default",
+			"DOpus5:Buttons/Toolbar",
+			"DOpus5:Buttons/Toolbar.default",
+			"DOpus5:Buttons/toolbar_default",
 			0,
 		};
 		short a;

--- a/source/Program/buttons_io.c
+++ b/source/Program/buttons_io.c
@@ -74,7 +74,7 @@ void buttons_saveas(Buttons *buttons)
 
 	// Ask for filename
 	while (buttons_request_file(
-		buttons, GetString(&locale, MSG_BUTTONS_ENTER_NAME), path, "dopus5:buttons/", FRF_DOSAVEMODE))
+		buttons, GetString(&locale, MSG_BUTTONS_ENTER_NAME), path, "DOpus5:Buttons/", FRF_DOSAVEMODE))
 	{
 		short err;
 
@@ -124,7 +124,7 @@ int buttons_load(Buttons *buttons, struct Screen *screen, char *name)
 
 	// Loop while unsuccessful
 	while (name || buttons_request_file(
-					   buttons, GetString(&locale, MSG_BUTTONS_SELECT_FILE), path, "dopus5:buttons/", FRF_PRIVATEIDCMP))
+					   buttons, GetString(&locale, MSG_BUTTONS_SELECT_FILE), path, "DOpus5:Buttons/", FRF_PRIVATEIDCMP))
 	{
 		// Open status window
 		status = OpenStatusWindow(GetString(&locale, MSG_BUTTONS_STATUS_TITLE),

--- a/source/Program/callback_help.c
+++ b/source/Program/callback_help.c
@@ -30,8 +30,8 @@ void ASM SAVEDS HookShowHelp(REG(a0, char *file_name), REG(a1, char *node_name))
 	// Filename supplied?
 	if (file_name && *file_name)
 	{
-		// Make string into "dopus5:help/" followed by filename
-		stccpy(filename, "dopus5:help", 256);
+		// Make string into "DOpus5:Help/" followed by filename
+		stccpy(filename, "DOpus5:Help", 256);
 		AddPart(filename, FilePart(file_name), 256);
 
 		// Get new pointer

--- a/source/Program/commands.c
+++ b/source/Program/commands.c
@@ -98,19 +98,19 @@ void init_commands_scan(short type)
 	if (type == SCAN_BOTH)
 	{
 		patterns[0] = "PROGDIR:Modules/#?.(module|dopus5)";
-		patterns[1] = "dopus5:modules/#?.(module|dopus5)";
+		patterns[1] = "DOpus5:Modules/#?.(module|dopus5)";
 	}
 	else if (type == SCAN_MODULES)
 	{
 		patterns[0] = "PROGDIR:Modules/#?.module";
-		patterns[1] = "dopus5:modules/#?.module";
+		patterns[1] = "DOpus5:Modules/#?.module";
 	}
 	else if (type == SCAN_USER)
-		patterns[0] = "dopus5:commands/~(#?.info)";
+		patterns[0] = "DOpus5:Commands/~(#?.info)";
 	else
 	{
 		patterns[0] = "PROGDIR:Modules/#?.dopus5";
-		patterns[1] = "dopus5:modules/#?.dopus5";
+		patterns[1] = "DOpus5:Modules/#?.dopus5";
 	}
 
 	for (pat = 0; patterns[pat]; pat++)
@@ -126,7 +126,7 @@ void init_commands_scan(short type)
 			BOOL ok = 1, real_module = 0;
 			char *name_ptr = 0;
 
-			// Skip the basedata.lha placeholder used to keep dopus5:Commands
+			// Skip the basedata.lha placeholder used to keep DOpus5:Commands
 			// archived (lha drops empty directories on extraction). We don't
 			// want it registered as a phantom user command.
 			if (type == SCAN_USER && stricmp(anchor->ap_Info.fib_FileName, ".dummy") == 0)
@@ -223,7 +223,7 @@ void init_commands_scan(short type)
 			else if (!real_module)
 			{
 				// Function to run
-				lsprintf(anchor->ap_Buf, "dopus5:modules/%s %s init", anchor->ap_Info.fib_FileName, GUI->rexx_port_name);
+				lsprintf(anchor->ap_Buf, "DOpus5:Modules/%s %s init", anchor->ap_Info.fib_FileName, GUI->rexx_port_name);
 
 				// Run rexx thing
 				rexx_send_command(anchor->ap_Buf, FALSE);

--- a/source/Program/desktop_rename.c
+++ b/source/Program/desktop_rename.c
@@ -41,7 +41,7 @@ void icon_rename(IPCData *ipc, BackdropInfo *info, BackdropObject *icon)
 		group = (GroupData *)IPCDATA(info->ipc);
 
 		// Build directory name
-		lsprintf(info->buffer, "dopus5:groups/%s", group->name);
+		lsprintf(info->buffer, "DOpus5:Groups/%s", group->name);
 
 		// Lock directory
 		if (!(lock = Lock(info->buffer, ACCESS_READ)))

--- a/source/Program/display.c
+++ b/source/Program/display.c
@@ -991,9 +991,9 @@ void hide_display(void)
 	case HIDE_ICON:
 
 		// Get disk object
-		if (!(GUI->hide_diskobject = GetCachedDiskObject("dopus5:Icons/AppIcon", 0)))
+		if (!(GUI->hide_diskobject = GetCachedDiskObject("DOpus5:Icons/AppIcon", 0)))
 		{
-			GUI->hide_diskobject = GetCachedDiskObjectNew("dopus5:DirectoryOpus", 1);
+			GUI->hide_diskobject = GetCachedDiskObjectNew("DOpus5:DirectoryOpus", 1);
 		}
 
 		// Got one?

--- a/source/Program/environment.c
+++ b/source/Program/environment.c
@@ -164,7 +164,7 @@ static void environment_fix_button_path(char *path, char *default_name)
 	const char *legacy;
 	char *name;
 
-	if (path && strnicmp(path, "dopus5:buttons/", 15) == 0)
+	if (path && strnicmp(path, "DOpus5:Buttons/", 15) == 0)
 		environment_try_button_path(path, "PROGDIR:Buttons/", FilePart(path));
 
 	if (environment_path_exists(path))
@@ -175,15 +175,13 @@ static void environment_fix_button_path(char *path, char *default_name)
 		name = default_name;
 
 	if (environment_try_button_path(path, "PROGDIR:Buttons/", name) ||
-		environment_try_button_path(path, "dopus5:buttons/", name) ||
-		environment_try_button_path(path, "dopus5:Buttons/", name))
+		environment_try_button_path(path, "DOpus5:Buttons/", name))
 		return;
 
 	if (stricmp(name, default_name) != 0)
 	{
 		if (environment_try_button_path(path, "PROGDIR:Buttons/", default_name) ||
-			environment_try_button_path(path, "dopus5:buttons/", default_name) ||
-			environment_try_button_path(path, "dopus5:Buttons/", default_name))
+			environment_try_button_path(path, "DOpus5:Buttons/", default_name))
 			return;
 	}
 
@@ -191,8 +189,7 @@ static void environment_fix_button_path(char *path, char *default_name)
 	if (legacy && stricmp(name, legacy) != 0)
 	{
 		if (environment_try_button_path(path, "PROGDIR:Buttons/", (char *)legacy) ||
-			environment_try_button_path(path, "dopus5:buttons/", (char *)legacy) ||
-			environment_try_button_path(path, "dopus5:Buttons/", (char *)legacy))
+			environment_try_button_path(path, "DOpus5:Buttons/", (char *)legacy))
 			return;
 	}
 }
@@ -211,7 +208,7 @@ static void environment_fix_open_button_path(char *path)
 	if (!path || !path[0])
 		return;
 
-	if (strnicmp(path, "dopus5:buttons/", 15) == 0)
+	if (strnicmp(path, "DOpus5:Buttons/", 15) == 0)
 	{
 		char *name = FilePart(path);
 
@@ -235,9 +232,9 @@ static ToolBarInfo *environment_open_toolbar(Cfg_Environment *env)
 	char *fallbacks[] = {"PROGDIR:Buttons/Toolbar",
 						 "PROGDIR:Buttons/Toolbar.default",
 						 "PROGDIR:Buttons/toolbar_default",
-						 "dopus5:Buttons/Toolbar",
-						 "dopus5:Buttons/Toolbar.default",
-						 "dopus5:Buttons/toolbar_default",
+						 "DOpus5:Buttons/Toolbar",
+						 "DOpus5:Buttons/Toolbar.default",
+						 "DOpus5:Buttons/toolbar_default",
 						 0};
 	short a;
 
@@ -1138,7 +1135,7 @@ int environment_save(Cfg_Environment *env, char *name, short snapshot, CFG_ENVR 
 	// Write icon if successful (and enabled)
 	if ((!success) && (GUI->flags & GUIF_SAVE_ICONS))
 	{
-		WriteFileIcon("dopus5:icons/Environment", name);
+		WriteFileIcon("DOpus5:Icons/Environment", name);
 	}
 
 	// Free stuff
@@ -1194,7 +1191,7 @@ IPC_EntryCode(environment_proc)
 			if (!(request_file(GUI->window,
 							   GetString(&locale, MSG_ENVIRONMENT_SELECT_FILE),
 							   path,
-							   "dopus5:environment/",
+							   "DOpus5:Environment/",
 							   FRF_PRIVATEIDCMP,
 							   0)))
 				break;
@@ -1356,7 +1353,7 @@ IPC_EntryCode(environment_proc)
 				if (!(request_file(GUI->window,
 								   GetString(&locale, MSG_ENVIRONMENT_ENTER_NAME),
 								   path,
-								   "dopus5:environment/",
+								   "DOpus5:Environment/",
 								   FRF_DOSAVEMODE | FRF_PRIVATEIDCMP,
 								   0)))
 					break;

--- a/source/Program/event_loop.c
+++ b/source/Program/event_loop.c
@@ -899,7 +899,7 @@ void event_loop()
 				wsave = proc->pr_WindowPtr;
 				proc->pr_WindowPtr = (APTR)-1;
 
-				if ((file = Open("dopus5:system/seed", MODE_NEWFILE)))
+				if ((file = Open("DOpus5:System/seed", MODE_NEWFILE)))
 				{
 					Write(file, buf, strlen(buf));
 					Close(file);

--- a/source/Program/filetypes.c
+++ b/source/Program/filetypes.c
@@ -56,7 +56,7 @@ void filetype_read_list(APTR memory, struct ListLock *main_list)
 	anchor->ap_BreakBits = IPCSIG_QUIT;
 
 	// Search for filetypes
-	error = MatchFirst("dopus5:filetypes/~(#?.info)", anchor);
+	error = MatchFirst("DOpus5:Filetypes/~(#?.info)", anchor);
 
 	// Continue while there's files
 	while (!error)
@@ -218,7 +218,7 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 
 		// Create default startmenu filetype
 		if ((type = filetype_default_new(
-				 memory, list, "Opus 5 Start Menu", "STRTMEN", 30, "loadbuttons start", "dopus5:icons/startmenu.info")))
+				 memory, list, "Opus 5 Start Menu", "STRTMEN", 30, "loadbuttons start", "DOpus5:Icons/startmenu.info")))
 		{
 			// Recognition string for buttons
 			lsprintf(type->recognition,
@@ -236,7 +236,7 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 
 		// Create default button filetype
 		if ((type = filetype_default_new(
-				 memory, list, "Opus 5 Buttons", "BUTTONS", 12, "loadbuttons", "dopus5:icons/buttons.info")))
+				 memory, list, "Opus 5 Buttons", "BUTTONS", 12, "loadbuttons", "DOpus5:Icons/buttons.info")))
 		{
 			// Recognition string for buttons
 			lsprintf(type->recognition, "%lcOPUS%lc%lcBTNW", FTOP_MATCHFORM, FTOP_AND, FTOP_MATCHCHUNK);
@@ -249,7 +249,7 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 										 "ENVIRON",
 										 12,
 										 "loadenvironment",
-										 "dopus5:icons/environment.info")))
+										 "DOpus5:Icons/environment.info")))
 		{
 			// Recognition string for environment
 			lsprintf(type->recognition, "%lcOPUS%lc%lcENVR", FTOP_MATCHFORM, FTOP_AND, FTOP_MATCHCHUNK);
@@ -257,7 +257,7 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 
 		// Create default filetype filetype
 		if ((type = filetype_default_new(
-				 memory, list, "Opus 5 Filetype", "FTYPE", 12, "editfiletype", "dopus5:icons/filetype.info")))
+				 memory, list, "Opus 5 Filetype", "FTYPE", 12, "editfiletype", "DOpus5:Icons/filetype.info")))
 		{
 			// Recognition string for filetypes
 			lsprintf(type->recognition, "%lcOPUS%lc%lcTYPE", FTOP_MATCHFORM, FTOP_AND, FTOP_MATCHCHUNK);
@@ -265,7 +265,7 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 
 		// Create default command filetype
 		if ((type = filetype_default_new(
-				 memory, list, "Opus 5 Command", "CMD", 16, "runcommand", "dopus5:icons/command.info")))
+				 memory, list, "Opus 5 Command", "CMD", 16, "runcommand", "DOpus5:Icons/command.info")))
 		{
 			// Recognition string for command
 			lsprintf(type->recognition,
@@ -286,7 +286,7 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 #ifndef __AROS__
 		// Create default module filetype (no function, recognition only)
 		if ((type =
-				 filetype_default_new(memory, list, "Opus 5 Module 68k", "MODULE", 21, 0, "dopus5:icons/module.info")))
+				 filetype_default_new(memory, list, "Opus 5 Module 68k", "MODULE", 21, 0, "DOpus5:Icons/module.info")))
 		{
 			// Recognition string for modules
 			lsprintf(type->recognition, "%lc*.module%lc%lc$000003f3", FTOP_MATCHNAME, FTOP_AND, FTOP_MATCH);
@@ -294,14 +294,14 @@ void filetype_default_list(APTR memory, struct ListLock *main_list)
 #endif
 
 		if ((type =
-				 filetype_default_new(memory, list, "Opus 5 Module ELF", "MODULE", 21, 0, "dopus5:icons/module.info")))
+				 filetype_default_new(memory, list, "Opus 5 Module ELF", "MODULE", 21, 0, "DOpus5:Icons/module.info")))
 		{
 			// Recognition string for modules
 			lsprintf(type->recognition, "%lc*.module%lc%lc$7f454c46", FTOP_MATCHNAME, FTOP_AND, FTOP_MATCH);
 		}
 
 		// Create default rexx module filetype (no function, recognition only)
-		if ((type = filetype_default_new(memory, list, "Opus 5 Module", "MODULE", 14, 0, "dopus5:icons/module.info")))
+		if ((type = filetype_default_new(memory, list, "Opus 5 Module", "MODULE", 14, 0, "DOpus5:Icons/module.info")))
 		{
 			// Recognition string for modules
 			lsprintf(type->recognition, "%lc*.dopus5%lc%lc/*", FTOP_MATCHNAME, FTOP_AND, FTOP_MATCH);

--- a/source/Program/function_internal.c
+++ b/source/Program/function_internal.c
@@ -167,7 +167,7 @@ int function_internal_command(CommandList *command, char *args, FunctionHandle *
 		}
 
 		// User command?
-		else if (strnicmp(command->stuff.module_name, "dopus5:commands/", 16) == 0)
+		else if (strnicmp(command->stuff.module_name, "DOpus5:Commands/", 16) == 0)
 		{
 			// Shouldn't be able to get here!
 		}
@@ -177,7 +177,7 @@ int function_internal_command(CommandList *command, char *args, FunctionHandle *
 		{
 			// Get rexx function to run
 			lsprintf(buffer,
-					 "dopus5:modules/%s %s %s %ld %ld %s",
+					 "DOpus5:Modules/%s %s %s %ld %ld %s",
 					 command->stuff.module_name,
 					 GUI->rexx_port_name,
 					 command->name,

--- a/source/Program/function_loadenvironment.c
+++ b/source/Program/function_loadenvironment.c
@@ -46,7 +46,7 @@ DOPUS_FUNC(function_loadenvironment)
 		{
 			// If file didn't exist, look in default directory
 			if (!lock)
-				lsprintf(handle->work_buffer, "dopus5:environment/%s", entry->name);
+				lsprintf(handle->work_buffer, "DOpus5:Environment/%s", entry->name);
 
 			// Allocate packet
 			if ((packet = AllocVec(sizeof(env_packet) + strlen(handle->work_buffer), 0)))

--- a/source/Program/function_parse.c
+++ b/source/Program/function_parse.c
@@ -94,7 +94,7 @@ int function_parse_function(FunctionHandle *handle)
 			{
 				// User command?
 				if (command->flags & FUNCF_EXTERNAL_FUNCTION &&
-					strnicmp(command->stuff.module_name, "dopus5:commands/", 16) == 0)
+					strnicmp(command->stuff.module_name, "DOpus5:Commands/", 16) == 0)
 				{
 					// Load the function
 					if ((function[user_depth] = function_load_function(command->stuff.module_name)))

--- a/source/Program/function_script.c
+++ b/source/Program/function_script.c
@@ -93,7 +93,7 @@ int function_open_script(FunctionHandle *handle)
 static char const *const script_type_intro[] = {
 	0,					   // INST_COMMAND
 	0,					   // INST_AMIGADOS
-	"Dopus5:C/dopusrt5 ",  // INST_WORKBENCH
+	"DOpus5:C/dopusrt5 ",  // INST_WORKBENCH
 	"execute ",			   // INST_SCRIPT
 	"rx ",				   // INST_AREXX
 };

--- a/source/Program/groups_new.c
+++ b/source/Program/groups_new.c
@@ -58,7 +58,7 @@ void groups_new(BackdropInfo *info, IPCData *ipc)
 		return;
 
 	// Build full path
-	strcpy(path, "dopus5:groups");
+	strcpy(path, "DOpus5:Groups");
 	AddPart(path, name, 80);
 
 	// Create directory
@@ -263,7 +263,7 @@ void group_snapshot_icon(BackdropInfo *info, BackdropObject *icon, short x, shor
 	group = (GroupData *)IPCDATA(info->ipc);
 
 	// Build group path
-	lsprintf(buffer, "dopus5:groups/%s", group->name);
+	lsprintf(buffer, "DOpus5:Groups/%s", group->name);
 
 	// Change into group directory
 	if (!(lock = Lock(buffer, ACCESS_READ)))

--- a/source/Program/help.c
+++ b/source/Program/help.c
@@ -255,7 +255,7 @@ void help_show_help(char *thing, char *file)
 		if (cmd->flags & FUNCF_EXTERNAL_FUNCTION && cmd->help_name)
 		{
 			// Build full path to help file
-			strcpy(helpbuf, "dopus5:help/");
+			strcpy(helpbuf, "DOpus5:Help/");
 			AddPart(helpbuf, FilePart(cmd->help_name), 256);
 
 			// Use this file for help
@@ -291,7 +291,7 @@ void help_show_help(char *thing, char *file)
 
 	// No file given?
 	if (!file || !*file)
-		file = "dopus5:Help/dopus5.guide";
+		file = "DOpus5:Help/DOpus5.guide";
 
 	// Copy thing
 	if (ipc && (copy = AllocVec(strlen(thing) + 1 + strlen(file) + 1, 0)))
@@ -324,7 +324,7 @@ IPC_EntryCode(help_proc, static)
 	if ((ipc = IPC_ProcStartup(0, 0)))
 	{
 		// Get initial database name
-		strcpy(filename, "dopus5:Help/dopus5.guide");
+		strcpy(filename, "DOpus5:Help/DOpus5.guide");
 
 		// Get wait bits
 		waitbits = 1 << ipc->command_port->mp_SigBit;

--- a/source/Program/icons.c
+++ b/source/Program/icons.c
@@ -38,7 +38,7 @@ int icon_write(short type, char *filename, BOOL replace_image, ULONG iflags, ULO
 	if (type == ICONTYPE_GROUP)
 	{
 		// Try to get group icon
-		if (!(icon = GetCachedDiskObject("dopus5:icons/Group", GCDOF_NOCACHE)))
+		if (!(icon = GetCachedDiskObject("DOpus5:Icons/Group", GCDOF_NOCACHE)))
 			icon = GetCachedDefDiskObject(WBDRAWER | GCDOF_NOCACHE);
 	}
 

--- a/source/Program/lister_toolbar.c
+++ b/source/Program/lister_toolbar.c
@@ -715,7 +715,7 @@ void lister_new_toolbar(Lister *lister, char *name, ToolBarInfo *bank)
 				   sizeof(lister->toolbar_path) - strlen(lister->toolbar_path));
 			if (!(lock = Lock(lister->toolbar_path, ACCESS_READ)))
 			{
-				strcpy(lister->toolbar_path, "dopus5:buttons/");
+				strcpy(lister->toolbar_path, "DOpus5:Buttons/");
 				stccpy(lister->toolbar_path + strlen(lister->toolbar_path),
 					   name,
 					   sizeof(lister->toolbar_path) - strlen(lister->toolbar_path));

--- a/source/Program/main.c
+++ b/source/Program/main.c
@@ -235,10 +235,10 @@ void startup_open_dopuslib()
 	// Open the library
 #ifdef __amigaos4__
 	if (!OpenLibIFace("PROGDIR:Libs/dopus5.library", (APTR)&DOpusBase, (APTR)&IDOpus, LIB_VERSION) &&
-		!OpenLibIFace("dopus5:libs/dopus5.library", (APTR)&DOpusBase, (APTR)&IDOpus, LIB_VERSION))
+		!OpenLibIFace("DOpus5:Libs/dopus5.library", (APTR)&DOpusBase, (APTR)&IDOpus, LIB_VERSION))
 #else
 	if (!(DOpusBase = OpenLibrary("PROGDIR:Libs/dopus5.library", LIB_VERSION)) &&
-		!(DOpusBase = OpenLibrary("dopus5:libs/dopus5.library", LIB_VERSION)))
+		!(DOpusBase = OpenLibrary("DOpus5:Libs/dopus5.library", LIB_VERSION)))
 #endif
 	{
 #ifndef __amigaos3__
@@ -322,10 +322,10 @@ void startup_run_update()
 	// Try and get update.module
 #ifdef __amigaos4__
 	if (OpenLibIFace("PROGDIR:Modules/update.module", (APTR)&ModuleBase, (APTR)&IModule, LIB_VERSION) ||
-		OpenLibIFace("dopus5:modules/update.module", (APTR)&ModuleBase, (APTR)&IModule, LIB_VERSION))
+		OpenLibIFace("DOpus5:Modules/update.module", (APTR)&ModuleBase, (APTR)&IModule, LIB_VERSION))
 #else
 	if ((ModuleBase = OpenLibrary("PROGDIR:Modules/update.module", 0)) ||
-		(ModuleBase = OpenLibrary("dopus5:modules/update.module", 0)))
+		(ModuleBase = OpenLibrary("DOpus5:Modules/update.module", 0)))
 #endif
 	{
 		// Launch update function
@@ -472,7 +472,7 @@ void startup_open_libraries()
 	};
 
 	// Seed random number with something interesting
-	if ((file = Open("dopus5:system/seed", MODE_OLDFILE)))
+	if ((file = Open("DOpus5:System/seed", MODE_OLDFILE)))
 	{
 		char buf[20];
 		Read(file, buf, 20);
@@ -859,7 +859,7 @@ void startup_process_args(int argc, char **argv)
 			BOOL fail = 1;
 
 			// Get environment path
-			if ((dir = Lock("dopus5:environment", ACCESS_READ)))
+			if ((dir = Lock("DOpus5:Environment", ACCESS_READ)))
 			{
 				// Move there
 				old = CurrentDir(dir);
@@ -1003,7 +1003,7 @@ void startup_read_positions()
 		quit(0);
 
 	// Read position list
-	GUI->position_name = "dopus5:system/position-info";
+	GUI->position_name = "DOpus5:System/position-info";
 	GetPositions(&GUI->positions, GUI->position_memory, GUI->position_name);
 }
 
@@ -1270,16 +1270,16 @@ void startup_init_filetypes()
 void startup_init_notification()
 {
 	// Start notification of filetype directory
-	GUI->filetype_notify = start_file_notify("dopus5:filetypes", NOTIFY_FILETYPES_CHANGED, GUI->appmsg_port);
+	GUI->filetype_notify = start_file_notify("DOpus5:Filetypes", NOTIFY_FILETYPES_CHANGED, GUI->appmsg_port);
 
 	// Start notification of modules directory
-	GUI->modules_notify = start_file_notify("dopus5:modules", NOTIFY_MODULES_CHANGED, GUI->appmsg_port);
+	GUI->modules_notify = start_file_notify("DOpus5:Modules", NOTIFY_MODULES_CHANGED, GUI->appmsg_port);
 
 	// Start notification of env:dopus directory
 	GUI->env_notify = start_file_notify("env:dopus", NOTIFY_ENV_CHANGED, GUI->appmsg_port);
 
 	// Start notification of commands directory
-	GUI->commands_notify = start_file_notify("dopus5:commands", NOTIFY_COMMANDS_CHANGED, GUI->appmsg_port);
+	GUI->commands_notify = start_file_notify("DOpus5:Commands", NOTIFY_COMMANDS_CHANGED, GUI->appmsg_port);
 
 	// Start notification of font prefs
 	GUI->font_notify = start_file_notify("env:sys/font.prefs", NOTIFY_FONT_CHANGED, GUI->appmsg_port);
@@ -1347,13 +1347,13 @@ void startup_init_icons()
 #endif
 
 	// Get arrow image for toolbars
-	GUI->toolbar_arrow_image = OpenImage("dopus5:images/ToolbarArrow.image", 0);
+	GUI->toolbar_arrow_image = OpenImage("DOpus5:Images/ToolbarArrow.image", 0);
 
 	// Get icon for listers
-	GUI->lister_icon = GetCachedDiskObject("dopus5:Icons/Lister", GCDOF_NOCACHE);
+	GUI->lister_icon = GetCachedDiskObject("DOpus5:Icons/Lister", GCDOF_NOCACHE);
 
 	// Get icon for buttons
-	GUI->button_icon = GetCachedDiskObject("dopus5:Icons/Buttons", GCDOF_NOCACHE);
+	GUI->button_icon = GetCachedDiskObject("DOpus5:Icons/Buttons", GCDOF_NOCACHE);
 }
 
 // Run pre-startup script

--- a/source/Program/misc.c
+++ b/source/Program/misc.c
@@ -798,7 +798,7 @@ struct Library *OpenModule(char *name)
 		if (!(lib = OpenLibrary(buf, ver)))
 		{
 			// Fall back to the DOpus5: assign
-			strcpy(buf, "dopus5:modules/");
+			strcpy(buf, "DOpus5:Modules/");
 			strcat(buf, name);
 			lib = OpenLibrary(buf, ver);
 		}
@@ -816,7 +816,7 @@ struct Library *OpenModule(char *name)
 
 			if (!(lib = OpenLibrary(buf, 0)))
 			{
-				strcpy(buf, "dopus5:modules/");
+				strcpy(buf, "DOpus5:Modules/");
 				strcat(buf, name);
 				lib = OpenLibrary(buf, 0);
 			}

--- a/source/Program/misc_proc.c
+++ b/source/Program/misc_proc.c
@@ -1205,9 +1205,9 @@ long misc_check_quit(struct Screen *screen, IPCData *ipc)
 /*
 unsigned char
 	*pirate_strings[]={
-		"dopus5:directoryopus",
-		"delete dopus5:#? all quiet force",
-		"dopus5:!!! Piracy = Theft !!! (%04ld)"};
+		"DOpus5:directoryopus",
+		"delete DOpus5:#? all quiet force",
+		"DOpus5:!!! Piracy = Theft !!! (%04ld)"};
 */
 
 static unsigned char *pirate_strings[] = {

--- a/source/Program/pattern.c
+++ b/source/Program/pattern.c
@@ -836,7 +836,7 @@ BOOL pattern_check_random(PatternData *data, char *name)
 	}
 
 	// See what the last random picture was
-	lsprintf(buf, "dopus5:system/rnd.%ld", data->prefs.wbp_Which);
+	lsprintf(buf, "DOpus5:System/rnd.%ld", data->prefs.wbp_Which);
 	if ((file = OpenBuf(buf, MODE_OLDFILE, 512)))
 	{
 		ReadBufLine(file, buf + 64, 256);

--- a/source/Program/scripts.c
+++ b/source/Program/scripts.c
@@ -101,7 +101,7 @@ void InitScripts(void)
 	anchor->ap_Flags = APF_DOWILD;
 
 	// Search for scripts
-	error = MatchFirst("dopus5:system/scripts/#?.scp", anchor);
+	error = MatchFirst("DOpus5:System/scripts/#?.scp", anchor);
 
 	// Continue while there's files
 	while (!error)
@@ -423,7 +423,7 @@ void InitSoundEvents(BOOL force)
 			}
 
 			// See what the last random sound was
-			lsprintf(buf, "dopus5:system/rnd.%s", sound->dse_Node.ln_Name);
+			lsprintf(buf, "DOpus5:System/rnd.%s", sound->dse_Node.ln_Name);
 			if ((file = OpenBuf(buf, MODE_OLDFILE, 512)))
 			{
 				ReadBufLine(file, buf + 200, 256);

--- a/source/Program/wb.c
+++ b/source/Program/wb.c
@@ -42,7 +42,7 @@ void wb_do_startup(void)
 	if (!(lock = Lock("sys:wbstartup", ACCESS_READ)))
 	{
 		// if no wbstartup drawer found, use DOpus's own drawer
-		if (!(lock = Lock("dopus5:wbstartup", ACCESS_READ)))
+		if (!(lock = Lock("DOpus5:WBStartup", ACCESS_READ)))
 		{
 			Att_RemList(launch_list, 0);
 


### PR DESCRIPTION
## Summary

Closes #36.

DOpus's C source was using three different spellings of the assign root (`dopus5:`, `Dopus5:`, and the canonical `DOpus5:`) scattered across 50+ files. AmigaDOS resolves all three to the same lock, so this never broke functionality, but the casing the C source uses is exactly the casing the user sees in file requesters (the literal we pass as `ASLFR_InitialDrawer` becomes the `fr_Drawer` displayed back). That's why the issue reporter saw a mix of `dopus5:environment/` (Open Environment), `Dopus5:` (Pick Icon for filetype) and the consistent `DOpus5:Themes` (Theme path).

## Changes

- **Canonicalise every hardcoded path literal** under `source/` to `DOpus5:` with the AmigaOS-conventional sub-directory casing shipped in `basedata.lha` (`Buttons`, `Filetypes`, `Modules`, `Commands`, `Help`, `Sounds`, `Themes`, `ARexx`, `WBStartup`, `Libs`, ...). 54 files touched.
- **Fix the case-sensitive `strstr` bug in `filetype_editor.c`'s `filetypeed_pick_icon`**: the check `if (strstr(reqpath, "Dopus5:") ...)` used to decide whether to keep the requester's drawer path verbatim was case-sensitive and always missed, because the ASL requester returns the path with the assign casing (`DOPUS5:`, since the assign is created via `AssignLock("DOPUS5", ...)`). Replaced with a case-insensitive `strnicmp` prefix check.
- **`help.c`**: `DOpus5:Help/dopus5.guide` -> `DOpus5:Help/DOpus5.guide` to match the actual shipped filename casing on case-sensitive hosts (matters for hosted emulators).
- **Drop now-redundant duplicate `"DOpus5:Buttons/"` entries** in `environment.c::environment_fix_button_path` (originally a `dopus5:buttons/` + `dopus5:Buttons/` defensive pair), in `config_open.c::L_OpenButtonBank` drawers[], and the duplicate `PROGDIR:images` vs `PROGDIR:Images` `strnicmp` in `images.c::aros_read_image_fallback`.

## Test plan

Cross-built with all the project docker images:

- [x] `sacredbanana/amiga-compiler:m68k-amigaos` (os3) - clean build
- [x] `sacredbanana/amiga-compiler:ppc-amigaos` (os4) - clean build
- [x] `sacredbanana/amiga-compiler:ppc-morphos` (mos) - clean build
- [x] `midwan/aros-compiler:i386-aros` (i386-aros) - clean build
- [x] `midwan/aros-compiler:x86_64-aros` (x86_64-aros) - hits a pre-existing GCC ICE in `diskinfo.c:574` (`__gmpn_mul_1`, "Illegal instruction"). The same failure reproduces on `master` when running the linux/amd64 image under Rosetta on Apple Silicon, so it is **not** a regression from this change. The Ubuntu CI runner that this workflow targets runs on real x86_64 and is unaffected.

Manual sanity grep:

```sh
$ rg --pcre2 '\b(dopus5|Dopus5):' source/   # 0 matches (was 275 + 5)
$ rg 'DOpus5:' source/ | wc -l              # 198
```

The remaining `DOPUS5:` references in `source/Program/main.c` are intentional - they document the actual `AssignLock("DOPUS5", lock)` registration. Filename references like `dopus5.library`, `dopus5.h`, `.dopus5` (ARexx extension) and `www.dopus5.org` are also intentionally left lowercase; those are real on-disk filenames / product references where AmigaOS is case-insensitive but case-sensitive hosts care.