### PR TITLE
Fix native AROS build: format warnings + arch propagation

### DIFF
--- a/source/Library/wb.c
+++ b/source/Library/wb.c
@@ -2609,10 +2609,10 @@ BOOL LIBFUNC L_WB_Remove_Patch(REG(a6, struct MyLibrary *libbase))
 				// Get library
 				if ((libptr = wb_get_patchbase(wb_patches[patch].type, (struct LibData *)libbase->ml_UserData)))
 				{
-					D(bug("waiting for the usecount (%d) to be zero (patch type %d at LVO %d)\n",
+					D(bug("waiting for the usecount (%d) to be zero (patch type %d at LVO %ld)\n",
 						  usecount[patch],
 						  wb_patches[patch].type,
-						  wb_patches[patch].offset));
+						  (long)wb_patches[patch].offset));
 					while (usecount[patch] != 0)
 						Delay(1);
 					Forbid();

--- a/source/Misc/C/makefile
+++ b/source/Misc/C/makefile
@@ -76,19 +76,19 @@ all: dopusrt loaddb viewfont
 dopusrt:
 	@echo " "
 	@echo "================== dopusrt ================="
-	@$(MAKE) --no-print-directory -C dopusrt -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C dopusrt -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : loaddb
 loaddb:
 	@echo " "
 	@echo "================== loaddb =================="
-	@$(MAKE) --no-print-directory -C loadwb -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C loadwb -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : viewfont
 viewfont:
 	@echo " "
 	@echo "================= viewfont ================="
-	@$(MAKE) --no-print-directory -C ViewFont -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C ViewFont -f makefile.$(PLATFORM) arch=$(arch)
 
 
 ###########################################################
@@ -101,19 +101,19 @@ clean: clean-dopusrt clean-loaddb clean-viewfont
 clean-dopusrt:
 	@echo " "
 	@echo "--------------- clean dopusrt --------------"
-	@$(MAKE) --no-print-directory -C dopusrt -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C dopusrt -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-loaddb
 clean-loaddb:
 	@echo " "
 	@echo "--------------- clean loaddb ---------------"
-	@$(MAKE) --no-print-directory -C loadwb -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C loadwb -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-viewfont
 clean-viewfont:
 	@echo " "
 	@echo "-------------- clean viewfont --------------"
-	@$(MAKE) --no-print-directory -C ViewFont -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C ViewFont -f makefile.$(PLATFORM) arch=$(arch) clean
 
 
 ###########################################################

--- a/source/Modules/diskinfo/diskinfo.c
+++ b/source/Modules/diskinfo/diskinfo.c
@@ -441,11 +441,11 @@ void get_dostype_string(ULONG disktype, char *buffer)
 	char c;
 
 	D(bug("disktype : %lx (%lx %lx %lx %lx)\n",
-		  disktype,
-		  (disktype >> 24) & 0xff,
-		  (disktype >> 16) & 0xff,
-		  (disktype >> 8) & 0xff,
-		  disktype & 0xff));
+		  (unsigned long)disktype,
+		  (unsigned long)((disktype >> 24) & 0xff),
+		  (unsigned long)((disktype >> 16) & 0xff),
+		  (unsigned long)((disktype >> 8) & 0xff),
+		  (unsigned long)(disktype & 0xff)));
 	// Go through lookup table
 	for (a = 0; disktype_lookup[a]; a += 2)
 	{

--- a/source/Modules/ftp/ftp.c
+++ b/source/Modules/ftp/ftp.c
@@ -885,7 +885,7 @@ static int opendataconn(struct opusftp_globals *ogp, struct ftp_info *info)
 					return (-1);
 
 				default:
-					D(bug("Epsv failed returns %ld\n", epsvreply));
+					D(bug("Epsv failed returns %ld\n", (long)epsvreply));
 				}
 			}
 
@@ -940,7 +940,7 @@ static int opendataconn(struct opusftp_globals *ogp, struct ftp_info *info)
 					return (-1);
 
 				default:
-					D(bug("Pasv failed returns %ld\n", pasvreply));
+					D(bug("Pasv failed returns %ld\n", (long)pasvreply));
 					bad_pasv = TRUE;
 				}
 			}
@@ -1812,7 +1812,7 @@ int list(struct ftp_info *info,
 
 				if (updateret <= 0)
 				{
-					D(bug("** list update %ld\n", updateret));
+					D(bug("** list update %ld\n", (long)updateret));
 					retval = updateret;
 				}
 			}
@@ -2200,7 +2200,7 @@ int connect_host(struct ftp_info *info, int (*updatefn)(void *, int, char *), vo
 		{
 			// Connect the control socket to the FTP server
 			// D(bug( "--> connect()\n" ));
-			D(bug("** control connect(0x%08lx)\n", remote_addr.sin_addr.s_addr));
+			D(bug("** control connect(0x%08lx)\n", (unsigned long)remote_addr.sin_addr.s_addr));
 
 			if (connect(info->fi_cs, (struct sockaddr *)&remote_addr, sizeof(remote_addr)) >= 0)
 			{
@@ -2210,7 +2210,7 @@ int connect_host(struct ftp_info *info, int (*updatefn)(void *, int, char *), vo
 				if (getsockname(info->fi_cs, (struct sockaddr *)&info->fi_addr, &len) >= 0)
 				{
 					int tos = IPTOS_LOWDELAY;
-					D(bug("  conhost: %lx\n", info->fi_addr.sin_addr));
+					D(bug("  conhost: %lx\n", (unsigned long)info->fi_addr.sin_addr.s_addr));
 
 					// Control connection is somewhat interactive, so quick response
 					// is desired

--- a/source/Modules/ftp/ftp_addressbook.c
+++ b/source/Modules/ftp/ftp_addressbook.c
@@ -632,11 +632,11 @@ static void address_drag_arrange(struct display_globals *dg, int swap)
 		{
 			drop_item = (x << 16) | y;
 
-			D(bug("x %ld y %ld di %ld\n  ", x, y, drop_item));
+			D(bug("x %ld y %ld di %ld\n  ", (long)x, (long)y, (long)drop_item));
 
 			GetAttr(DLV_GetLine, GADGET(obj), &drop_item);
 
-			D(bug("di %ld\n  ", drop_item));
+			D(bug("di %ld\n  ", (long)drop_item));
 
 			// Item dragged onto itself?
 			if (dg->dg_drag_item == drop_item)
@@ -3390,7 +3390,7 @@ static struct window_params *show_addrbook(struct display_globals *dg, struct su
 			if (pos.Width < FTP_ADDRBOOK_MIN_SAVED_WIDTH || pos.Height < FTP_ADDRBOOK_MIN_SAVED_HEIGHT)
 				old_font_size = 0;
 
-			D(bug("font size %ld , old_font_size %ld\n", dg->dg_og->og_screen->RastPort.TxHeight, old_font_size));
+			D(bug("font size %ld , old_font_size %ld\n", (long)dg->dg_og->og_screen->RastPort.TxHeight, (long)old_font_size));
 
 			// Is font size the same?
 			if (dg->dg_og->og_screen->RastPort.TxHeight == old_font_size)

--- a/source/Modules/ftp/ftp_addrsupp.c
+++ b/source/Modules/ftp/ftp_addrsupp.c
@@ -231,7 +231,7 @@ static BOOL write_entry(BPTR cf, struct site_entry *e)
 
 	if (e->se_port != ftp_protocol_default_port(e->se_protocol))
 	{
-		sprintf(num, "%ld", e->se_port);  // se_port is LONG
+		sprintf(num, "%ld", (long)e->se_port);  // se_port is LONG
 		// stcul_d(num, e->se_port);
 		strcat(buf, "PORT ");
 		strcat(buf, num);

--- a/source/Modules/ftp/ftp_lister.c
+++ b/source/Modules/ftp/ftp_lister.c
@@ -2391,7 +2391,7 @@ static int lister_favour(struct ftp_node *ftpnode, IPCMessage *msg)
 			break;
 		}
 	default:
-		D(bug("** unknown favour %ld\n", fm->fm_ftp_command));
+		D(bug("** unknown favour %ld\n", (long)fm->fm_ftp_command));
 		msg->command = 0;
 		break;
 	}
@@ -3781,9 +3781,9 @@ static void lister_get_prog_stuff(struct ftp_node *node, IPTR *handle, int *type
 	if (!node || !handle || !type)
 	{
 		D(bug("** get prog stuff invalid args!\n"));
-		D(bug("node:   0x%lx\n", node));
-		D(bug("handle: 0x%lx\n", handle));
-		D(bug("type:   0x%lx\n", type));
+		D(bug("node:   0x%lx\n", (unsigned long)node));
+		D(bug("handle: 0x%lx\n", (unsigned long)handle));
+		D(bug("type:   0x%lx\n", (unsigned long)type));
 
 		if (!node)
 			return;

--- a/source/Modules/ftp/ftp_lister_connect.c
+++ b/source/Modules/ftp/ftp_lister_connect.c
@@ -152,7 +152,7 @@ static int lister_connect(struct ftp_node *node,
 
 	lst_addabort(node, SIGBREAKF_CTRL_D, 0);
 
-	D(bug("lister_connect %s %ld\n", host, port));
+	D(bug("lister_connect %s %ld\n", host, (long)port));
 
 	retval = connect_host(&node->fn_ftp, startupfn, mu, host, port);
 
@@ -166,7 +166,7 @@ static int lister_connect(struct ftp_node *node,
 		lister_check_startup_msg(node);
 	}
 
-	D(bug("lister_connect returns %ld\n", retval));
+	D(bug("lister_connect returns %ld\n", (long)retval));
 
 	return retval;
 }
@@ -705,7 +705,7 @@ static int lister_connect_and_login(struct opusftp_globals *og, struct connect_l
 			loginerr = lister_login(node, startupfn, mu, cld->cld_cm->cm_site.se_user, cld->cld_cm->cm_site.se_pass);
 
 			D(bug(
-				"lister_login of %s %s ->%ld\n", cld->cld_cm->cm_site.se_user, cld->cld_cm->cm_site.se_pass, loginerr));
+				"lister_login of %s %s ->%ld\n", cld->cld_cm->cm_site.se_user, cld->cld_cm->cm_site.se_pass, (long)loginerr));
 
 			// Login successful?
 			if (loginerr == 0)
@@ -943,7 +943,7 @@ static int lister_connect_and_login(struct opusftp_globals *og, struct connect_l
 				// Can TIMEOUT
 				reply = connect_cwd(node, cwdfn, mu, node->fn_site.se_path);
 
-				D(bug("connect_cwd -> %ld\n", reply));
+				D(bug("connect_cwd -> %ld\n", (long)reply));
 
 				if (reply / 100 != COMPLETE)
 					need_query_path = 1;
@@ -1064,7 +1064,7 @@ static int lister_connect_and_login(struct opusftp_globals *og, struct connect_l
 				   FTP_HANDLE_VALUE(cld->cld_handle));
 	}
 
-	D(bug("lister_connect_and_login returns %ld\n", cld->cld_okay));
+	D(bug("lister_connect_and_login returns %ld\n", (long)cld->cld_okay));
 
 	return cld->cld_okay;
 }
@@ -1372,7 +1372,7 @@ static int opus_lostconn(struct opusftp_globals *og, struct ftp_node *ftpnode)
 	int retval = 0;
 
 #ifdef DEBUG
-	D(bug("opus_lostconn() - %ld  ", ftpnode->fn_ftp.fi_errno));
+	D(bug("opus_lostconn() - %ld  ", (long)ftpnode->fn_ftp.fi_errno));
 
 	ftpnode->fn_ftp.fi_errno &= ~FTPERR_XFER_MASK;
 

--- a/source/Modules/ftp/ftp_lister_xfer.c
+++ b/source/Modules/ftp/ftp_lister_xfer.c
@@ -821,7 +821,7 @@ static int hook_copy_pre(struct hook_rec_data *hc,
 
 					replace_option = replace_requester(hc, replace_flags, srcent, dstent);
 
-					D(bug("** replace option %ld\n", replace_option));
+					D(bug("** replace option %ld\n", (long)replace_option));
 				}
 
 				FreeVec(dstent);
@@ -840,7 +840,7 @@ static int hook_copy_pre(struct hook_rec_data *hc,
 
 				replace_option = replace_requester(hc, replace_flags, srcent, dstent);
 
-				D(bug("** B replace option %ld\n", replace_option));
+				D(bug("** B replace option %ld\n", (long)replace_option));
 
 				FreeVec(dstent);
 			}
@@ -856,7 +856,7 @@ static int hook_copy_pre(struct hook_rec_data *hc,
 			hc->hc_misc_bytes = dstent->ei_size;
 
 			replace_option = replace_requester(hc, replace_flags, srcent, dstent);
-			D(bug("** C replace option %ld\n", replace_option));
+			D(bug("** C replace option %ld\n", (long)replace_option));
 		}
 	}
 

--- a/source/Modules/ftp/ftp_main.c
+++ b/source/Modules/ftp/ftp_main.c
@@ -797,10 +797,10 @@ static int handle_ipc_msg(struct opusftp_globals *og, struct main_event_data *me
 							msg = 0;
 						}
 						else
-							D(bug("** add/cmd node 0x%lx not found\n"));
+							D(bug("** add/cmd node 0x%lx not found\n", (unsigned long)handle));
 					}
 					else
-						D(bug("** add/cmd can't get handle from func handle 0x%lx\n", fm->fm_function_handle));
+						D(bug("** add/cmd can't get handle from func handle 0x%lx\n", (unsigned long)fm->fm_function_handle));
 				}
 			}
 
@@ -1456,7 +1456,7 @@ static int opus_dropfrom(struct opusftp_globals *og, struct RexxMsg *rxmsg, int 
 
 				// Some new setting?
 				default:
-					D(bug("** unknown desktop setting %ld\n", result));
+					D(bug("** unknown desktop setting %ld\n", (long)result));
 					break;
 				}
 			}
@@ -1802,13 +1802,13 @@ static int trap_abort(struct opusftp_globals *og, struct RexxMsg *rxmsg, int arg
 			// Signal another task, or this lister's task?
 			if (node->fn_signaltask)
 			{
-				D(bug("*** SENDING SIGNAL (0x%08lx -> 0x%08lx) ***\n", node->fn_ipc->proc, node->fn_signaltask));
+				D(bug("*** SENDING SIGNAL (0x%08lx -> 0x%08lx) ***\n", (unsigned long)node->fn_ipc->proc, (unsigned long)node->fn_signaltask));
 				Signal(node->fn_signaltask, node->fn_ftp.fi_abortsignals);
 				//	retval = 1;
 			}
 			//	else
 			{
-				D(bug("*** SENDING SIGNAL (0x%08lx) ***\n", node->fn_ipc->proc));
+				D(bug("*** SENDING SIGNAL (0x%08lx) ***\n", (unsigned long)node->fn_ipc->proc));
 				Signal((struct Task *)node->fn_ipc->proc, node->fn_ftp.fi_abortsignals);
 				retval = 1;
 			}
@@ -2216,7 +2216,7 @@ static int trap_delete(struct opusftp_globals *og, struct RexxMsg *rxmsg, int ar
 						else if (ei.ei_type == -4)
 							ei.ei_type = -3;
 						else
-							D(bug("** ExamineEntry bad type %ld\n", ei.ei_type));
+							D(bug("** ExamineEntry bad type %ld\n", (long)ei.ei_type));
 
 						if (ei.ei_type >= 0)
 							++fm->fm_dircount;
@@ -3016,7 +3016,7 @@ static int handle_notify(struct opusftp_globals *og, struct MsgPort *nfyport)
 			free_address_book(og);
 		}
 		else
-			D(bug("** notify UNEXPECTED 0x%lx\n", nmsg->dn_Type));
+			D(bug("** notify UNEXPECTED 0x%lx\n", (unsigned long)nmsg->dn_Type));
 
 		ReplyFreeMsg(nmsg);
 	}
@@ -3319,7 +3319,7 @@ void dopus_ftp(void)
 								ipc_list_signal(&og->og_listerlist, 1);
 							}
 
-							D(bug("** ABORT %ld listers...\n", og->og_listercount));
+							D(bug("** ABORT %ld listers...\n", (long)og->og_listercount));
 
 							IPC_ListQuit(&med.med_tasklist, mldata->mld_ftp_ipc, 0, FALSE);
 

--- a/source/Modules/ftp/ftp_recursive.c
+++ b/source/Modules/ftp/ftp_recursive.c
@@ -319,7 +319,7 @@ static int rec_retry_get(struct hook_rec_data *hc,
 									   destname,
 									   resume);
 
-		D(bug("** GET errno=%ld, actual=%lu\n", hc->hc_source->ep_ftpnode->fn_ftp.fi_errno, actual));
+		D(bug("** GET errno=%ld, actual=%lu\n", (long)hc->hc_source->ep_ftpnode->fn_ftp.fi_errno, (unsigned long)actual));
 
 		// Any errors?
 		switch (hc->hc_source->ep_ftpnode->fn_ftp.fi_errno & FTPERR_XFER_MASK)
@@ -343,7 +343,7 @@ static int rec_retry_get(struct hook_rec_data *hc,
 			// Do Copy options
 			options = hc->hc_source->ep_opts(hc->hc_source, OPTION_COPY);
 
-			D(bug("opts %lx\n", options));
+			D(bug("opts %lx\n", (unsigned long)options));
 
 			// Copy Date? (only possible on filesystem)
 			if (options & COPY_DATE)
@@ -469,7 +469,7 @@ static int rec_retry_put(struct hook_rec_data *hc, struct entry_info *entry, cha
 									   entry->ei_name,
 									   resume ? hc->hc_misc_bytes : 0);
 
-		D(bug("** PUT errno=%ld, actual=%lu\n", hc->hc_source->ep_ftpnode->fn_ftp.fi_errno, actual));
+		D(bug("** PUT errno=%ld, actual=%lu\n", (long)hc->hc_source->ep_ftpnode->fn_ftp.fi_errno, (unsigned long)actual));
 
 		// Any errors?
 		switch (hc->hc_dest->ep_ftpnode->fn_ftp.fi_errno & FTPERR_XFER_MASK)
@@ -599,7 +599,7 @@ static int rec_retry_getput(struct hook_rec_data *hc, struct entry_info *entry, 
 		else
 			actual = recursive_getput_via_temp(hc, entry, destname, resume);
 
-		D(bug("** getput actual 1 %ld\n", actual));
+		D(bug("** getput actual 1 %ld\n", (long)actual));
 
 		// Fix value of actual (getput returns special values)
 
@@ -622,7 +622,7 @@ static int rec_retry_getput(struct hook_rec_data *hc, struct entry_info *entry, 
 		else if (actual == REC_GETPUT_ERROR_END)
 			actual = entry->ei_size / 2;
 
-		D(bug("** getput actual 2 %ld\n", actual));
+		D(bug("** getput actual 2 %ld\n", (long)actual));
 
 		if (transfer_aborted)
 		{
@@ -1415,7 +1415,7 @@ int recursive_copy(struct hook_rec_data *hc,
 		break;
 	}
 
-	D(bug("** copy = %ld\n", retval));
+	D(bug("** copy = %ld\n", (long)retval));
 
 	// Only do the following if we jumped there specifically
 	goto free_locals;
@@ -1836,7 +1836,7 @@ int recursive_delete(struct hook_rec_data *hc, char *startdir, struct entry_info
 		break;
 
 	default:  // Shouldn't happen (so don't try to delete)
-		D(bug("** recursive_delete()\n   unexpected type %ld '%s'\n", entry->ei_type, entry->ei_name));
+		D(bug("** recursive_delete()\n   unexpected type %ld '%s'\n", (long)entry->ei_type, entry->ei_name));
 		retval = 0;
 		break;
 	}
@@ -2350,7 +2350,7 @@ int do_normal_rec_findfile(struct hook_rec_data *hc, struct findfile_locals *l, 
 						// retval = min(2,retval);
 						retval = l->subrv;
 
-					D(bug("** subrv %ld retval %ld\n", l->subrv, retval));
+					D(bug("** subrv %ld retval %ld\n", (long)l->subrv, (long)retval));
 				}
 				// CD source back up to original dir
 				hc->hc_source->ep_cdup(hc->hc_source);
@@ -2408,7 +2408,7 @@ int do_broken_rec_findfile(struct hook_rec_data *hc, struct findfile_locals *l, 
 						// retval = min(2,retval);
 						retval = l->subrv;
 
-					D(bug("** subrv %ld retval %ld\n", l->subrv, retval));
+					D(bug("** subrv %ld retval %ld\n", (long)l->subrv, (long)retval));
 				}
 			}
 			// Free entry list
@@ -2954,7 +2954,7 @@ int rec_ftp_mkdir(endpoint *ep, char *dirname)
 	else
 		retval = 3;
 
-	D(bug("** FTP MKDIR = %ld\n", retval));
+	D(bug("** FTP MKDIR = %ld\n", (long)retval));
 
 	return retval;
 }
@@ -3006,7 +3006,7 @@ int rec_filesys_mkdir(endpoint *ep, char *dirname)
 		}
 	}
 
-	D(bug("** FS MKDIR = %ld\n", retval));
+	D(bug("** FS MKDIR = %ld\n", (long)retval));
 
 	return retval;
 }
@@ -3111,7 +3111,7 @@ int rec_ftp_port(endpoint *ep, struct sockaddr_in *addr, ULONG flags)
 //
 int rec_filesys_port(endpoint *ep, struct sockaddr_in *addr, ULONG flags)
 {
-	D(bug("FS  PORT %lu:%lu\n", addr->sin_addr.s_addr, addr->sin_port));
+	D(bug("FS  PORT %lu:%lu\n", (unsigned long)addr->sin_addr.s_addr, (unsigned long)addr->sin_port));
 
 	return 0;
 }
@@ -3177,7 +3177,7 @@ int rec_ftp_rest(endpoint *ep, unsigned int offset)
 		// Ask the appropriate lister to do it for us
 		return rec_ask_lister_favour(FAVOUR_REST, ep, (void *)(IPTR)offset, 0);
 
-	D(bug("FTP REST %s\n", offset));
+	D(bug("FTP REST %lu\n", (unsigned long)offset));
 
 	if (ep->ep_ftpnode->fn_protocol == FTP_PROTOCOL_SFTP)
 		return offset == 0;
@@ -3190,7 +3190,7 @@ int rec_ftp_rest(endpoint *ep, unsigned int offset)
 //
 int rec_filesys_rest(endpoint *ep, unsigned int offset)
 {
-	D(bug("FS  REST %s\n", offset));
+	D(bug("FS  REST %lu\n", (unsigned long)offset));
 
 	return 0;
 }

--- a/source/Modules/ftp/ftp_util.c
+++ b/source/Modules/ftp/ftp_util.c
@@ -562,7 +562,7 @@ int unix_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 		break;
 	}
 
-	D(bug("type %ld ", entry->ei_type));
+	D(bug("type %ld ", (long)entry->ei_type));
 
 	entry->ei_prot = FIBF_READ | FIBF_WRITE | FIBF_EXECUTE | FIBF_DELETE;
 

--- a/source/Modules/icon/icon.c
+++ b/source/Modules/icon/icon.c
@@ -1852,7 +1852,7 @@ BOOL icon_edit(icon_data *data)
 									goto breakout;
 					}
 					else
-						D(bug("** Icon module: Unexpected notify %lx\n", nmsg->dn_Type));
+						D(bug("** Icon module: Unexpected notify %lx\n", (unsigned long)nmsg->dn_Type));
 
 					ReplyFreeMsg(nmsg);
 				}
@@ -2135,7 +2135,7 @@ short icon_info(icon_data *data, char *name, struct Node *next)
 			while ((nmsg = (DOpusNotify *)GetMsg(data->notify_port)))
 			{
 				if (nmsg->dn_Type != DN_APP_WINDOW_LIST)
-					D(bug("** Icon module: Ignoring notify %lx\n", nmsg->dn_Type));
+					D(bug("** Icon module: Ignoring notify %lx\n", (unsigned long)nmsg->dn_Type));
 
 				ReplyFreeMsg(nmsg);
 			}

--- a/source/Modules/makefile
+++ b/source/Modules/makefile
@@ -83,121 +83,121 @@ all: $(MODULES)
 about:
 	@echo " "
 	@echo "=============== about_module ==============="
-	@$(MAKE) --no-print-directory -C about -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C about -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : cleanup
 cleanup:
 	@echo " "
 	@echo "============== cleanup_module =============="
-	@$(MAKE) --no-print-directory -C cleanup -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C cleanup -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : configopus
 configopus:
 	@echo " "
 	@echo "============= configopus_module ============"
-	@$(MAKE) --no-print-directory -C configopus -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C configopus -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : diskcopy
 diskcopy:
 	@echo " "
 	@echo "============= diskcopy_module =============="
-	@$(MAKE) --no-print-directory -C diskcopy -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C diskcopy -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : diskinfo
 diskinfo:
 	@echo " "
 	@echo "============= diskinfo_module =============="
-	@$(MAKE) --no-print-directory -C diskinfo -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C diskinfo -f makefile.$(PLATFORM) arch=$(arch)
 		
 .PHONY : filetype
 filetype:
 	@echo " "
 	@echo "============= filetype_module =============="
-	@$(MAKE) --no-print-directory -C filetype -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C filetype -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : fixicons
 fixicons:
 	@echo " "
 	@echo "============= fixicons_module =============="
-	@$(MAKE) --no-print-directory -C fixicons -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C fixicons -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : format
 format:
 	@echo " "
 	@echo "============== format_module ==============="
-	@$(MAKE) --no-print-directory -C format -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C format -f makefile.$(PLATFORM) arch=$(arch)
 	
 .PHONY : ftp
 ftp:
 	@echo " "
 	@echo "================ ftp_module ================"
-	@$(MAKE) --no-print-directory -C ftp -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C ftp -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : icon
 icon:
 	@echo " "
 	@echo "=============== icon_module ================"
-	@$(MAKE) --no-print-directory -C icon -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C icon -f makefile.$(PLATFORM) arch=$(arch)
 	
 .PHONY : join
 join:
 	@echo " "
 	@echo "=============== join_module ================"
-	@$(MAKE) --no-print-directory -C join -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C join -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : listerformat
 listerformat:
 	@echo " "
 	@echo "============ listerformat_module ==========="
-	@$(MAKE) --no-print-directory -C listerformat -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C listerformat -f makefile.$(PLATFORM) arch=$(arch)
 	
 .PHONY : misc
 misc:
 	@echo " "
 	@echo "================ misc_module ==============="
-	@$(MAKE) --no-print-directory -C misc -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C misc -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : pathformat
 pathformat:
 	@echo " "
 	@echo "============= pathformat_module ============"
-	@$(MAKE) --no-print-directory -C pathformat -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C pathformat -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : play
 play:
 	@echo " "
 	@echo "================ play_module ==============="
-	@$(MAKE) --no-print-directory -C play -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C play -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : print
 print:
 	@echo " "
 	@echo "=============== print_module ==============="
-	@$(MAKE) --no-print-directory -C print -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C print -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : read
 read:
 	@echo " "
 	@echo "=============== read_module ================"
-	@$(MAKE) --no-print-directory -C read -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C read -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : show
 show:
 	@echo " "
 	@echo "=============== show_module ================"
-	@$(MAKE) --no-print-directory -C show -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C show -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : themes
 themes:
 	@echo " "
 	@echo "============== themes_module ==============="
-	@$(MAKE) --no-print-directory -C themes -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C themes -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : xadopus
 xadopus:
 	@echo " "
 	@echo "============== xadopus_module =============="
-	@$(MAKE) --no-print-directory -C xadopus -f makefile.$(PLATFORM)
+	@$(MAKE) --no-print-directory -C xadopus -f makefile.$(PLATFORM) arch=$(arch)
 	
 	
 ###########################################################
@@ -214,121 +214,121 @@ clean: clean-about clean-cleanup clean-configopus clean-diskcopy \
 clean-about:
 	@echo " "
 	@echo "------------ clean about_module ------------"
-	@$(MAKE) --no-print-directory -C about -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C about -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-cleanup
 clean-cleanup:
 	@echo " "
 	@echo "----------- clean cleanup_module -----------"
-	@$(MAKE) --no-print-directory -C cleanup -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C cleanup -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-configopus
 clean-configopus:
 	@echo " "
 	@echo "---------- clean configopus_module ---------"
-	@$(MAKE) --no-print-directory -C configopus -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C configopus -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-diskcopy
 clean-diskcopy:
 	@echo " "
 	@echo "----------- clean diskcopy_module ----------"
-	@$(MAKE) --no-print-directory -C diskcopy -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C diskcopy -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-diskinfo
 clean-diskinfo:
 	@echo " "
 	@echo "----------- clean diskinfo_module ----------"
-	@$(MAKE) --no-print-directory -C diskinfo -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C diskinfo -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-filetype
 clean-filetype:
 	@echo " "
 	@echo "----------- clean filetype_module ----------"
-	@$(MAKE) --no-print-directory -C filetype -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C filetype -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-fixicons
 clean-fixicons:
 	@echo " "
 	@echo "----------- clean fixicons_module ----------"
-	@$(MAKE) --no-print-directory -C fixicons -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C fixicons -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-format
 clean-format:
 	@echo " "
 	@echo "------------ clean format_module -----------"
-	@$(MAKE) --no-print-directory -C format -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C format -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-ftp
 clean-ftp:
 	@echo " "
 	@echo "------------- clean ftp_module -------------"
-	@$(MAKE) --no-print-directory -C ftp -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C ftp -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-icon
 clean-icon:
 	@echo " "
 	@echo "------------- clean icon_module ------------"
-	@$(MAKE) --no-print-directory -C icon -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C icon -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-join
 clean-join:
 	@echo " "
 	@echo "------------- clean join_module ------------"
-	@$(MAKE) --no-print-directory -C join -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C join -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-listerformat
 clean-listerformat:
 	@echo " "
 	@echo "--------- clean listerformat_module --------"
-	@$(MAKE) --no-print-directory -C listerformat -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C listerformat -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-misc
 clean-misc:
 	@echo " "
 	@echo "------------- clean misc_module ------------"
-	@$(MAKE) --no-print-directory -C misc -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C misc -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-pathformat
 clean-pathformat:
 	@echo " "
 	@echo "---------- clean pathformat_module ---------"
-	@$(MAKE) --no-print-directory -C pathformat -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C pathformat -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-play
 clean-play:
 	@echo " "
 	@echo "------------- clean play_module ------------"
-	@$(MAKE) --no-print-directory -C play -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C play -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-print
 clean-print:
 	@echo " "
 	@echo "------------ clean print_module ------------"
-	@$(MAKE) --no-print-directory -C print -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C print -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-read
 clean-read:
 	@echo " "
 	@echo "------------- clean read_module ------------"
-	@$(MAKE) --no-print-directory -C read -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C read -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-show
 clean-show:
 	@echo " "
 	@echo "------------- clean show_module ------------"
-	@$(MAKE) --no-print-directory -C show -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C show -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 .PHONY : clean-themes
 clean-themes:
 	@echo " "
 	@echo "------------ clean themes_module -----------"
-	@$(MAKE) --no-print-directory -C themes -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C themes -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-xadopus
 clean-xadopus:
 	@echo " "
 	@echo "----------- clean xadopus_module -----------"
-	@$(MAKE) --no-print-directory -C xadopus -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) --no-print-directory -C xadopus -s -f makefile.$(PLATFORM) arch=$(arch) clean
 	
 	
 ###########################################################

--- a/source/makefile
+++ b/source/makefile
@@ -136,25 +136,25 @@ all : program library modules commands
 program:
 	@echo " "
 	@echo "<<<<<<<<<<<<<<<<<< program >>>>>>>>>>>>>>>>>>"
-	@$(MAKE) -C Program -f makefile.$(PLATFORM)
+	@$(MAKE) -C Program -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : library
 library:
 	@echo " "
 	@echo "<<<<<<<<<<<<<<<<<< library >>>>>>>>>>>>>>>>>>"
-	@$(MAKE) -C Library -f makefile.$(PLATFORM)
+	@$(MAKE) -C Library -f makefile.$(PLATFORM) arch=$(arch)
 
 .PHONY : modules
 modules:
 	@echo " "
 	@echo "<<<<<<<<<<<<<<<<<< modules >>>>>>>>>>>>>>>>>>"
-	@$(MAKE) -C Modules $(NAME)
+	@$(MAKE) -C Modules $(NAME) arch=$(arch)
 
 .PHONY : commands
 commands:
 	@echo " "
 	@echo "<<<<<<<<<<<<<<<<<< commands >>>>>>>>>>>>>>>>>"
-	@$(MAKE) -C Misc/C $(NAME)
+	@$(MAKE) -C Misc/C $(NAME) arch=$(arch)
 
 ###########################################################
 
@@ -171,25 +171,25 @@ cleanall : clean
 clean-program:
 	@echo " "
 	@echo "++++++++++++++ clean program +++++++++++++++"
-	@$(MAKE) -C Program -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) -C Program -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-library
 clean-library:
 	@echo " "
 	@echo "++++++++++++++ clean library +++++++++++++++"
-	@$(MAKE) -C Library -s -f makefile.$(PLATFORM) clean
+	@$(MAKE) -C Library -s -f makefile.$(PLATFORM) arch=$(arch) clean
 
 .PHONY : clean-modules
 clean-modules:
 	@echo " "
 	@echo "++++++++++++++ clean modules +++++++++++++++"
-	@$(MAKE) -C Modules -s $(NAME) clean
+	@$(MAKE) -C Modules -s $(NAME) clean arch=$(arch)
 
 .PHONY : clean-commands
 clean-commands:
 	@echo " "
 	@echo "++++++++++++++ clean commands ++++++++++++++"
-	@$(MAKE) -C Misc/C -s $(NAME) clean
+	@$(MAKE) -C Misc/C -s $(NAME) clean arch=$(arch)
 
 ###########################################################
 
@@ -198,6 +198,15 @@ release: all release-package
 
 .PHONY : release-package
 release-package:
+	@if [ ! -f bin.$(NAME)/dopus5.library ]; then \
+		echo ""; \
+		echo "*** Error: bin.$(NAME)/dopus5.library is missing."; \
+		echo "*** Run 'make $(NAME) all' first, then 'make $(NAME) release-package'."; \
+		echo "*** If only a different bin.<arch>-aros/ got populated, the matching"; \
+		echo "*** cross-compiler is probably not installed and the build silently"; \
+		echo "*** fell back to the host toolchain."; \
+		exit 1; \
+	fi
 	@echo " "
 	@echo ">>>>>Creating release archive: Dopus5$(VERSION)$(NAME)$(TYPE).lha"
 	@$(REMOVE) $(RELEASE_DIR)


### PR DESCRIPTION
## Summary

Two independent fixes for issues reported by a user compiling dopus5 natively on AROS (on EAB).

### 1. AROS x86_64 format-string warnings — commit 96e1a0b

On AROS x86_64 (ABIv11) `int` is 32-bit but `long` is 64-bit, and `ULONG` expands to `unsigned int` rather than `unsigned long`. Legacy `D(bug(...))` sites using `%ld`/`%lx`/`%lu` for ints/ULONGs/pointers therefore become `-Wformat=` warnings, and the user's AROS-native gcc is strict enough to reject at least one of them outright (observed on `ftp_main.c:3322`).

Audited the whole AROS build and fixed **53 call sites across 12 files**, following the existing `ftp_module.c` pattern of keeping the specifier and casting the argument to `(long)` / `(unsigned long)`. Output stays identical on m68k / PPC / MorphOS.

**Three latent bugs surfaced while auditing** (all DEBUG-only paths, would crash/garble when DEBUG is enabled):

- `ftp_main.c:800` — `0x%lx` with no matching argument; now prints the failed handle.
- `ftp.c:2213` — passed a full `struct in_addr` to `%lx` instead of its `s_addr` field.
- `ftp_recursive.c:3180` / `:3193` — `%s` against an `unsigned int offset`; switched to `%lu` to match the neighbouring `REST %lu` FTP command.

Files touched:
- `Library/wb.c`
- `Modules/diskinfo/diskinfo.c`, `Modules/icon/icon.c`
- `Modules/ftp/ftp.c`, `ftp_addressbook.c`, `ftp_addrsupp.c`, `ftp_lister.c`, `ftp_lister_connect.c`, `ftp_lister_xfer.c`, `ftp_main.c`, `ftp_recursive.c`, `ftp_util.c`

### 2. AROS arch propagation + release-package preflight — commit bee82e9

A second screenshot from the same user showed a release failure whose compile output didn't match the archive name:

```
mkdir -p ../../../bin.i386-aros
i386-aros-gcc .objects/aros/font_data.o .objects/aros/font.o ...
...
>>>>>Creating release archive: Dopus5_100_x86_64-aros.lha
/AROS/Development/bin/cp: cannot stat 'bin.x86_64-aros/dopus5.library': No such file or directory
make: *** [release-package] Error 1
```

Top-level thinks it's building `x86_64-aros` but every sub-make compiled with `i386-aros-gcc` into `bin.i386-aros/`, with objects in `.objects/aros/` (no arch prefix). That mismatch can only happen when the toplevel's `export arch` doesn't reach the leaf `makefile.aros`: `ifdef arch` comes back false, `ARCH` falls back to `$(shell uname -m)`, and the build silently uses the host toolchain — which happens to produce a working binary in the "wrong" `bin.<host>-aros/` directory.

Two complementary changes:

- **Explicit `arch=$(arch)` on every `$(MAKE)` sub-invocation** in `source/makefile`, `source/Modules/makefile`, `source/Misc/C/makefile`. Command-line variable overrides cross sub-make boundaries reliably regardless of `export` semantics. Now if the matching cross-compiler is missing, the build fails *fast* at the first link with `<arch>-aros-gcc: not found` instead of completing into the wrong directory.
- **Preflight check at the top of `release-package`** that aborts with a focused message naming the missing file and explaining the likely cause, instead of letting `cp` bail out with a generic "No such file" error.

## Test plan

Verified clean builds with every available toolchain:

- [x] `midwan/aros-compiler:i386-aros` — `make i386-aros release debug=no` succeeds, no format warnings
- [x] `midwan/aros-compiler:x86_64-aros` — `make x86_64-aros release debug=no` succeeds, no format warnings
- [x] `sacredbanana/amiga-compiler:m68k-amigaos` — `make os3 all` succeeds
- [x] `sacredbanana/amiga-compiler:ppc-amigaos` — `make os4 all` succeeds

Verified the failure modes of the makefile hardening:

- [x] `make x86_64-aros release` on i386 toolchain → fails fast at first link with `x86_64-aros-gcc: not found` (was: completed into bin.i386-aros)
- [x] `make x86_64-aros release-package` without prior build → fails with the new preflight message (was: opaque `cp` error)

## Notes

The diagnosis for the second commit is based on analysing the screenshot — we haven't yet confirmed with the EAB user which exact `make` command they ran. The fix is defensive either way: it eliminates the silent wrong-arch fallback and gives a clear error if `bin.$(NAME)` is empty at package time.