### PR TITLE
Fix issue #45: ghost icon menu data, label leaks, missing icons, stale env banks

### DIFF
--- a/source/Modules/configopus/filetype_editor.c
+++ b/source/Modules/configopus/filetype_editor.c
@@ -707,18 +707,47 @@ short filetypeed_receive_edit(filetype_ed_data *data, FunctionReturn *ret)
 	Cfg_Function *function = 0;
 	Cfg_Function *func_copy = 0;
 	BOOL no_func = 0, icon = 0;
-	func_node *fndata = 0;
 	short success = 0;
+
+	// Icon menu? (this is a bit kludgy)
+	if (ret->object_flags > 15)
+		icon = 1;
 
 	// Is the new function empty?
 	if (IsListEmpty((struct List *)&ret->function->instructions))
 		no_func = 1;
 
+	// Icon menu entries are identified by their label; if the user
+	// cleared it, the entry would be invisible in the listview but
+	// still saved to disk. Treat such an entry as empty so the old
+	// function gets removed instead. Match filetypeed_update_iconmenu's
+	// "first INST_LABEL wins" semantics so the predicate stays in
+	// sync with how the listview is populated.
+	else if (icon)
+	{
+		Cfg_Instruction *ins;
+		BOOL has_label = FALSE;
+
+		for (ins = (Cfg_Instruction *)ret->function->instructions.mlh_Head;
+			 ins->node.mln_Succ;
+			 ins = (Cfg_Instruction *)ins->node.mln_Succ)
+		{
+			if (ins->type == INST_LABEL)
+			{
+				has_label = (BOOL)(ins->string && ins->string[0]);
+				break;
+			}
+		}
+
+		if (!has_label)
+			no_func = 1;
+	}
+
 	// Try to copy the new function
 	if (no_func || (func_copy = CopyFunction(ret->function, 0, 0)))
 	{
-		// Icon menu? (this is a bit kludgy)
-		if (ret->object_flags > 15)
+		// Look up the function we are replacing
+		if (icon)
 		{
 			Att_Node *node;
 
@@ -734,8 +763,6 @@ short filetypeed_receive_edit(filetype_ed_data *data, FunctionReturn *ret)
 					break;
 				}
 			}
-
-			icon = 1;
 		}
 
 		// Otherwise, find the function we want to replace
@@ -763,10 +790,6 @@ short filetypeed_receive_edit(filetype_ed_data *data, FunctionReturn *ret)
 			Remove(&function->node);
 			FreeFunction(function);
 		}
-
-		// Store for icon menu
-		if (fndata)
-			fndata->func = func_copy;
 
 		success = (icon) ? 2 : 1;
 	}
@@ -867,7 +890,35 @@ void filetypeed_show_icon(filetype_ed_data *data)
 
 	// Valid icon?
 	if (!data->icon_image)
+	{
+		// An icon path is configured but the image could not be
+		// loaded - draw a "?" placeholder so the user knows the
+		// referenced file is missing rather than no icon being set.
+		if (data->type->icon_path && data->type->icon_path[0] &&
+			GetObjectRect(data->objlist, GAD_FILETYPEED_ICON_AREA, &bounds))
+		{
+			short text_width;
+
+			// Match the inset used by the icon-image draw below
+			// so the "?" stays clear of the recessed border.
+			bounds.MinX += 2;
+			bounds.MinY += 1;
+			bounds.MaxX -= 2;
+			bounds.MaxY -= 1;
+
+			text_width = TextLength(data->window->RPort, (char *)"?", 1);
+
+			SetAPen(data->window->RPort, DRAWINFO(data->window)->dri_Pens[TEXTPEN]);
+			SetDrMd(data->window->RPort, JAM1);
+			Move(data->window->RPort,
+				 bounds.MinX + (((bounds.MaxX - bounds.MinX) + 1 - text_width) >> 1),
+				 bounds.MinY +
+					 (((bounds.MaxY - bounds.MinY) + 1 - data->window->RPort->TxHeight) >> 1) +
+					 data->window->RPort->TxBaseline);
+			Text(data->window->RPort, (char *)"?", 1);
+		}
 		return;
+	}
 
 	// Get icon area
 	if (!(GetObjectRect(data->objlist, GAD_FILETYPEED_ICON_AREA, &bounds)))

--- a/source/Modules/configopus/function_editor.c
+++ b/source/Modules/configopus/function_editor.c
@@ -1355,7 +1355,13 @@ void funced_store_edits(FuncEdData *data)
 		data->function->function.flags2 |= FUNCF2_LABEL_FUNC;
 	}
 	else
+	{
+		// This editor has no label gadget; ensure no stale label
+		// (e.g. from a paste of a labelled function) leaks through
+		// to the compiled instructions.
+		data->label[0] = 0;
 		data->function->function.flags2 &= ~FUNCF2_LABEL_FUNC;
+	}
 
 	// Compile function list into function
 	funced_compile(data);

--- a/source/Program/environment.c
+++ b/source/Program/environment.c
@@ -32,6 +32,92 @@ For more information on Directory Opus for Windows please see:
 
 static int write_env_string(APTR, char *, ULONG);
 
+// Internal flag for environment_save: filter out paths recorded in
+// env_drop_banks instead of writing them back to the layout. Only
+// honoured when ENVSAVE_LAYOUT is unset (the dropped-paths filter
+// lives inside the non-snapshot bank loop; an ENVSAVE_LAYOUT save
+// writes the live GUI state, where missing entries are already
+// absent).
+#define ENVSAVE_DROP_MISSING_BANKS (1 << 2)
+
+// List of bank paths the user opted to remove from the environment file
+// after they were detected as missing during environment_open. Consumed
+// by the next environment_save call (with ENVSAVE_DROP_MISSING_BANKS).
+//
+// Keys are stored as the raw, unfixed `ButtonBankNode->ln_Name` from
+// the on-disk env file so env_drop_banks_contains can match exactly
+// the same string when environment_save re-reads the file. Both sides
+// must keep using ln_Name and not the resolved path produced by
+// environment_fix_open_button_path.
+struct EnvDropBankNode
+{
+	struct MinNode node;
+	char path[256];
+};
+
+static struct MinList env_drop_banks;
+static BOOL env_drop_banks_inited = FALSE;
+
+static void env_drop_banks_ensure_init(void)
+{
+	if (!env_drop_banks_inited)
+	{
+		NewList((struct List *)&env_drop_banks);
+		env_drop_banks_inited = TRUE;
+	}
+}
+
+static void env_drop_banks_add(const char *path)
+{
+	struct EnvDropBankNode *node;
+
+	env_drop_banks_ensure_init();
+
+	if (!path || !path[0])
+		return;
+
+	if ((node = AllocVec(sizeof(struct EnvDropBankNode), MEMF_CLEAR)))
+	{
+		stccpy(node->path, (char *)path, sizeof(node->path));
+		AddTail((struct List *)&env_drop_banks, (struct Node *)node);
+	}
+}
+
+static BOOL env_drop_banks_contains(const char *path)
+{
+	struct EnvDropBankNode *node;
+
+	env_drop_banks_ensure_init();
+
+	if (!path)
+		return FALSE;
+
+	for (node = (struct EnvDropBankNode *)env_drop_banks.mlh_Head; node->node.mln_Succ;
+		 node = (struct EnvDropBankNode *)node->node.mln_Succ)
+	{
+		if (stricmp(node->path, (char *)path) == 0)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static BOOL env_drop_banks_empty(void)
+{
+	env_drop_banks_ensure_init();
+	return IsListEmpty((struct List *)&env_drop_banks);
+}
+
+static void env_drop_banks_clear(void)
+{
+	struct EnvDropBankNode *node;
+
+	env_drop_banks_ensure_init();
+
+	while ((node = (struct EnvDropBankNode *)RemHead((struct List *)&env_drop_banks)))
+		FreeVec(node);
+}
+
 // Allocate a new environment structure
 Cfg_Environment *environment_new(void)
 {
@@ -439,12 +525,31 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 			stccpy(button_path, button->node.ln_Name, sizeof(button_path));
 			environment_fix_open_button_path(button_path);
 
-			// Create button bank from this node
-			if ((but = buttons_new(button_path, 0, &button->pos, 0, button->flags | BUTTONF_FAIL)))
+			// File still on disk? Try to open the bank.
+			if (environment_path_exists(button_path))
 			{
-				// Set icon position
-				but->icon_pos_x = button->icon_pos_x;
-				but->icon_pos_y = button->icon_pos_y;
+				// Create button bank from this node
+				if ((but = buttons_new(button_path, 0, &button->pos, 0, button->flags | BUTTONF_FAIL)))
+				{
+					// Set icon position
+					but->icon_pos_x = button->icon_pos_x;
+					but->icon_pos_y = button->icon_pos_y;
+				}
+			}
+			else
+			{
+				// The bank file referenced by the layout is gone.
+				// Ask the user whether to drop the entry from the
+				// environment so the next save no longer carries it.
+				if (SimpleRequestTags(NULL,
+									  dopus_name,
+									  (char *)"Remove|Keep",
+									  (char *)"Button bank '%s'\ncould not be opened.\n"
+											  "Remove from environment?",
+									  (IPTR)button->node.ln_Name))
+				{
+					env_drop_banks_add(button->node.ln_Name);
+				}
 			}
 
 			// Free this node, get next
@@ -466,8 +571,25 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 			stccpy(button_path, button->node.ln_Name, sizeof(button_path));
 			environment_fix_open_button_path(button_path);
 
-			// Create new start menu
-			start_new(button_path, 0, 0, button->pos.Left, button->pos.Top);
+			if (environment_path_exists(button_path))
+			{
+				// Create new start menu
+				start_new(button_path, 0, 0, button->pos.Left, button->pos.Top);
+			}
+			else
+			{
+				// Same treatment as missing button banks: ask the
+				// user whether to drop the entry from the layout.
+				if (SimpleRequestTags(NULL,
+									  dopus_name,
+									  (char *)"Remove|Keep",
+									  (char *)"Start menu '%s'\ncould not be opened.\n"
+											  "Remove from environment?",
+									  (IPTR)button->node.ln_Name))
+				{
+					env_drop_banks_add(button->node.ln_Name);
+				}
+			}
 
 			// Free this node, get next
 			Remove((struct Node *)button);
@@ -601,6 +723,19 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 
 	// Initialise sound events
 	InitSoundEvents(TRUE);
+
+	// User asked to drop one or more missing button banks during the
+	// load? Persist the change so the next save does not bring them
+	// back. The save itself filters the list using env_drop_banks.
+	// Only clear the list on a successful save - if the save failed
+	// (e.g. env->path empty, or disk error) we want the next load to
+	// still know which entries the user wanted gone, rather than
+	// silently consuming the choice.
+	if (!env_drop_banks_empty())
+	{
+		if (environment_save(env, env->path, ENVSAVE_DROP_MISSING_BANKS, 0) == 0)
+			env_drop_banks_clear();
+	}
 
 	return success;
 }
@@ -796,6 +931,16 @@ int environment_save(Cfg_Environment *env, char *name, short snapshot, CFG_ENVR 
 				struct IBox pos_be;
 #endif
 
+				// Caller asked us to drop banks the user marked as
+				// missing during the most recent environment_open.
+				if ((snapshot & ENVSAVE_DROP_MISSING_BANKS) &&
+					env_drop_banks_contains(button->node.ln_Name))
+				{
+					Remove((struct Node *)button);
+					button = next;
+					continue;
+				}
+
 				// Write bank header
 				if (!(IFFPushChunk(iff, ID_BANK)))
 					break;
@@ -846,6 +991,15 @@ int environment_save(Cfg_Environment *env, char *name, short snapshot, CFG_ENVR 
 #ifdef __AROS__
 				struct IBox pos_be;
 #endif
+
+				// Same skip logic as the BANK loop above.
+				if ((snapshot & ENVSAVE_DROP_MISSING_BANKS) &&
+					env_drop_banks_contains(button->node.ln_Name))
+				{
+					Remove((struct Node *)button);
+					button = next;
+					continue;
+				}
 
 				// Write bank header
 				if (!(IFFPushChunk(iff, ID_STRT)))

--- a/source/Program/environment.c
+++ b/source/Program/environment.c
@@ -40,82 +40,107 @@ static int write_env_string(APTR, char *, ULONG);
 // absent).
 #define ENVSAVE_DROP_MISSING_BANKS (1 << 2)
 
-// List of bank paths the user opted to remove from the environment file
-// after they were detected as missing during environment_open. Consumed
-// by the next environment_save call (with ENVSAVE_DROP_MISSING_BANKS).
+// Module-private bookkeeping for the "remove missing button banks"
+// feature, split into two lists:
 //
-// Keys are stored as the raw, unfixed `ButtonBankNode->ln_Name` from
-// the on-disk env file so env_drop_banks_contains can match exactly
-// the same string when environment_save re-reads the file. Both sides
-// must keep using ln_Name and not the resolved path produced by
-// environment_fix_open_button_path.
-struct EnvDropBankNode
+//  - env_missing_banks  filled by environment_open when a BANK/STRT
+//                       entry's file is gone. Owned by the most recent
+//                       open; cleared at the start of every load and
+//                       drained by environment_resolve_missing_banks.
+//
+//  - env_drop_banks     populated by environment_resolve_missing_banks
+//                       from the user's "Remove" answers, then handed
+//                       to environment_save with the
+//                       ENVSAVE_DROP_MISSING_BANKS flag so the rewritten
+//                       env file no longer carries those entries.
+//
+// Both lists key paths as the raw `ButtonBankNode->ln_Name` from the
+// env file (not the resolved path produced by
+// environment_fix_open_button_path) so environment_save can match
+// the exact string it re-reads from disk. Both lists are cleared at
+// the start of every environment_open / environment_resolve_missing_banks
+// pair so a save failure for layout A never bleeds into layout B.
+// Kind of entry an EnvBankPathNode refers to, so the resolve prompt
+// can use the right wording.
+#define ENV_KIND_BANK 0	   // BANK chunk - normal button bank
+#define ENV_KIND_START 1   // STRT chunk - start menu
+
+struct EnvBankPathNode
 {
 	struct MinNode node;
+	UBYTE kind;
 	char path[256];
 };
 
+// Both lists are owned by the most recent environment_open / paired
+// environment_resolve_missing_banks call. They are first touched on
+// the main task during early startup (main.c calls environment_open
+// before environment_proc is spawned), so the lazy init below does
+// not need a lock.
+static struct MinList env_missing_banks;
 static struct MinList env_drop_banks;
-static BOOL env_drop_banks_inited = FALSE;
+static BOOL env_bank_lists_inited = FALSE;
 
-static void env_drop_banks_ensure_init(void)
+static void env_bank_lists_ensure_init(void)
 {
-	if (!env_drop_banks_inited)
+	if (!env_bank_lists_inited)
 	{
+		NewList((struct List *)&env_missing_banks);
 		NewList((struct List *)&env_drop_banks);
-		env_drop_banks_inited = TRUE;
+		env_bank_lists_inited = TRUE;
 	}
 }
 
-static void env_drop_banks_add(const char *path)
+static void env_bank_list_add(struct MinList *list, const char *path, UBYTE kind)
 {
-	struct EnvDropBankNode *node;
+	struct EnvBankPathNode *node;
 
-	env_drop_banks_ensure_init();
+	env_bank_lists_ensure_init();
 
 	if (!path || !path[0])
 		return;
 
-	if ((node = AllocVec(sizeof(struct EnvDropBankNode), MEMF_CLEAR)))
+	if ((node = AllocVec(sizeof(struct EnvBankPathNode), MEMF_CLEAR)))
 	{
+		node->kind = kind;
 		stccpy(node->path, (char *)path, sizeof(node->path));
-		AddTail((struct List *)&env_drop_banks, (struct Node *)node);
+		AddTail((struct List *)list, (struct Node *)node);
 	}
+}
+
+static void env_bank_list_clear(struct MinList *list)
+{
+	struct EnvBankPathNode *node;
+
+	env_bank_lists_ensure_init();
+
+	while ((node = (struct EnvBankPathNode *)RemHead((struct List *)list)))
+		FreeVec(node);
+}
+
+static BOOL env_bank_list_empty(struct MinList *list)
+{
+	env_bank_lists_ensure_init();
+	return IsListEmpty((struct List *)list);
 }
 
 static BOOL env_drop_banks_contains(const char *path)
 {
-	struct EnvDropBankNode *node;
+	struct EnvBankPathNode *node;
 
-	env_drop_banks_ensure_init();
+	env_bank_lists_ensure_init();
 
 	if (!path)
 		return FALSE;
 
-	for (node = (struct EnvDropBankNode *)env_drop_banks.mlh_Head; node->node.mln_Succ;
-		 node = (struct EnvDropBankNode *)node->node.mln_Succ)
+	for (node = (struct EnvBankPathNode *)env_drop_banks.mlh_Head; node->node.mln_Succ;
+		 node = (struct EnvBankPathNode *)node->node.mln_Succ)
 	{
 		if (stricmp(node->path, (char *)path) == 0)
 			return TRUE;
 	}
 
 	return FALSE;
-}
-
-static BOOL env_drop_banks_empty(void)
-{
-	env_drop_banks_ensure_init();
-	return IsListEmpty((struct List *)&env_drop_banks);
-}
-
-static void env_drop_banks_clear(void)
-{
-	struct EnvDropBankNode *node;
-
-	env_drop_banks_ensure_init();
-
-	while ((node = (struct EnvDropBankNode *)RemHead((struct List *)&env_drop_banks)))
-		FreeVec(node);
 }
 
 // Allocate a new environment structure
@@ -416,6 +441,13 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 	BOOL success;
 	short progress = 1;
 
+	// Discard any unresolved missing-bank state from a previous load
+	// so it can never be applied to a different env file. Both lists
+	// are owned by this open / its paired environment_resolve_missing_banks
+	// call.
+	env_bank_list_clear(&env_missing_banks);
+	env_bank_list_clear(&env_drop_banks);
+
 	// Free volatile memory
 	ClearMemHandle(env->volatile_memory);
 
@@ -538,18 +570,13 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 			}
 			else
 			{
-				// The bank file referenced by the layout is gone.
-				// Ask the user whether to drop the entry from the
-				// environment so the next save no longer carries it.
-				if (SimpleRequestTags(NULL,
-									  dopus_name,
-									  (char *)"Remove|Keep",
-									  (char *)"Button bank '%s'\ncould not be opened.\n"
-											  "Remove from environment?",
-									  (IPTR)button->node.ln_Name))
-				{
-					env_drop_banks_add(button->node.ln_Name);
-				}
+				// The bank file is gone. Record the original
+				// path; environment_resolve_missing_banks will
+				// prompt the user once the display is up - the
+				// SimpleRequest at this point in startup would
+				// land on Workbench (no DOpus screen yet) and
+				// is easy to miss.
+				env_bank_list_add(&env_missing_banks, button->node.ln_Name, ENV_KIND_BANK);
 			}
 
 			// Free this node, get next
@@ -578,17 +605,8 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 			}
 			else
 			{
-				// Same treatment as missing button banks: ask the
-				// user whether to drop the entry from the layout.
-				if (SimpleRequestTags(NULL,
-									  dopus_name,
-									  (char *)"Remove|Keep",
-									  (char *)"Start menu '%s'\ncould not be opened.\n"
-											  "Remove from environment?",
-									  (IPTR)button->node.ln_Name))
-				{
-					env_drop_banks_add(button->node.ln_Name);
-				}
+				// Same deferred handling as button banks above.
+				env_bank_list_add(&env_missing_banks, button->node.ln_Name, ENV_KIND_START);
 			}
 
 			// Free this node, get next
@@ -724,20 +742,70 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 	// Initialise sound events
 	InitSoundEvents(TRUE);
 
-	// User asked to drop one or more missing button banks during the
-	// load? Persist the change so the next save does not bring them
-	// back. The save itself filters the list using env_drop_banks.
-	// Only clear the list on a successful save - if the save failed
-	// (e.g. env->path empty, or disk error) we want the next load to
-	// still know which entries the user wanted gone, rather than
-	// silently consuming the choice.
-	if (!env_drop_banks_empty())
+	// Any missing BANK/STRT entries that were collected above are
+	// drained later by environment_resolve_missing_banks once the
+	// caller has a usable parent screen for the requesters. We do
+	// nothing else here: a startup-time SimpleRequest with no DOpus
+	// screen yet was unreliable in earlier builds.
+	return success;
+}
+
+// Prompt the user about each BANK/STRT entry that environment_open
+// found missing on disk, and rewrite the env file without the ones
+// they chose to remove. Caller is responsible for invoking this at a
+// point where requesters can be displayed (i.e. after the DOpus
+// screen is open). Calling it when there is nothing to resolve is
+// cheap.
+//
+// `parent` is the window the requester anchors to. NULL falls back to
+// the default public screen, which is fine for the layout-load path
+// where the DOpus window is up; for the very first startup load the
+// caller passes GUI->window once the display is initialised.
+//
+// We deliberately don't clear env_missing_banks at entry: the whole
+// point of this function is to drain the list environment_open just
+// populated. env_drop_banks, on the other hand, is cleared up-front
+// so a previous load whose follow-up save failed cannot bleed its
+// removals into a different env file (Codex review).
+void environment_resolve_missing_banks(Cfg_Environment *env, struct Window *parent)
+{
+	struct EnvBankPathNode *node;
+
+	env_bank_lists_ensure_init();
+
+	env_bank_list_clear(&env_drop_banks);
+
+	if (env_bank_list_empty(&env_missing_banks))
+		return;
+
+	// Drain the missing list into a Remove/Keep prompt per entry.
+	while ((node = (struct EnvBankPathNode *)RemHead((struct List *)&env_missing_banks)))
 	{
-		if (environment_save(env, env->path, ENVSAVE_DROP_MISSING_BANKS, 0) == 0)
-			env_drop_banks_clear();
+		const char *fmt = (node->kind == ENV_KIND_START)
+							  ? "Start menu '%s'\ncould not be opened.\n"
+								"Remove from environment?"
+							  : "Button bank '%s'\ncould not be opened.\n"
+								"Remove from environment?";
+
+		if (SimpleRequestTags(parent,
+							  dopus_name,
+							  (char *)"Remove|Keep",
+							  (char *)fmt,
+							  (IPTR)node->path))
+		{
+			env_bank_list_add(&env_drop_banks, node->path, node->kind);
+		}
+
+		FreeVec(node);
 	}
 
-	return success;
+	// Persist the chosen removals. On save failure leave the drop
+	// list empty anyway: the env file is unchanged so the next load
+	// will detect the same entries again and re-prompt.
+	if (!env_bank_list_empty(&env_drop_banks))
+		environment_save(env, env->path, ENVSAVE_DROP_MISSING_BANKS, 0);
+
+	env_bank_list_clear(&env_drop_banks);
 }
 
 // Save an environment
@@ -1565,9 +1633,14 @@ IPC_EntryCode(environment_proc)
 	// Send goodbye
 	IPC_Goodbye(ipc, &main_ipc, 0);
 
-	// Send change/reopen status to main process
+	// Send change/reopen status to main process. The OPEN_DISPLAY
+	// command is synchronous (matches the CLOSE_DISPLAY at the top
+	// of this branch) so a back-to-back layout load cannot start
+	// another environment_open while the main task still has this
+	// load's missing-bank list to drain in
+	// environment_resolve_missing_banks.
 	if (reopen)
-		IPC_Command(&main_ipc, MAINCMD_OPEN_DISPLAY, DSPOPENF_DESKTOP, 0, 0, 0);
+		IPC_Command(&main_ipc, MAINCMD_OPEN_DISPLAY, DSPOPENF_DESKTOP, 0, 0, (struct MsgPort *)-1);
 	else if (change_flags[0] || change_flags[1])
 		send_main_reset_cmd(change_flags[0], change_flags[1], 0);
 

--- a/source/Program/environment.h
+++ b/source/Program/environment.h
@@ -28,6 +28,7 @@ Cfg_Environment *environment_new(void);
 void environment_free(Cfg_Environment *env);
 BOOL environment_open(Cfg_Environment *env, char *name, BOOL, APTR);
 int environment_save(Cfg_Environment *env, char *name, short, CFG_ENVR *);
+void environment_resolve_missing_banks(Cfg_Environment *env, struct Window *parent);
 IPC_EntryProto(environment_proc, extern);
 ButtonBankNode *env_read_open_bank(APTR, Cfg_Environment *, ULONG);
 OpenListerNode *env_read_open_lister(APTR, Cfg_Environment *, ULONG);

--- a/source/Program/event_loop.c
+++ b/source/Program/event_loop.c
@@ -387,6 +387,11 @@ void event_loop()
 				// Open display
 				if (!GUI->window)
 					display_open(ipc_msg->flags);
+
+				// If the load that triggered this reopen flagged
+				// any missing button banks, prompt the user about
+				// them now (display is up).
+				environment_resolve_missing_banks(environment, GUI->window);
 				break;
 
 			// Get screen data

--- a/source/Program/main.c
+++ b/source/Program/main.c
@@ -99,6 +99,11 @@ int main(int argc, char **argv)
 	PROG(14);  // Initialise display
 	startup_check_pirates();
 	PROG(15);  // Check for pirated version
+	// Now that the display is up, resolve any missing button banks
+	// noted by the initial environment_open above. Doing this earlier
+	// would put the requesters on Workbench, where they often vanish
+	// behind the startup picture.
+	environment_resolve_missing_banks(environment, GUI->window);
 	startup_misc_final();
 	PROG(16);  // Startup final miscellaneous steps
 


### PR DESCRIPTION
Closes #45.

The issue collects four FileTypes / Environment editor papercuts where stale data either persists invisibly in saved configs or has no UI signal. Each bullet from the report is addressed independently below.

## 1a. Icon Menu entries with cleared label remain in the file

**Symptom:** in the FileType editor, removing the label of an Icon Menu entry made the row vanish from the listview, but its commands still got written to disk on the next save.

**Cause:** the function editor returns a `Cfg_Function` with `FUNCF2_LABEL_FUNC` still set but no `INST_LABEL` instruction. `filetypeed_receive_edit` only treated a function as empty when its instruction list was completely empty, so it kept replacing the entry; `filetypeed_update_iconmenu` then skipped it because no `INST_LABEL` was found, hiding it from the listview while it stayed in `data->type->function_list`.

**Fix:** the receiver now also flags the new function as empty when its first `INST_LABEL` is missing or empty (matching `filetypeed_update_iconmenu`'s "first label wins" semantics). The old entry is removed cleanly, the listview rebuilds without it, and the next save no longer carries it.

## 1b. Pasting a labelled function into an Event leaks the label

**Symptom:** copying an Icon Menu entry (which has a label) and pasting it into an Event (which has no label gadget) silently embedded the label into the saved Event, with no way to see or edit it short of deleting the event.

**Cause:** `funced_decompile` populates `data->label` from any `INST_LABEL` it encounters regardless of whether the editor has a label gadget. On save, `funced_store_edits` cleared `FUNCF2_LABEL_FUNC` but left `data->label` populated, and `funced_compile` re-emitted the `INST_LABEL` from it.

**Fix:** in the no-label-gadget branch of `funced_store_edits`, also clear `data->label[0]`. The recompile then has nothing to emit. Side benefit: existing leaks self-heal next time the user re-saves the event.

## 1c. Missing icon indicator

**Symptom:** when `data->type->icon_path` was set but the icon couldn't be loaded (file removed, drawer renamed, etc.) the icon area was just blank, indistinguishable from "no icon configured".

**Fix:** when `icon_image` is NULL but `icon_path` is set, draw a centred \"?\" placeholder in the icon area using `TEXTPEN`/`JAM1`. Mirrors the same 2/1 inset the icon-image path uses so the marker stays clear of the recessed border.

## 2. Environment file holds entries for missing button banks

**Symptom:** if a button bank or start menu file referenced by a saved layout was deleted from disk, the env file kept referencing it across every non-snapshot save (the load reads BANK/STRT entries, the save reads them back from the same file and writes them out unchanged).

**Fix:** `environment_open` now checks each BANK/STRT path with `environment_path_exists` before calling `buttons_new`/`start_new`. If the file is gone the user gets a per-entry `Remove|Keep` requester. Paths the user opted to remove are recorded in a module-private list, and the load tail-ends with a non-snapshot `environment_save` that uses the new internal `ENVSAVE_DROP_MISSING_BANKS` flag to filter those entries out of the rewritten file. Choosing Keep leaves the entry intact (matches the issue author's request for opt-in cleanup).

The drop list is keyed by the raw `ButtonBankNode->ln_Name` so it matches the same string the env file holds; both sides are documented to keep using `ln_Name` (not the resolved path produced by `environment_fix_open_button_path`). The list is only cleared on save success, so a failed save (empty `env->path` or disk error) leaves the choice queued for the next load instead of silently consuming the click.

## Test plan

- [x] OS3 (m68k-amigaos) build, debug=no
- [x] OS4 (ppc-amigaos) build, debug=no
- [x] MOS (ppc-morphos) build, debug=no
- [x] AROS i386 build, debug=no
- [x] AROS x86_64 build, debug=no

Manual testing on real hardware/emulator recommended for:

- [ ] Add three Icon Menu entries to a filetype, clear the label of the second, save, re-open ⇒ the second entry is gone.
- [ ] Open Edit > Copy on a labelled icon-menu function, switch to an Event editor, Paste, save the filetype, reload ⇒ event has no INST_LABEL.
- [ ] Edit a filetype whose `icon_path` points at a deleted .info ⇒ the icon area shows a centred "?" instead of being empty.
- [ ] Snapshot a layout with a buttonbank, delete the buttonbank file, restart DOpus ⇒ requester appears at startup; clicking Remove drops it from the env file; clicking Keep leaves it.