### PR TITLE
format: Long File Names support and PFS awareness (#46)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+[dopus5allamigas next] format.module: Long File Names (FFS-LNFS) support
+Program remains at 5.100. format.module ships in v73r5.
+
+Format / FFS-LNFS:
+- Add a "Long File Names" checkbox to the format dialog so volumes can
+  be formatted as FFS-LNFS (DOS\7), matching the option exposed by the
+  AmigaOS 3.2+ system Format command.
+- LNFS implies FFS+International compare and excludes Directory
+  Caching: selecting it auto-enables and locks FFS/INTL while clearing
+  and locking the Caching checkbox. Toggling Caching also clears LNFS
+  so the two stay mutually exclusive.
+- When inspecting an existing FFS-LNFS volume, default the Long File
+  Names checkbox on so the format defaults round-trip to DOS\7.
+- Resizes the format window by one row to accommodate the new gadget;
+  listview height grows in step so it still aligns with the bottom
+  checkbox.
+- Resolves #46.
+2026-05-05 by Dimitris Panokostas <midwan@gmail.com>
+
 [dopus5allamigas next] FTP SFTP support
 Program remains at 5.100. ftp.module bumps to v73r5.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-[dopus5allamigas next] format.module: LNFS support and PFS3 awareness
+[dopus5allamigas next] format.module: LNFS support and PFS awareness
 Program remains at 5.100. format.module ships in v73r5.
 
 Format / FFS-LNFS:
@@ -16,13 +16,17 @@ Format / FFS-LNFS:
   checkbox.
 - Resolves #46.
 
-Format / PFS3:
-- When a PFS3-family volume (DOS type PFS\3, PDS\3, or muPF) is
-  selected in the device list, append "(Personal File System 3)" to
-  the status bar. The dialog otherwise behaves as before - all
-  FFS-specific checkboxes stay greyed out and the format goes through
-  Format() with the volume's existing PFS3 DOS type, which is what
-  the PFS3 filesystem expects.
+Format / PFS:
+- When a PFS-family volume (any DOS type in the PFS\x, PDS\x, or muPF
+  ranges, where the PFS3 filesystem is what's actually mounted) is
+  selected in the device list, append "(Personal File System)" to the
+  status bar. The dialog otherwise behaves as before - all FFS-specific
+  checkboxes stay greyed out and the format goes through Format() with
+  the volume's existing DOS type, which is what the PFS3 filesystem
+  expects. The check covers PFS\0..PFS\3, PDS\0..PDS\3 and muPF since
+  the PFS3 filesystem can serve any of those depending on which
+  features (deldir, large file, multiuser) the partition was set up
+  with.
 2026-05-05 by Dimitris Panokostas <midwan@gmail.com>
 
 [dopus5allamigas next] FTP SFTP support

--- a/ChangeLog
+++ b/ChangeLog
@@ -19,14 +19,15 @@ Format / FFS-LNFS:
 Format / PFS:
 - When a PFS-family volume (any DOS type in the PFS\x, PDS\x, or muPF
   ranges, where the PFS3 filesystem is what's actually mounted) is
-  selected in the device list, append "(Personal File System)" to the
-  status bar. The dialog otherwise behaves as before - all FFS-specific
-  checkboxes stay greyed out and the format goes through Format() with
-  the volume's existing DOS type, which is what the PFS3 filesystem
+  selected in the device list, append "(PFS)" to the status bar. The
+  dialog otherwise behaves as before - all FFS-specific checkboxes
+  stay greyed out and the format goes through Format() with the
+  volume's existing DOS type, which is what the PFS3 filesystem
   expects. The check covers PFS\0..PFS\3, PDS\0..PDS\3 and muPF since
   the PFS3 filesystem can serve any of those depending on which
   features (deldir, large file, multiuser) the partition was set up
-  with.
+  with. Short label keeps the status string from overflowing the
+  status bar at typical Workbench fonts.
 2026-05-05 by Dimitris Panokostas <midwan@gmail.com>
 
 [dopus5allamigas next] FTP SFTP support

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-[dopus5allamigas next] format.module: Long File Names (FFS-LNFS) support
+[dopus5allamigas next] format.module: LNFS support and PFS3 awareness
 Program remains at 5.100. format.module ships in v73r5.
 
 Format / FFS-LNFS:
@@ -15,6 +15,14 @@ Format / FFS-LNFS:
   listview height grows in step so it still aligns with the bottom
   checkbox.
 - Resolves #46.
+
+Format / PFS3:
+- When a PFS3-family volume (DOS type PFS\3, PDS\3, or muPF) is
+  selected in the device list, append "(Personal File System 3)" to
+  the status bar. The dialog otherwise behaves as before - all
+  FFS-specific checkboxes stay greyed out and the format goes through
+  Format() with the volume's existing PFS3 DOS type, which is what
+  the PFS3 filesystem expects.
 2026-05-05 by Dimitris Panokostas <midwan@gmail.com>
 
 [dopus5allamigas next] FTP SFTP support

--- a/source/Modules/format/format.c
+++ b/source/Modules/format/format.c
@@ -547,20 +547,42 @@ void show_device_info(format_data *data)
 	// Unlock dos list
 	UnLockDosList(LDF_DEVICES | LDF_READ);
 
-	// Identify PFS3-family volumes in the status text so the user knows
-	// they are re-formatting a PFS3 partition rather than a plain DOS one.
-	if (info_buf[0] &&
-		(dos_type == ID_PFS3_DISK || dos_type == ID_PFS3_SC_DISK || dos_type == ID_PFS3_MULTI))
+	// Identify PFS-family volumes in the status text so the user knows
+	// they are re-formatting a PFS partition rather than a plain DOS
+	// one. The PFS3 filesystem itself can serve any of these DOS types
+	// depending on which features (deldir, large file, multiuser) the
+	// partition was set up with, so match the whole family rather than
+	// just the PFS\3 / PDS\3 / muPF triple.
+	if (info_buf[0])
 	{
-		char *fs_name = GetString(locale, MSG_FORMAT_FS_PFS3);
-		int cur_len = strlen(info_buf);
-		int suffix_len = strlen(fs_name) + 4; /* " (" + name + ")" + NUL */
+		BOOL is_pfs = FALSE;
 
-		if ((long)(cur_len + suffix_len) < (long)sizeof(info_buf))
+		/* PFS\0..PFS\3: the standard four PFS / PFS3 dostypes. */
+		if ((dos_type & 0xFFFFFFFCUL) == (ID_PFS_FLOPPY & 0xFFFFFFFCUL))
+			is_pfs = TRUE;
+
+		/* PDS\0..PDS\3: the four Direct-SCSI dostypes (only PDS\2/3
+		 * have ID_ defines in dopus5.h, but PDS\0/1 are valid too).
+		 */
+		else if ((dos_type & 0xFFFFFFFCUL) == 0x50445300UL)
+			is_pfs = TRUE;
+
+		/* muPF: PFS3 multiuser. */
+		else if (dos_type == ID_PFS3_MULTI)
+			is_pfs = TRUE;
+
+		if (is_pfs)
 		{
-			strcat(info_buf, " (");
-			strcat(info_buf, fs_name);
-			strcat(info_buf, ")");
+			char *fs_name = GetString(locale, MSG_FORMAT_FS_PFS);
+			int cur_len = strlen(info_buf);
+			int suffix_len = strlen(fs_name) + 4; /* " (" + name + ")" + NUL */
+
+			if ((long)(cur_len + suffix_len) < (long)sizeof(info_buf))
+			{
+				strcat(info_buf, " (");
+				strcat(info_buf, fs_name);
+				strcat(info_buf, ")");
+			}
 		}
 	}
 

--- a/source/Modules/format/format.c
+++ b/source/Modules/format/format.c
@@ -374,11 +374,14 @@ BOOL format_open(format_data *data, BOOL noactive)
 		DisableObject(data->list, GAD_FORMAT_FORMAT, TRUE);
 	}
 
-	// If <39, disable International and Caching
+	// If <39, disable International, Caching and Long File Names
+	// (LNFS implies International compare, so it can't work on
+	// pre-KS2 dos.library either)
 	if (((struct Library *)DOSBase)->lib_Version < 39)
 	{
 		DisableObject(data->list, GAD_FORMAT_INTERNATIONAL, TRUE);
 		DisableObject(data->list, GAD_FORMAT_CACHING, TRUE);
+		DisableObject(data->list, GAD_FORMAT_LNFS, TRUE);
 	}
 
 	// Set defaults
@@ -557,14 +560,17 @@ void show_device_info(format_data *data)
 	{
 		BOOL is_pfs = FALSE;
 
-		/* PFS\0..PFS\3: the standard four PFS / PFS3 dostypes. */
+		/* PFS\0..PFS\3: PFS variants in DOS\x ID space. */
 		if ((dos_type & 0xFFFFFFFCUL) == (ID_PFS_FLOPPY & 0xFFFFFFFCUL))
 			is_pfs = TRUE;
 
-		/* PDS\0..PDS\3: the four Direct-SCSI dostypes (only PDS\2/3
-		 * have ID_ defines in dopus5.h, but PDS\0/1 are valid too).
+		/* PDS\0..PDS\3: Direct-SCSI variants. dopus5.h only declares
+		 * PDS\2/PDS\3 (ID_PFS2_SC_DISK / ID_PFS3_SC_DISK), but the
+		 * masked compare also covers any PDS\0/PDS\1 a setup might
+		 * use; deriving the base from ID_PFS3_SC_DISK keeps this in
+		 * step with the header.
 		 */
-		else if ((dos_type & 0xFFFFFFFCUL) == 0x50445300UL)
+		else if ((dos_type & 0xFFFFFFFCUL) == (ID_PFS3_SC_DISK & 0xFFFFFFFCUL))
 			is_pfs = TRUE;
 
 		/* muPF: PFS3 multiuser. */
@@ -589,21 +595,18 @@ void show_device_info(format_data *data)
 	// Display status
 	SetGadgetValue(data->list, GAD_FORMAT_STATUS, (IPTR)info_buf);
 
-	// If this isn't a standard dos disk, disable FFS, etc
+	// If this isn't a standard dos disk, disable FFS, etc.
+	// Also lock FFS/International/Caching whenever LNFS is on, since
+	// LNFS implies FFS+International and excludes Directory Caching.
 	{
-		BOOL not_dos = (BOOL)((dos_type & ID_DOS_DISK) != ID_DOS_DISK);
-		BOOL lnfs_on = (BOOL)GetGadgetValue(data->list, GAD_FORMAT_LNFS);
-		BOOL cache_on = (BOOL)GetGadgetValue(data->list, GAD_FORMAT_CACHING);
+		BOOL not_dos = (dos_type & ID_DOS_DISK) != ID_DOS_DISK;
+		BOOL lnfs_on = GetGadgetValue(data->list, GAD_FORMAT_LNFS);
+		BOOL cache_on = GetGadgetValue(data->list, GAD_FORMAT_CACHING);
 
-		// LNFS is only valid for standard DOS disks
 		DisableObject(data->list, GAD_FORMAT_LNFS, not_dos);
-
-		// FFS/Caching are locked when LNFS is active
-		DisableObject(data->list, GAD_FORMAT_FFS, (BOOL)(not_dos || lnfs_on));
-		DisableObject(data->list, GAD_FORMAT_CACHING, (BOOL)(not_dos || lnfs_on));
-		DisableObject(data->list,
-					  GAD_FORMAT_INTERNATIONAL,
-					  (BOOL)(not_dos || cache_on || lnfs_on));
+		DisableObject(data->list, GAD_FORMAT_FFS, not_dos || lnfs_on);
+		DisableObject(data->list, GAD_FORMAT_CACHING, not_dos || lnfs_on);
+		DisableObject(data->list, GAD_FORMAT_INTERNATIONAL, not_dos || cache_on || lnfs_on);
 	}
 
 	// Disable install if no bootblock entry in table

--- a/source/Modules/format/format.c
+++ b/source/Modules/format/format.c
@@ -94,7 +94,7 @@ int LIBFUNC L_Module_Entry(REG(a0, struct List *disks),
 
 			// FFS?
 			if (data->info.id_DiskType == ID_FFS_DISK || data->info.id_DiskType == ID_INTER_FFS_DISK ||
-				data->info.id_DiskType == ID_FASTDIR_FFS_DISK)
+				data->info.id_DiskType == ID_FASTDIR_FFS_DISK || data->info.id_DiskType == ID_FFS7_DISK)
 				data->default_ffs = 1;
 
 			// >=39?
@@ -109,6 +109,13 @@ int LIBFUNC L_Module_Entry(REG(a0, struct List *disks),
 				{
 					data->default_int = 1;
 					data->default_cache = 1;
+				}
+
+				// Long File Names? (FFS-LNFS implies FFS+International)
+				if (data->info.id_DiskType == ID_FFS7_DISK)
+				{
+					data->default_int = 1;
+					data->default_lnfs = 1;
 				}
 			}
 
@@ -215,7 +222,7 @@ int LIBFUNC L_Module_Entry(REG(a0, struct List *disks),
 						show_device_info(data);
 						break;
 
-					// Caching implies International:
+					// Caching implies International, mutually exclusive with Long File Names
 					case GAD_FORMAT_CACHING: {
 						BOOL state;
 
@@ -225,9 +232,34 @@ int LIBFUNC L_Module_Entry(REG(a0, struct List *disks),
 						// Enable/disable International gadget
 						DisableObject(data->list, GAD_FORMAT_INTERNATIONAL, state);
 
-						// If on, check International
+						// If on, check International and clear LNFS
 						if (state)
+						{
 							SetGadgetValue(data->list, GAD_FORMAT_INTERNATIONAL, 1);
+							SetGadgetValue(data->list, GAD_FORMAT_LNFS, 0);
+						}
+					}
+					break;
+
+					// Long File Names implies FFS+International, excludes Caching
+					case GAD_FORMAT_LNFS: {
+						BOOL state;
+
+						// Get state
+						state = GetGadgetValue(data->list, GAD_FORMAT_LNFS);
+
+						// If on, force FFS+International, clear Caching
+						if (state)
+						{
+							SetGadgetValue(data->list, GAD_FORMAT_FFS, 1);
+							SetGadgetValue(data->list, GAD_FORMAT_INTERNATIONAL, 1);
+							SetGadgetValue(data->list, GAD_FORMAT_CACHING, 0);
+						}
+
+						// Lock implied gadgets while LNFS is active
+						DisableObject(data->list, GAD_FORMAT_FFS, state);
+						DisableObject(data->list, GAD_FORMAT_INTERNATIONAL, state);
+						DisableObject(data->list, GAD_FORMAT_CACHING, state);
 					}
 					break;
 
@@ -354,6 +386,7 @@ BOOL format_open(format_data *data, BOOL noactive)
 	SetGadgetValue(data->list, GAD_FORMAT_FFS, data->default_ffs);
 	SetGadgetValue(data->list, GAD_FORMAT_INTERNATIONAL, data->default_int);
 	SetGadgetValue(data->list, GAD_FORMAT_CACHING, data->default_cache);
+	SetGadgetValue(data->list, GAD_FORMAT_LNFS, data->default_lnfs);
 	SetGadgetValue(data->list, GAD_FORMAT_TRASHCAN, data->default_trash);
 	SetGadgetValue(data->list, GAD_FORMAT_INSTALL, data->default_boot);
 	SetGadgetValue(data->list, GAD_FORMAT_VERIFY, data->default_verify);
@@ -361,6 +394,14 @@ BOOL format_open(format_data *data, BOOL noactive)
 	// If caching is on, disable international
 	if (data->default_cache)
 		DisableObject(data->list, GAD_FORMAT_INTERNATIONAL, TRUE);
+
+	// If LNFS is on, FFS/International/Caching are forced and locked
+	if (data->default_lnfs)
+	{
+		DisableObject(data->list, GAD_FORMAT_FFS, TRUE);
+		DisableObject(data->list, GAD_FORMAT_INTERNATIONAL, TRUE);
+		DisableObject(data->list, GAD_FORMAT_CACHING, TRUE);
+	}
 
 	return 1;
 }
@@ -380,6 +421,7 @@ void format_close(format_data *data)
 		data->default_ffs = GetGadgetValue(data->list, GAD_FORMAT_FFS);
 		data->default_int = GetGadgetValue(data->list, GAD_FORMAT_INTERNATIONAL);
 		data->default_cache = GetGadgetValue(data->list, GAD_FORMAT_CACHING);
+		data->default_lnfs = GetGadgetValue(data->list, GAD_FORMAT_LNFS);
 		data->default_trash = GetGadgetValue(data->list, GAD_FORMAT_TRASHCAN);
 		data->default_boot = GetGadgetValue(data->list, GAD_FORMAT_INSTALL);
 		data->default_verify = GetGadgetValue(data->list, GAD_FORMAT_VERIFY);
@@ -509,11 +551,21 @@ void show_device_info(format_data *data)
 	SetGadgetValue(data->list, GAD_FORMAT_STATUS, (IPTR)info_buf);
 
 	// If this isn't a standard dos disk, disable FFS, etc
-	DisableObject(data->list, GAD_FORMAT_FFS, (dos_type & ID_DOS_DISK) != ID_DOS_DISK);
-	DisableObject(data->list, GAD_FORMAT_CACHING, (dos_type & ID_DOS_DISK) != ID_DOS_DISK);
-	DisableObject(data->list,
-				  GAD_FORMAT_INTERNATIONAL,
-				  ((dos_type & ID_DOS_DISK) != ID_DOS_DISK || (GetGadgetValue(data->list, GAD_FORMAT_CACHING))));
+	{
+		BOOL not_dos = (BOOL)((dos_type & ID_DOS_DISK) != ID_DOS_DISK);
+		BOOL lnfs_on = (BOOL)GetGadgetValue(data->list, GAD_FORMAT_LNFS);
+		BOOL cache_on = (BOOL)GetGadgetValue(data->list, GAD_FORMAT_CACHING);
+
+		// LNFS is only valid for standard DOS disks
+		DisableObject(data->list, GAD_FORMAT_LNFS, not_dos);
+
+		// FFS/Caching are locked when LNFS is active
+		DisableObject(data->list, GAD_FORMAT_FFS, (BOOL)(not_dos || lnfs_on));
+		DisableObject(data->list, GAD_FORMAT_CACHING, (BOOL)(not_dos || lnfs_on));
+		DisableObject(data->list,
+					  GAD_FORMAT_INTERNATIONAL,
+					  (BOOL)(not_dos || cache_on || lnfs_on));
+	}
 
 	// Disable install if no bootblock entry in table
 	DisableObject(data->list, GAD_FORMAT_INSTALL, (table_size < DE_BOOTBLOCKS));
@@ -670,6 +722,10 @@ BOOL start_format(format_data *data, unsigned short type, BOOL reopen)
 	// Non-standard DOS?
 	if ((disk->dh_geo->de_DosType & ID_DOS_DISK) != ID_DOS_DISK)
 		data->dos_type = disk->dh_geo->de_DosType;
+
+	// Long File Names? (always FFS+International, requires FFS-LNFS aware filesystem)
+	else if (data->default_lnfs)
+		data->dos_type = ID_FFS7_DISK;
 
 	// Caching?
 	else if (data->default_cache)

--- a/source/Modules/format/format.c
+++ b/source/Modules/format/format.c
@@ -494,7 +494,7 @@ void show_device_info(format_data *data)
 	Att_Node *node;
 	struct DosList *dl;
 	char name_buf[32], *ptr;
-	char info_buf[80];
+	char info_buf[120];
 	unsigned long dos_type = ID_DOS_DISK, table_size = 0;
 
 	// Get selected node
@@ -546,6 +546,23 @@ void show_device_info(format_data *data)
 
 	// Unlock dos list
 	UnLockDosList(LDF_DEVICES | LDF_READ);
+
+	// Identify PFS3-family volumes in the status text so the user knows
+	// they are re-formatting a PFS3 partition rather than a plain DOS one.
+	if (info_buf[0] &&
+		(dos_type == ID_PFS3_DISK || dos_type == ID_PFS3_SC_DISK || dos_type == ID_PFS3_MULTI))
+	{
+		char *fs_name = GetString(locale, MSG_FORMAT_FS_PFS3);
+		int cur_len = strlen(info_buf);
+		int suffix_len = strlen(fs_name) + 4; /* " (" + name + ")" + NUL */
+
+		if ((long)(cur_len + suffix_len) < (long)sizeof(info_buf))
+		{
+			strcat(info_buf, " (");
+			strcat(info_buf, fs_name);
+			strcat(info_buf, ")");
+		}
+	}
 
 	// Display status
 	SetGadgetValue(data->list, GAD_FORMAT_STATUS, (IPTR)info_buf);

--- a/source/Modules/format/format.cd
+++ b/source/Modules/format/format.cd
@@ -104,3 +104,6 @@ Installing Bootblock...
 MSG_FORMAT_DESC (//)
 Format disks
 ;
+MSG_FORMAT_LNFS (//)
+_Long File Names
+;

--- a/source/Modules/format/format.cd
+++ b/source/Modules/format/format.cd
@@ -107,3 +107,6 @@ Format disks
 MSG_FORMAT_LNFS (//)
 _Long File Names
 ;
+MSG_FORMAT_FS_PFS3 (//)
+Personal File System 3
+;

--- a/source/Modules/format/format.cd
+++ b/source/Modules/format/format.cd
@@ -107,6 +107,6 @@ Format disks
 MSG_FORMAT_LNFS (//)
 _Long File Names
 ;
-MSG_FORMAT_FS_PFS3 (//)
-Personal File System 3
+MSG_FORMAT_FS_PFS (//)
+Personal File System
 ;

--- a/source/Modules/format/format.cd
+++ b/source/Modules/format/format.cd
@@ -108,5 +108,5 @@ MSG_FORMAT_LNFS (//)
 _Long File Names
 ;
 MSG_FORMAT_FS_PFS (//)
-Personal File System
+PFS
 ;

--- a/source/Modules/format/format.h
+++ b/source/Modules/format/format.h
@@ -48,6 +48,7 @@ typedef struct
 	char default_ffs;
 	char default_int;
 	char default_cache;
+	char default_lnfs;
 	char default_trash;
 	char default_boot;
 	char default_verify;
@@ -91,6 +92,7 @@ enum {
 	GAD_FORMAT_FFS,
 	GAD_FORMAT_INTERNATIONAL,
 	GAD_FORMAT_CACHING,
+	GAD_FORMAT_LNFS,
 	GAD_FORMAT_TRASHCAN,
 	GAD_FORMAT_INSTALL,
 	GAD_FORMAT_VERIFY,

--- a/source/Modules/format/format.strings
+++ b/source/Modules/format/format.strings
@@ -65,6 +65,7 @@
 #define MSG_FORMAT_MAKING_TRASH 1031
 #define MSG_INSTALLING_DISK 1032
 #define MSG_FORMAT_DESC 1033
+#define MSG_FORMAT_LNFS 1034
 
 #endif /* CATCOMP_NUMBERS */
 
@@ -107,6 +108,7 @@
 #define MSG_FORMAT_MAKING_TRASH_STR "Making Trashcan..."
 #define MSG_INSTALLING_DISK_STR "Installing Bootblock..."
 #define MSG_FORMAT_DESC_STR "Format disks"
+#define MSG_FORMAT_LNFS_STR "_Long File Names"
 
 #endif /* CATCOMP_STRINGS */
 
@@ -157,6 +159,7 @@ static const struct CatCompArrayType CatCompArray[] =
     {MSG_FORMAT_MAKING_TRASH,(STRPTR)MSG_FORMAT_MAKING_TRASH_STR},
     {MSG_INSTALLING_DISK,(STRPTR)MSG_INSTALLING_DISK_STR},
     {MSG_FORMAT_DESC,(STRPTR)MSG_FORMAT_DESC_STR},
+    {MSG_FORMAT_LNFS,(STRPTR)MSG_FORMAT_LNFS_STR},
 };
 
 #endif /* CATCOMP_ARRAY */
@@ -235,6 +238,8 @@ static const char CatCompBlock[] =
     MSG_INSTALLING_DISK_STR "\x00"
     "\x00\x00\x04\x09\x00\x0E"
     MSG_FORMAT_DESC_STR "\x00\x00"
+    "\x00\x00\x04\x0A\x00\x12"
+    MSG_FORMAT_LNFS_STR "\x00"
 };
 
 #endif /* CATCOMP_BLOCK */

--- a/source/Modules/format/format.strings
+++ b/source/Modules/format/format.strings
@@ -66,6 +66,7 @@
 #define MSG_INSTALLING_DISK 1032
 #define MSG_FORMAT_DESC 1033
 #define MSG_FORMAT_LNFS 1034
+#define MSG_FORMAT_FS_PFS3 1035
 
 #endif /* CATCOMP_NUMBERS */
 
@@ -109,6 +110,7 @@
 #define MSG_INSTALLING_DISK_STR "Installing Bootblock..."
 #define MSG_FORMAT_DESC_STR "Format disks"
 #define MSG_FORMAT_LNFS_STR "_Long File Names"
+#define MSG_FORMAT_FS_PFS3_STR "Personal File System 3"
 
 #endif /* CATCOMP_STRINGS */
 
@@ -160,6 +162,7 @@ static const struct CatCompArrayType CatCompArray[] =
     {MSG_INSTALLING_DISK,(STRPTR)MSG_INSTALLING_DISK_STR},
     {MSG_FORMAT_DESC,(STRPTR)MSG_FORMAT_DESC_STR},
     {MSG_FORMAT_LNFS,(STRPTR)MSG_FORMAT_LNFS_STR},
+    {MSG_FORMAT_FS_PFS3,(STRPTR)MSG_FORMAT_FS_PFS3_STR},
 };
 
 #endif /* CATCOMP_ARRAY */
@@ -239,7 +242,9 @@ static const char CatCompBlock[] =
     "\x00\x00\x04\x09\x00\x0E"
     MSG_FORMAT_DESC_STR "\x00\x00"
     "\x00\x00\x04\x0A\x00\x12"
-    MSG_FORMAT_LNFS_STR "\x00"
+    MSG_FORMAT_LNFS_STR "\x00\x00"
+    "\x00\x00\x04\x0B\x00\x18"
+    MSG_FORMAT_FS_PFS3_STR "\x00\x00"
 };
 
 #endif /* CATCOMP_BLOCK */

--- a/source/Modules/format/format.strings
+++ b/source/Modules/format/format.strings
@@ -66,7 +66,7 @@
 #define MSG_INSTALLING_DISK 1032
 #define MSG_FORMAT_DESC 1033
 #define MSG_FORMAT_LNFS 1034
-#define MSG_FORMAT_FS_PFS3 1035
+#define MSG_FORMAT_FS_PFS 1035
 
 #endif /* CATCOMP_NUMBERS */
 
@@ -110,7 +110,7 @@
 #define MSG_INSTALLING_DISK_STR "Installing Bootblock..."
 #define MSG_FORMAT_DESC_STR "Format disks"
 #define MSG_FORMAT_LNFS_STR "_Long File Names"
-#define MSG_FORMAT_FS_PFS3_STR "Personal File System 3"
+#define MSG_FORMAT_FS_PFS_STR "Personal File System"
 
 #endif /* CATCOMP_STRINGS */
 
@@ -162,7 +162,7 @@ static const struct CatCompArrayType CatCompArray[] =
     {MSG_INSTALLING_DISK,(STRPTR)MSG_INSTALLING_DISK_STR},
     {MSG_FORMAT_DESC,(STRPTR)MSG_FORMAT_DESC_STR},
     {MSG_FORMAT_LNFS,(STRPTR)MSG_FORMAT_LNFS_STR},
-    {MSG_FORMAT_FS_PFS3,(STRPTR)MSG_FORMAT_FS_PFS3_STR},
+    {MSG_FORMAT_FS_PFS,(STRPTR)MSG_FORMAT_FS_PFS_STR},
 };
 
 #endif /* CATCOMP_ARRAY */
@@ -243,8 +243,8 @@ static const char CatCompBlock[] =
     MSG_FORMAT_DESC_STR "\x00\x00"
     "\x00\x00\x04\x0A\x00\x12"
     MSG_FORMAT_LNFS_STR "\x00\x00"
-    "\x00\x00\x04\x0B\x00\x18"
-    MSG_FORMAT_FS_PFS3_STR "\x00\x00"
+    "\x00\x00\x04\x0B\x00\x16"
+    MSG_FORMAT_FS_PFS_STR "\x00\x00"
 };
 
 #endif /* CATCOMP_BLOCK */

--- a/source/Modules/format/format.strings
+++ b/source/Modules/format/format.strings
@@ -110,7 +110,7 @@
 #define MSG_INSTALLING_DISK_STR "Installing Bootblock..."
 #define MSG_FORMAT_DESC_STR "Format disks"
 #define MSG_FORMAT_LNFS_STR "_Long File Names"
-#define MSG_FORMAT_FS_PFS_STR "Personal File System"
+#define MSG_FORMAT_FS_PFS_STR "PFS"
 
 #endif /* CATCOMP_STRINGS */
 
@@ -243,8 +243,8 @@ static const char CatCompBlock[] =
     MSG_FORMAT_DESC_STR "\x00\x00"
     "\x00\x00\x04\x0A\x00\x12"
     MSG_FORMAT_LNFS_STR "\x00\x00"
-    "\x00\x00\x04\x0B\x00\x16"
-    MSG_FORMAT_FS_PFS_STR "\x00\x00"
+    "\x00\x00\x04\x0B\x00\x04"
+    MSG_FORMAT_FS_PFS_STR "\x00"
 };
 
 #endif /* CATCOMP_BLOCK */

--- a/source/Modules/format/format_data.c
+++ b/source/Modules/format/format_data.c
@@ -26,7 +26,7 @@ For more information on Directory Opus for Windows please see:
 ModuleInfo module_info =
 	{1, "format.module", "format.catalog", 0, 1, {{0, "Format", MSG_FORMAT_DESC, FUNCF_NO_ARGS, 0}}};
 
-ConfigWindow format_window = {{POS_CENTER, POS_CENTER, 40, 9}, {0, 0, 44, 67}};
+ConfigWindow format_window = {{POS_CENTER, POS_CENTER, 40, 10}, {0, 0, 44, 72}};
 
 struct TagItem
 
@@ -51,8 +51,8 @@ ObjectDef format_objects[] = {
 	// Device lister
 	{OD_GADGET,
 	 MY_LISTVIEW_KIND,
-	 {0, 0, 10, 7},
-	 {4, 4, 24, 35},
+	 {0, 0, 10, 8},
+	 {4, 4, 24, 40},
 	 0,
 	 LISTVIEWFLAG_CURSOR_KEYS,
 	 GAD_FORMAT_DEVICES,
@@ -98,11 +98,21 @@ ObjectDef format_objects[] = {
 	 GAD_FORMAT_CACHING,
 	 format_layout_tags},
 
-	// Install
+	// Long File Names
 	{OD_GADGET,
 	 CHECKBOX_KIND,
 	 {10, 4, 0, 1},
 	 {36, 25, 26, 4},
+	 MSG_FORMAT_LNFS,
+	 PLACETEXT_RIGHT,
+	 GAD_FORMAT_LNFS,
+	 format_layout_tags},
+
+	// Install
+	{OD_GADGET,
+	 CHECKBOX_KIND,
+	 {10, 5, 0, 1},
+	 {36, 30, 26, 4},
 	 MSG_FORMAT_INSTALL,
 	 PLACETEXT_RIGHT,
 	 GAD_FORMAT_INSTALL,
@@ -111,8 +121,8 @@ ObjectDef format_objects[] = {
 	// Trashcan
 	{OD_GADGET,
 	 CHECKBOX_KIND,
-	 {10, 5, 0, 1},
-	 {36, 30, 26, 4},
+	 {10, 6, 0, 1},
+	 {36, 35, 26, 4},
 	 MSG_FORMAT_TRASHCAN,
 	 PLACETEXT_RIGHT,
 	 GAD_FORMAT_TRASHCAN,
@@ -121,8 +131,8 @@ ObjectDef format_objects[] = {
 	// Verify
 	{OD_GADGET,
 	 CHECKBOX_KIND,
-	 {10, 6, 0, 1},
-	 {36, 35, 26, 4},
+	 {10, 7, 0, 1},
+	 {36, 40, 26, 4},
 	 MSG_FORMAT_VERIFY,
 	 PLACETEXT_RIGHT,
 	 GAD_FORMAT_VERIFY,
@@ -131,8 +141,8 @@ ObjectDef format_objects[] = {
 	// Status bar
 	{OD_AREA,
 	 TEXTPEN,
-	 {0, 7, SIZE_MAXIMUM, 1},
-	 {4, 43, -4, 6},
+	 {0, 8, SIZE_MAXIMUM, 1},
+	 {4, 48, -4, 6},
 	 0,
 	 AREAFLAG_RECESSED | AREAFLAG_ERASE | TEXTFLAG_CENTER,
 	 GAD_FORMAT_STATUS,


### PR DESCRIPTION
Resolves #46.

## Summary

The `format.module` dialog gains an `_Long File Names` checkbox, mapped to the FFS-LNFS DOSType (`DOS\7` / `ID_FFS7_DISK`), matching the option that AmigaOS 3.2+ exposes in the system Format command. As a small side-improvement requested during review, the same dialog now also tags PFS-family volumes (`PFS\0..PFS\3`, `PDS\0..PDS\3`, `muPF`) with a `(PFS)` suffix in the status bar so the user knows they're re-formatting a PFS partition rather than a plain DOS one.

The AmigaOS 4 path is untouched — it still delegates to `SYS:System/Format`, which already exposes its own LNFS option.

## What's in the four commits

1. **`format: add Long File Names (FFS-LNFS) support`** (`2a8365d`)
   - New `_Long File Names` checkbox between Caching and Install.
   - Window grows by one char row (`40x10` char / `44x72` fine), listview height grows in step so it still aligns with the bottom checkbox; right-justified buttons stay anchored to the bottom edge.
   - Interlocks: LNFS implies FFS+International and excludes Directory Caching. Toggling LNFS auto-checks FFS+INTL, clears Caching, and locks all three. Toggling Caching also clears LNFS so the two stay mutually exclusive.
   - Round-trip: when an existing FFS-LNFS volume is selected, `default_lnfs` defaults to 1 so the dialog opens with the same options the volume was created with.
   - `start_format` resolves to `ID_FFS7_DISK` when LNFS is set, ahead of the existing Caching / International / FFS branches; the non-DOS pre-check is unchanged.
   - Catalog plumbing for `MSG_FORMAT_LNFS` (id 1034). Added at the end of the table so existing message IDs and localized `.catalog` binaries stay valid; localized `.ct` files are not touched (runtime falls back to the built-in English string).
2. **`format: identify PFS3 volumes in the status bar`** (`57da857`)
   - First cut at the PFS hint: appends `(Personal File System 3)` to the `%ld tracks, ...` status text when a PFS3-family DOSType is selected.
   - `info_buf` grows from 80 to 120 bytes so the appended tag never has to be truncated.
   - Latent fix: the `MSG_FORMAT_LNFS` `CatCompBlock` entry only worked while it was the last entry — it relied on the implicit NUL at the end of the concatenated literal to match its declared length. Adding any entry after it broke the parse. Both new entries now use an explicit `"\x00\x00"` suffix so the declared length matches the byte count regardless of position.
3. **`format: broaden PFS detection to the whole PFS family`** (`17528a7`)
   - User reported a real-world PFS3 partition with DOSType `0x50465300` (`PFS\0`) — the simplest PFS variant, without deldir / large file / multiuser features. The PFS3 filesystem itself can serve any of the PFS DOSTypes, so the check needed to cover the family.
   - Detection now matches `PFS\0..PFS\3`, `PDS\0..PDS\3` and `muPF` via two range comparisons (`(x & 0xFFFFFFFC) == base`) plus an exact match for `muPF`. PDS\0 / PDS\1 don't have `ID_` defines in `dopus5.h` yet but the masked range catches them without inventing more names.
   - Catalog string renamed to `MSG_FORMAT_FS_PFS` / `Personal File System` (no version suffix), since labelling a PFS\0 partition as "Personal File System 3" would have been wrong.
4. **`format: shorten PFS status tag to fit the status bar`** (`9b07ff5`)
   - `Personal File System` overflowed the status bar on Workbench setups with proportional fonts (the geometry string already takes most of the bar). Dropped to a plain `PFS` tag, which is unambiguous in context. Detection logic unchanged.

## Files touched

- <ref_file file=\"/Users/midwan/Github/dopus5/source/Modules/format/format.h\" /> — `default_lnfs` field + `GAD_FORMAT_LNFS` enum
- <ref_file file=\"/Users/midwan/Github/dopus5/source/Modules/format/format.cd\" /> — new `MSG_FORMAT_LNFS` and `MSG_FORMAT_FS_PFS` strings
- <ref_file file=\"/Users/midwan/Github/dopus5/source/Modules/format/format.strings\" /> — id 1034/1035, `_STR` defines, array entries, binary block entries
- <ref_file file=\"/Users/midwan/Github/dopus5/source/Modules/format/format_data.c\" /> — new checkbox object, listview and window resize
- <ref_file file=\"/Users/midwan/Github/dopus5/source/Modules/format/format.c\" /> — interlocks, dos_type computation, round-trip detection, PFS family check, status tag append
- <ref_file file=\"/Users/midwan/Github/dopus5/ChangeLog\" /> — entries under the `[dopus5allamigas next]` heading

## Test plan

- [x] `m68k-amigaos` (OS3) build clean
- [x] `ppc-amigaos` (OS4) build clean (warnings are pre-existing)
- [x] `ppc-morphos` build clean (warnings are pre-existing)
- [x] `i386-aros` build clean
- [x] `x86_64-aros` build clean
- [x] CatCompBlock parses cleanly end-to-end (verified with a host C parser)
- [x] PFS DOSType range check verified to match all 9 PFS variants and not false-match `DOS\x`, `SFS\x`, `FAT32`
- [x] Manual smoke tested on AmigaOS 3.2 (A4000, KS47.115): format dialog opens, LNFS gadget toggles correctly, status text shows `(PFS)` on a real `PFS\0` partition.