### PR TITLE
docs(headers): clarify ID_OPUS vs ID_EPUS FORM ids (#60)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,26 @@
+[dopus5allamigas next] dopus5.h / dopus_config.h: document OPUS vs EPUS FORM ids
+Program remains at 5.100.  No module version changes.  Comment-only.
+
+Source / Include/libraries/dopus5.h, Program/dopus_config.h:
+- The ID_OPUS / ID_EPUS macros only had a single-line comment ("Opus
+  FORM" / "Opus Environment FORM") that no longer reflected reality:
+  ID_EPUS is also written by button banks (Buttons / Hotkeys / Start
+  Menu) and the configopus environment converter, not just the
+  Environment file.  Anyone trying to write a Filetype recognition
+  rule (issue #60) had no way to tell from the headers that DOpus 5
+  config files come in two flavours.
+- Both headers now spell out that ID_OPUS == legacy schema (the
+  convert_env / convert_button_window / convert_open_lister
+  migrations in config_open.c kick in on read) and ID_EPUS ==
+  current schema (read straight via L_IFFReadChunkBytes).  The
+  long-form block lives in libraries/dopus5.h; dopus_config.h has
+  a TL;DR plus a pointer to it.
+- Each macro line still has its original short trailing comment,
+  updated to "Opus FORM (current schema)" / "Opus FORM (legacy
+  schema, migrated on read)" so casual greps still see what's what.
+- Resolves #60.
+2026-05-06 by Dimitris Panokostas <midwan@gmail.com>
+
 [dopus5allamigas next] LoadDB: detach launched DOpus from caller's CLI streams
 Program remains at 5.100.  LoadDB ships in v65r3.
 

--- a/source/Include/libraries/dopus5.h
+++ b/source/Include/libraries/dopus5.h
@@ -117,8 +117,22 @@ enum {
 						  IFF Configuration Storage
  ****************************************************************************/
 
-#define ID_EPUS MAKE_ID('E', 'P', 'U', 'S')	 // Opus Environment FORM
-#define ID_OPUS MAKE_ID('O', 'P', 'U', 'S')	 // Opus FORM
+// Opus FORM ids.  Both identify a Directory Opus 5 IFF config file; the
+// difference is which on-disk struct schema is used:
+//   ID_OPUS  = legacy schema (CFG_ENVR/CFG_BTNW/CFG_LSTR pre-extension).
+//              Readers in config_open.c run a convert_*() migration to
+//              the current in-memory layout.  Settings, filetype lists,
+//              position-info, FTP address books, exported function files
+//              and clipboard copy/paste still write this id.
+//   ID_EPUS  = current schema (extended structs read directly via
+//              L_IFFReadChunkBytes).  Originally introduced for the
+//              environment file (hence the historical "E"); now also
+//              written by button banks (Buttons / Hotkeys / Start Menu)
+//              and the configopus environment converter.
+// File-type recognition rules that want to identify any DOpus 5 config
+// file should match FORM == OPUS *or* FORM == EPUS.
+#define ID_EPUS MAKE_ID('E', 'P', 'U', 'S')	 // Opus FORM (current schema)
+#define ID_OPUS MAKE_ID('O', 'P', 'U', 'S')	 // Opus FORM (legacy schema, migrated on read)
 #define ID_BTBK MAKE_ID('B', 'T', 'B', 'K')	 // Button bank to open
 #define ID_BANK MAKE_ID('B', 'A', 'N', 'K')	 // Button bank to open
 #define ID_BTNW MAKE_ID('B', 'T', 'N', 'W')	 // Button window

--- a/source/Program/dopus_config.h
+++ b/source/Program/dopus_config.h
@@ -145,8 +145,14 @@ enum {
 						  IFF Configuration Storage
  ****************************************************************************/
 
-#define ID_EPUS MAKE_ID('E', 'P', 'U', 'S')	 // Opus Environment FORM
-#define ID_OPUS MAKE_ID('O', 'P', 'U', 'S')	 // Opus FORM
+// Opus FORM ids.  Both identify a Directory Opus 5 IFF config file; the
+// difference is which on-disk struct schema is used.  See the matching
+// block in libraries/dopus5.h for the full explanation.  TL;DR:
+//   ID_OPUS = legacy schema, reader migrates structs via convert_*().
+//   ID_EPUS = current schema, structs read directly.
+// Filetype recognition should match FORM == OPUS *or* FORM == EPUS.
+#define ID_EPUS MAKE_ID('E', 'P', 'U', 'S')	 // Opus FORM (current schema)
+#define ID_OPUS MAKE_ID('O', 'P', 'U', 'S')	 // Opus FORM (legacy schema, migrated on read)
 #define ID_BTBK MAKE_ID('B', 'T', 'B', 'K')	 // Button bank to open
 #define ID_BANK MAKE_ID('B', 'A', 'N', 'K')	 // Button bank to open
 #define ID_BTNW MAKE_ID('B', 'T', 'N', 'W')	 // Button window


### PR DESCRIPTION
## Summary

Resolves #60.

DOpus 5 IFF config files come in two FORM-id flavours and the headers
didn't make that obvious. The `ID_EPUS` macro had a `// Opus Environment
FORM` trailing comment, which made sense when EPUS was used only for the
Environment file but is now stale: EPUS is also written by button banks
(Buttons / Hotkeys / Start Menu) and the configopus environment
converter. Anyone trying to author a Filetype recognition rule (which is
what @EctoOne was doing in #60) had no way to tell from the headers that
DOpus 5 configs come in two flavours and need both ids matched.

This PR rewrites the comment block above `ID_OPUS` / `ID_EPUS` in both
`source/Include/libraries/dopus5.h` and `source/Program/dopus_config.h`
to spell out the actual semantics:

- `ID_OPUS` = legacy on-disk schema; readers in `config_open.c` run a
  `convert_*()` migration (`convert_env`, `convert_button_window`,
  `convert_open_lister`) to upgrade the structs into the current
  in-memory layout. Still written by Settings, the filetype list,
  position-info, the FTP address book, exported function files and
  clipboard copy/paste.
- `ID_EPUS` = current on-disk schema; structs are read directly via
  `L_IFFReadChunkBytes`. Originally introduced for the Environment file
  (hence the historical *E*); now also written by button banks and the
  configopus environment converter.

Each macro line still has its short trailing comment, updated to
`Opus FORM (current schema)` / `Opus FORM (legacy schema, migrated on
read)` so casual greps still see what's what. The long-form block lives
in `libraries/dopus5.h`; `dopus_config.h` carries a TL;DR plus a pointer
to it.

The block also explicitly tells anyone authoring a Filetype rule to
match `FORM == OPUS *or* FORM == EPUS`, which is what @EctoOne wanted to
know in #60 and is the only correct answer (OPUS-format files exist in
the wild and always will).

#### Test plan

- [x] `git diff` shows changes are confined to comments + ChangeLog.
- [x] No `MAKE_ID` value, struct, or chunk handler touched.
- [x] No build run because the change is C `//` line comments inside
      files that already use `//` comments throughout — there is no
      mechanism by which it could affect compilation or behaviour.
- [x] Followed the project's `[dopus5allamigas next]` ChangeLog
      convention with a comment-only entry that points at #60.