### PR TITLE
diskinfo: fix AROS x86_64 cross-compiler ICE on Apple Silicon (Rosetta)

### DIFF
--- a/source/Modules/diskinfo/math_replace.h
+++ b/source/Modules/diskinfo/math_replace.h
@@ -2,8 +2,33 @@
 
 #include <math.h>
 
+/* Resolve PI at runtime (via atan(1.0)*4) instead of as a compile-time
+ * constant. The AROS x86_64 cross-compiler shipped in
+ * midwan/aros-compiler:x86_64-aros (GCC 10.5) parses every literal
+ * float and folds every compile-time double->float conversion through
+ * MPFR/GMP. GMP's `__gmpn_mul_1` is hand-written x86_64 assembly that
+ * hits an instruction Apple Rosetta 2 mis-emulates - cc1 dies with
+ * "internal compiler error: Illegal instruction" before it even
+ * reaches the optimiser. The minimal trigger is one line:
+ *
+ *     float t(void) { return (float)3.141592653589793; }   // ICE
+ *
+ * Even `static const float PI = 3.14159265f;` crashes for the same
+ * reason (GMP-precision parsing of the literal). Real x86_64 Linux
+ * hosts (the GitHub CI runner) are unaffected, so this only matters
+ * for local cross-builds on Apple Silicon. atan(1.0) is a function
+ * call that GCC does not const-fold at -O2 here, so the GMP path
+ * is never reached. */
+static float dopus_diskinfo_pi(void)
+{
+	static float pi_value;
+	if (pi_value == 0.0f)
+		pi_value = (float)atan(1.0) * 4.0f;
+	return pi_value;
+}
+
 #ifndef PI
-	#define PI M_PI
+	#define PI dopus_diskinfo_pi()
 #endif
 
 float SPFlt(int inum)


### PR DESCRIPTION
## Summary

`make x86_64-aros` from a local Mac running the project's `midwan/aros-compiler:x86_64-aros` docker image under Apple Rosetta 2 was crashing `cc1` with:

```
diskinfo.c: In function 'diskinfo_show_graph':
diskinfo.c:574:3: internal compiler error: Illegal instruction
  574 |   rads = SPDiv((FLOAT)180, SPMul((FLOAT)PI, SPFlt(p)));
0x175d649 __gmpn_mul_1
    gen/host/tools/crosstools/gnu/gmp/mpn/tmp-mul_1.s:200
```

GCC 10.5's front-end parses every floating-point literal and every compile-time `double` → `float` conversion through MPFR/GMP. GMP's `__gmpn_mul_1` is hand-written x86_64 assembly that hits an instruction Apple Rosetta 2 mis-emulates, raising `SIGILL` inside `cc1`. **Real Linux x86_64 hosts (the Ubuntu CI runner) are unaffected**, which is why all five matrix builds pass on CI but locally only `i386-aros` and the m68k/ppc cross-builds work on Apple Silicon.

The minimal repro is a one-liner:

```c
float t(void) { return (float)3.141592653589793; }   // ICE under Rosetta
```

`static const float PI = 3.141592653589793f;` reproduces it too — the parse path itself is what crashes, not any optimisation step.

## Fix

Replace the compile-time `#define PI M_PI` macro in `source/Modules/diskinfo/math_replace.h` with a tiny runtime helper that computes PI as `(float)atan(1.0) * 4.0f` and caches the result in a function-static. `atan()` is a libcall that GCC 10.5 does not const-fold at `-O2` here, so the MPFR/GMP path is never entered.

```c
static float dopus_diskinfo_pi(void)
{
    static float pi_value;
    if (pi_value == 0.0f)
        pi_value = (float)atan(1.0) * 4.0f;
    return pi_value;
}

#ifndef PI
    #define PI dopus_diskinfo_pi()
#endif
```

The value is mathematically identical to the previous `(float)M_PI` and feeds straight back into `SPMul`/`SPSincos` (both single-precision), so no precision is lost. Cost is one comparison + branch per call after first init — negligible compared to the `AreaDraw` loop it lives inside.

Only `diskinfo.c` includes `math_replace.h`, so the change is fully scoped to that module.

## Test plan

Local cross-builds on macOS/arm64 (Apple Silicon, Rosetta) with every project docker image:

- [x] `sacredbanana/amiga-compiler:m68k-amigaos` (os3) — clean build
- [x] `sacredbanana/amiga-compiler:ppc-amigaos` (os4) — clean build
- [x] `sacredbanana/amiga-compiler:ppc-morphos` (mos) — clean build
- [x] `midwan/aros-compiler:i386-aros` (i386-aros) — clean build
- [x] `midwan/aros-compiler:x86_64-aros` (x86_64-aros) — **was hitting ICE, now clean build**

`diskinfo.module` artifact builds for every platform; resulting binary sizes look sensible (between 10 KB and 38 KB depending on platform).

CI is unchanged because real x86_64 Linux never tripped the Rosetta path.