### PR TITLE
display.c: runtime intuition.library v45 check for SA_OffScreenDragging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+[dopus5allamigas next] display.c: runtime version check for SA_OffScreenDragging
+Program remains at 5.100.  No module version changes.
+
+Source / display.c:
+- Off-screen window dragging on the DOpus custom screen (introduced
+  in #22) now also runtime-checks intuition.library lib_Version >=
+  45 before passing SA_OffScreenDragging to OpenScreenTags.  The
+  compile-time #if guards already kept the binary from emitting a
+  tag the SDK does not know about, but on AmigaOS 3.1 (intuition
+  v40) a binary built against NDK3.2 was still pushing an
+  unrecognised tag at runtime.  When the running Intuition is
+  older than v45, the tag is now replaced with TAG_IGNORE so the
+  whole tag pair is skipped.  v45+ (3.1.4) and v47+ (3.2.x), plus
+  any future 3.x release with v48+, continue to receive
+  SA_OffScreenDragging = TRUE.  OS4, MorphOS and AROS already
+  carry intuition.library >= 45 so the check is harmless there.
+- Follow-up to #20 / #22 based on rubicon2026's review feedback.
+2026-05-06 by Dimitris Panokostas <midwan@gmail.com>
+
 [dopus5allamigas next] Release archive: DOpus5 casing + restore drawer icon
 Program remains at 5.100.  No module version changes.
 

--- a/source/Program/display.c
+++ b/source/Program/display.c
@@ -112,14 +112,23 @@ BOOL display_open(long flags)
 			0,
 			SA_LikeWorkbench,
 			TRUE,
+			/* Enable AmigaOS 3.1.4+ (intuition.library v45+) off-screen window
+			 * dragging when the running system supports it.  The compile-time
+			 * #if guards ensure we only emit a known tag if the SDK defines it;
+			 * the runtime lib_Version >= 45 check then keeps OS3.1 (v40) and
+			 * any other older Intuition from receiving an unrecognised tag.
+			 * The canonical NDK 3.2 / OS4 / MorphOS / AROS spelling is
+			 * SA_OffScreenDragging.  The other two spellings below are
+			 * defensive fallbacks for any third-party SDK that ever picked
+			 * a different casing; they do not appear in the official headers. */
 #if defined(SA_OffscreenDragging)
-			SA_OffscreenDragging,
+			(((struct Library *)IntuitionBase)->lib_Version >= 45) ? SA_OffscreenDragging : TAG_IGNORE,
 			TRUE,
 #elif defined(SA_OFFSCREENDRAGGING)
-			SA_OFFSCREENDRAGGING,
+			(((struct Library *)IntuitionBase)->lib_Version >= 45) ? SA_OFFSCREENDRAGGING : TAG_IGNORE,
 			TRUE,
 #elif defined(SA_OffScreenDragging)
-			SA_OffScreenDragging,
+			(((struct Library *)IntuitionBase)->lib_Version >= 45) ? SA_OffScreenDragging : TAG_IGNORE,
 			TRUE,
 #endif
 			SA_Width,


### PR DESCRIPTION
## Summary

Follow-up to #22 (closes #20 follow-up feedback from @rubicon2026).

The compile-time `#if defined(SA_OffScreenDragging)` guard added in #22 only protects against the SDK not defining the tag at build time. An OS3 binary built against NDK 3.2 was still pushing `SA_OffScreenDragging = TRUE` to `OpenScreenTags()` at runtime on AmigaOS 3.1 systems where `intuition.library` is v40 and does not recognise the tag.

This patch wraps each spelling branch in a runtime `IntuitionBase->lib_Version >= 45` check, falling back to `TAG_IGNORE` when the running Intuition is older. The pattern matches the existing `(((struct Library *)IntuitionBase)->lib_Version >= XX)` idiom used elsewhere in the codebase (e.g. `source/Modules/configopus/config_environment.c:634`, `source/Library/misc.c:241`, `source/Program/display_pattern.c:158`) and the `cond ? TAG_X : TAG_IGNORE` ternary used at `display.c:341` and many other tag-list sites.

### Per-platform behaviour

| Platform | Runtime behaviour |
|---|---|
| AmigaOS 3.1 (intuition v40) | `TAG_IGNORE` — tag pair is skipped, no unrecognised tag passed |
| AmigaOS 3.1.4 (intuition v45) | `SA_OffScreenDragging = TRUE` |
| AmigaOS 3.2.x (intuition v47) | `SA_OffScreenDragging = TRUE` |
| AmigaOS 3.3 (intuition v48+, future) | `SA_OffScreenDragging = TRUE` |
| AmigaOS 4.x (intuition v53+) | `SA_OffScreenDragging = TRUE` |
| MorphOS / AROS | SDK does not define any spelling — entire `#if/#elif` block compiles to nothing |

The runtime check is a no-op on every target whose SDK actually defines the tag, since they all already ship intuition.library >= 45.

### Other notes

- Comment now documents that `SA_OffScreenDragging` (camel case) is the canonical NDK 3.2 / OS4 spelling, and the other two `#elif` variants (`SA_OffscreenDragging`, `SA_OFFSCREENDRAGGING`) are defensive fallbacks that do not appear in the official headers.
- No version cap (e.g. `<= 50`) is applied. OS4/MorphOS/AROS each have their own `intuition.library` binary in their own version space, all >= 45, and a cap would unnecessarily exclude them and any future OS3 v48+.

## Testing

All five Docker images build cleanly with zero new warnings on `display.c`:

- `docker run --rm -v ${PWD}:/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 program debug=no`
- `docker run --rm -v ${PWD}:/work -w /work/source sacredbanana/amiga-compiler:ppc-amigaos make os4 program debug=no`
- `docker run --rm -v ${PWD}:/work -w /work/source sacredbanana/amiga-compiler:ppc-morphos make mos program debug=no`
- `docker run --rm -v ${PWD}:/work -w /work/source midwan/aros-compiler:i386-aros make i386-aros program debug=no`
- `docker run --rm -v ${PWD}:/work -w /work/source midwan/aros-compiler:x86_64-aros make x86_64-aros program debug=no`

Resulting binaries:
- `bin.os3/DirectoryOpus`            513,620 B
- `bin.os4/DirectoryOpus`          1,015,876 B
- `bin.mos/DirectoryOpus`          1,100,588 B
- `bin.i386-aros/DirectoryOpus`    2,409,060 B
- `bin.x86_64-aros/DirectoryOpus`  8,347,824 B

ChangeLog entry added under `[dopus5allamigas next]`.