### PR TITLE
backdrop: sort by type in Workbench order (DIRS, TOOLS, PROJECTS)

### DIFF
--- a/source/Program/backdrop_arrange.c
+++ b/source/Program/backdrop_arrange.c
@@ -764,23 +764,37 @@ void backdrop_sort_objects(BackdropInfo *info, short type, BOOL align)
 			// Sort by type
 			else if (type == BSORT_TYPE)
 			{
-				short t1, t2;
+				BOOL skip_name_compare = FALSE;
 
-				// Primary key: match Workbench's "Sort By Type" so users get
-				// the familiar DIRS / TOOLS / PROJECTS grouping (issue #26
-				// follow-up). The DiskObject->do_Type values (WBDISK=1,
-				// WBDRAWER=2, WBTOOL=3, WBPROJECT=4, WBGARBAGE=5, ...) sort
-				// numerically into exactly that order. Icon-less objects
-				// fall through to the existing filetype-name comparison.
-				t1 = object->icon ? object->icon->do_Type : 0;
-				t2 = sort_object->icon ? sort_object->icon->do_Type : 0;
+				// Primary key: match Workbench's "Sort By Type" so users
+				// get the familiar DIRS / TOOLS / PROJECTS grouping
+				// (issue #26 follow-up). The DiskObject->do_Type values
+				// (WBDISK=1, WBDRAWER=2, WBTOOL=3, WBPROJECT=4,
+				// WBGARBAGE=5, ...) sort numerically into exactly that
+				// order. We only apply this key when BOTH sides have an
+				// icon; if either is icon-less we fall through to the
+				// previous filetype-name comparison so icon-less entries
+				// don't get artificially placed ahead of every WB type.
+				if (object->icon && sort_object->icon)
+				{
+					short t1 = object->icon->do_Type;
+					short t2 = sort_object->icon->do_Type;
 
-				if (t1 < t2)
-					break;
+					if (t1 < t2)
+						break;
+					if (t1 > t2)
+					{
+						// object's category sorts after sort_object's;
+						// the WB key has fully decided the order, so
+						// skip the secondary name comparison too.
+						skip_name_compare = TRUE;
+					}
+					// t1 == t2: fall through to filetype-name compare
+				}
 
-				// Same icon category (or no icon either side): keep the
-				// previous behaviour and order by filetype name.
-				if (t1 == t2)
+				// Same WB category, or icon-less on one/both sides:
+				// keep the previous behaviour and order by filetype name.
+				if (!skip_name_compare)
 				{
 					Cfg_Filetype *type1, *type2;
 					short res;
@@ -800,8 +814,6 @@ void backdrop_sort_objects(BackdropInfo *info, short type, BOOL align)
 					else
 						sort_type = BSORT_NAME;
 				}
-				// t1 > t2: object's category sorts after sort_object's;
-				// don't break and don't fall through to name comparison.
 			}
 
 			// Sort by name?

--- a/source/Program/backdrop_arrange.c
+++ b/source/Program/backdrop_arrange.c
@@ -764,23 +764,44 @@ void backdrop_sort_objects(BackdropInfo *info, short type, BOOL align)
 			// Sort by type
 			else if (type == BSORT_TYPE)
 			{
-				Cfg_Filetype *type1, *type2;
-				short res;
+				short t1, t2;
 
-				// Get filetypes
-				type1 = backdrop_get_filetype(info, object);
-				type2 = backdrop_get_filetype(info, sort_object);
+				// Primary key: match Workbench's "Sort By Type" so users get
+				// the familiar DIRS / TOOLS / PROJECTS grouping (issue #26
+				// follow-up). The DiskObject->do_Type values (WBDISK=1,
+				// WBDRAWER=2, WBTOOL=3, WBPROJECT=4, WBGARBAGE=5, ...) sort
+				// numerically into exactly that order. Icon-less objects
+				// fall through to the existing filetype-name comparison.
+				t1 = object->icon ? object->icon->do_Type : 0;
+				t2 = sort_object->icon ? sort_object->icon->do_Type : 0;
 
-				// Got filetypes?
-				if (type1 && type2)
+				if (t1 < t2)
+					break;
+
+				// Same icon category (or no icon either side): keep the
+				// previous behaviour and order by filetype name.
+				if (t1 == t2)
 				{
-					if ((res = stricmp(type1->type.name, type2->type.name)) < 0)
-						break;
-					else if (res == 0)
+					Cfg_Filetype *type1, *type2;
+					short res;
+
+					// Get filetypes
+					type1 = backdrop_get_filetype(info, object);
+					type2 = backdrop_get_filetype(info, sort_object);
+
+					// Got filetypes?
+					if (type1 && type2)
+					{
+						if ((res = stricmp(type1->type.name, type2->type.name)) < 0)
+							break;
+						else if (res == 0)
+							sort_type = BSORT_NAME;
+					}
+					else
 						sort_type = BSORT_NAME;
 				}
-				else
-					sort_type = BSORT_NAME;
+				// t1 > t2: object's category sorts after sort_object's;
+				// don't break and don't fall through to name comparison.
 			}
 
 			// Sort by name?


### PR DESCRIPTION
## Summary

Follow-up to the comment on #26
(https://github.com/BlitterStudio/dopus5/issues/26#issuecomment-4383107105):
the icon view's `Arrange Icons -> by Type` was sorting purely on the
filetype-config name, which with the default filetype set comes out
as **DIRS, PROJECTS, TOOLS**. Modern Workbench sorts the same option
as **DIRS, TOOLS, PROJECTS** (programs before data files), which is
what most users expect.

## Change

- In `backdrop_sort_objects`, when sorting with `BSORT_TYPE`, use the
  icon's Workbench `do_Type` as the primary key. The native constants
  `WBDISK=1`, `WBDRAWER=2`, `WBTOOL=3`, `WBPROJECT=4`, `WBGARBAGE=5`
  sort numerically into exactly that order, so a single integer
  compare gives the desired DIRS / TOOLS / PROJECTS / trash grouping.
- Within the same WB category the previous behaviour is preserved:
  fall back to filetype name (alphabetical), then to file name.
- Icon-less objects (rare in icon view) keep the previous behaviour
  by falling through to the name comparison.

Touches a single file: `source/Program/backdrop_arrange.c`
(34 insertions, 13 deletions).

## Test plan

- [x] OS3 (`sacredbanana/amiga-compiler:m68k-amigaos`) clean build,
      no new warnings on `backdrop_arrange.c`.
- [x] OS4 (`sacredbanana/amiga-compiler:ppc-amigaos`) clean build,
      no new warnings on `backdrop_arrange.c`.
- [x] AROS i386 (`midwan/aros-compiler:i386-aros`) clean build,
      no new warnings on `backdrop_arrange.c`.
- [x] Runtime smoke test: with a directory containing a mix of
      drawers, executables (WBTOOL) and data files (WBPROJECT),
      open in icon view and run `Arrange Icons -> by Type`; expect
      drawers first, then tools, then projects.