### PR TITLE
loaddb: detach launched DOpus from caller's CLI streams (#56)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,21 @@
+[dopus5allamigas next] LoadDB: detach launched DOpus from caller's CLI streams
+Program remains at 5.100.  LoadDB ships in v65r3.
+
+Source / Misc/C/loadwb/loaddb.c:
+- launch_detached() now opens explicit NIL: filehandles for SYS_Input,
+  SYS_Output and SYS_Error before calling SystemTags(... SYS_Asynch=TRUE
+  ...).  Previously it passed 0 for all three, which under the dos.library
+  contract makes System() clone the caller's Input()/Output() handles for
+  the new asynchronous process.  Those clones kept the parent shell's
+  console handler referenced, so the user's Shell window could not be
+  closed until DOpus5 itself quit, even though LoadDB had already
+  returned (issue #56).
+- The launched DOpus5 now holds zero references to the caller's CLI
+  streams, so the Shell that ran LoadDB exits normally as soon as
+  LoadDB returns.  Same fix applies to the LoadWB fallback path.
+- Resolves #56.
+2026-05-06 by Dimitris Panokostas <midwan@gmail.com>
+
 [dopus5allamigas next] display.c: runtime version check for SA_OffScreenDragging
 Program remains at 5.100.  No module version changes.
 

--- a/source/Include/dopus/version.h
+++ b/source/Include/dopus/version.h
@@ -24,7 +24,7 @@
 
 // set the commands version/revision (viewfont, dopusrt5, loadwb)
 #define CMD_VERSION    65
-#define CMD_REVISION   2
+#define CMD_REVISION   3
 
 // set platform identification
 #ifdef DEBUG

--- a/source/Misc/C/loadwb/loaddb.c
+++ b/source/Misc/C/loadwb/loaddb.c
@@ -246,23 +246,47 @@ int main(int argc, char **arg_string)
 	return (0);
 }
 
-// Launch without keeping the startup shell/script process or its files open
+// Launch without keeping the startup shell/script process or its files open.
+//
+// SystemTags() in async mode (SYS_Asynch=TRUE) takes ownership of the input/
+// output/error filehandles and closes them when the launched command exits.
+// If we pass 0 for those tags, dos.library clones the *caller's* Input() and
+// Output() handles for the new process - which keeps the parent CLI/shell
+// pinned open until DOpus exits, even though LoadDB itself has already
+// returned (see issue #56). Open explicit NIL: streams instead so the
+// launched process holds zero references to our shell.
 BOOL launch_detached(char *command)
 {
-	return (SystemTags(command,
-					   SYS_Input,
-					   0,
-					   SYS_Output,
-					   0,
-					   DETACH_Error,
-					   0,
-					   SYS_Asynch,
-					   TRUE,
-					   SYS_UserShell,
-					   TRUE,
-					   NP_Cli,
-					   TRUE,
-					   TAG_DONE) != -1);
+	BPTR nil_in = 0, nil_out = 0, nil_err = 0;
+	BOOL ok = FALSE;
+
+	nil_in  = Open("NIL:", MODE_OLDFILE);
+	nil_out = Open("NIL:", MODE_NEWFILE);
+	nil_err = Open("NIL:", MODE_NEWFILE);
+
+	if (nil_in && nil_out && nil_err)
+	{
+		ok = (SystemTags(command,
+						 SYS_Input,     nil_in,
+						 SYS_Output,    nil_out,
+						 DETACH_Error,  nil_err,
+						 SYS_Asynch,    TRUE,
+						 SYS_UserShell, TRUE,
+						 NP_Cli,        TRUE,
+						 TAG_DONE) != -1);
+	}
+
+	if (!ok)
+	{
+		// SystemTags failed (or NIL: open failed); we still own the handles.
+		if (nil_in)  Close(nil_in);
+		if (nil_out) Close(nil_out);
+		if (nil_err) Close(nil_err);
+	}
+	// On success, SystemTags() owns the handles and closes them when the
+	// async command finishes.
+
+	return ok;
 }
 
 // See if Workbench is running


### PR DESCRIPTION
## Summary

Fixes #56.

The previous LoadDB detach fix (commit `bcfbe0a`, "Fix LoadDB startup detaching") replaced `Execute()` with `SystemTags(... SYS_Asynch=TRUE ...)` so LoadDB would return immediately to the calling shell. However it kept passing `0` for `SYS_Input`, `SYS_Output` and `SYS_Error`.

Per the AmigaOS `dos.library` autodoc for `SystemTagList()`:

> **SYS_Input** — Filehandle to use as Input. **Defaults to a copy of `Input()`.** Closed by `System()` when finished.
> **SYS_Output** — Default is NULL, in which case **`System()` will use a copy of `Output()`.** Closed by `System()` when finished.

So when LoadDB passed `0`/NULL, `dos.library` cloned the *parent shell's* `Input()` / `Output()` handles for the new async DirectoryOpus process. Those clones referenced the shell's console handler, so the Shell window could not be closed until DOpus5 itself eventually exited — exactly the symptom in #56.

## Fix

`launch_detached()` in `source/Misc/C/loadwb/loaddb.c` now opens explicit `NIL:` filehandles for input/output/error and hands them to `SystemTags()`. The launched DirectoryOpus holds zero references to the caller's CLI streams, so the Shell exits normally as soon as LoadDB returns.

If `Open("NIL:", ...)` or `SystemTags()` fails, we close the handles ourselves; on success `SystemTags()` owns them and closes them when DirectoryOpus eventually exits. The `LoadWB` fallback path uses the same helper, so it is covered too.

Bumps `CMD_REVISION` 2 → 3.

#### Test plan

- [x] OS3 (m68k) clean build via `sacredbanana/amiga-compiler:m68k-amigaos`
- [x] OS4 (PPC) clean build via `sacredbanana/amiga-compiler:ppc-amigaos`
- [x] MorphOS clean build via `sacredbanana/amiga-compiler:ppc-morphos`
- [x] AROS i386 clean build via `midwan/aros-compiler:i386-aros`
- [x] AROS x86_64 clean build via `midwan/aros-compiler:x86_64-aros`
- [x] All five binaries report `\$VER: LoadDB 65.3 [...]`
- [x] Non-debug release archive `DOpus5_100_os3.lha` built with `make os3 release debug=no log=yes` and tested on AmigaOS 3 — the parent Shell now closes cleanly after `LoadDB` returns and DirectoryOpus stays running.