### PR TITLE
Fix OS3 titlebar height handling

### DIFF
--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -36,6 +36,48 @@ void calc_daymonyr(long days, long *day, long *month, long *year);
 #define MOON_BIG_SIZE 13
 #define MOON_SMALL_SIZE 9
 
+#ifndef USE_SCREENTITLE
+struct ClockTitleBarMetrics
+{
+	short height;
+	short text_y;
+	short fill_bottom;
+};
+
+static struct ClockTitleBarMetrics clock_titlebar_metrics = {0, 0, 0};
+
+static void clock_titlebar_set_metrics(struct Screen *screen, struct RastPort *rp)
+{
+	short height = rp->TxHeight + 2;
+	short text_y = rp->TxBaseline + 1;
+	short fill_bottom = height - 1;
+
+#ifdef __amigaos3__
+	if (screen && ((struct Library *)IntuitionBase)->lib_Version >= 47 && screen->BarHeight > 0)
+	{
+		height = screen->BarHeight + 1;
+
+		if (height > rp->TxHeight)
+			text_y = ((height - rp->TxHeight) >> 1) + rp->TxBaseline;
+
+		fill_bottom = height - 2;
+	}
+#endif
+
+	clock_titlebar_metrics.height = height;
+	clock_titlebar_metrics.text_y = text_y;
+	clock_titlebar_metrics.fill_bottom = fill_bottom;
+}
+
+static short clock_titlebar_image_y(short image_height)
+{
+	if (clock_titlebar_metrics.height > image_height)
+		return (clock_titlebar_metrics.height - image_height) >> 1;
+
+	return 0;
+}
+#endif
+
 #ifdef __amigaos4__
 APTR clock_show_custom_title(struct RastPort *rp,
 							 long clock_x,
@@ -181,6 +223,10 @@ IPC_EntryCode(clock_proc)
 
 								// Free draw info
 								FreeScreenDrawInfo(screen, drawinfo);
+
+#ifndef USE_SCREENTITLE
+								clock_titlebar_set_metrics(screen, &clock_rp);
+#endif
 
 								// Get position to render clock
 								bar_x = screen->Width - 16;
@@ -390,7 +436,7 @@ IPC_EntryCode(clock_proc)
 					if (window || layer)
 					{
 						short hours, seconds;
-						unsigned long minutes;
+						ULONG minutes;
 
 						// Get current datestamp
 						DateStamp(&date.dat_Stamp);
@@ -501,7 +547,7 @@ IPC_EntryCode(clock_proc)
 									if (GUI->flags & GUIF_CLOCK)
 									{
 #ifndef USE_SCREENTITLE
-										Move(&clock_rp, clock_x, clock_rp.TxBaseline + 1);
+										Move(&clock_rp, clock_x, clock_titlebar_metrics.text_y);
 										Text(&clock_rp, titlebuf, strlen(titlebuf));
 #endif
 
@@ -654,7 +700,7 @@ void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 
 #ifndef USE_SCREENTITLE
 	// Render text
-	Move(rp, 5, rp->Font->tf_Baseline + 1);
+	Move(rp, 5, clock_titlebar_metrics.text_y);
 	Text(rp, GUI->screen_title, strlen(GUI->screen_title));
 
 	// Erase to start of clock text
@@ -665,7 +711,7 @@ void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 		// Save front pen
 		fp = rp->FgPen;
 		SetAPen(rp, rp->BgPen);
-		RectFill(rp, rp->cp_x, 0, clock_x - 1, rp->Font->tf_YSize + 1);
+		RectFill(rp, rp->cp_x, 0, clock_x - 1, clock_titlebar_metrics.fill_bottom);
 		SetAPen(rp, fp);
 	}
 #endif
@@ -719,12 +765,10 @@ APTR clock_show_custom_title(struct RastPort *rp,
 							 struct Library *SysInfoBase)
 #endif
 {
-	char *ptr, *format, *title_buffer;
+	char *ptr, *title_buffer;
 	short pos = 0, moon_day = -1, moon_pos = 0;
 	struct BitMap bm;
 
-	// Get numeric formatting string
-	format = (environment->env->settings.date_flags & DATE_1000SEP && GUI->flags & GUIF_LOCALE_OK) ? "%lU" : "%ld";
 	title_buffer = GUI->screen_title;
 
 	// Go through title text
@@ -1045,7 +1089,6 @@ APTR clock_show_custom_title(struct RastPort *rp,
 				{
 					// memory values should always be unsigned
 					lsprintf(buf, "%lu", memval);
-					// lsprintf(buf,format,memval);
 				}
 			}
 
@@ -1072,7 +1115,7 @@ APTR clock_show_custom_title(struct RastPort *rp,
 
 	// Render text
 #ifndef USE_SCREENTITLE
-	Move(rp, 5, rp->Font->tf_Baseline + 1);
+	Move(rp, 5, clock_titlebar_metrics.text_y);
 	Text(rp, title_buffer, (moon_day > -1) ? moon_pos : strlen(title_buffer));
 
 	// Moon to show?
@@ -1132,10 +1175,10 @@ APTR clock_show_custom_title(struct RastPort *rp,
 		}
 
 		// Draw moon
-		BltBitMapRastPort(&bm, 0, 0, rp, x, (rp->TxHeight + 2 - size) >> 1, size, size, 0xc0);
+		BltBitMapRastPort(&bm, 0, 0, rp, x, clock_titlebar_image_y(size), size, size, 0xc0);
 
 		// Draw the rest of the text
-		Move(rp, x + size, rp->Font->tf_Baseline + 1);
+		Move(rp, x + size, clock_titlebar_metrics.text_y);
 		if ((x = strlen(title_buffer) - moon_pos - 2) > 0)
 			Text(rp, title_buffer + moon_pos + 2, x);
 	}
@@ -1148,7 +1191,7 @@ APTR clock_show_custom_title(struct RastPort *rp,
 		// Save front pen
 		fp = rp->FgPen;
 		SetAPen(rp, rp->BgPen);
-		RectFill(rp, rp->cp_x, 0, clock_x - 1, rp->Font->tf_YSize + 1);
+		RectFill(rp, rp->cp_x, 0, clock_x - 1, clock_titlebar_metrics.fill_bottom);
 		SetAPen(rp, fp);
 	}
 #endif

--- a/source/Program/tests/test_clock_task_warnings.py
+++ b/source/Program/tests/test_clock_task_warnings.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Regression checks for warning-prone clock_task.c code."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CLOCK_TASK_C = ROOT / "source" / "Program" / "clock_task.c"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+class ClockTaskWarningTests(unittest.TestCase):
+    def test_divideu_remainder_uses_ulong_storage(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("ULONG minutes;", source)
+        self.assertIn("&minutes, UtilityBase", source)
+        self.assertNotIn("unsigned long minutes;", source)
+
+    def test_custom_title_has_no_dead_format_variable(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("char *ptr, *title_buffer;", source)
+        self.assertNotIn("char *ptr, *format, *title_buffer;", source)
+        self.assertNotIn("format =", source)
+        self.assertNotIn("lsprintf(buf,format,memval)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/Program/tests/test_screen_titlebar_offsets.py
+++ b/source/Program/tests/test_screen_titlebar_offsets.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression checks for OS3 screen title-bar vertical centering."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CLOCK_TASK_C = ROOT / "source" / "Program" / "clock_task.c"
+PROTOS_H = ROOT / "source" / "Program" / "protos.h"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+class ScreenTitleBarOffsetTests(unittest.TestCase):
+    def test_os3_v47_centers_text_in_extra_height_titlebar(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("struct ClockTitleBarMetrics", source)
+        self.assertIn("clock_titlebar_set_metrics(struct Screen *screen, struct RastPort *rp)", source)
+        self.assertIn("((struct Library *)IntuitionBase)->lib_Version >= 47", source)
+        self.assertIn("height = screen->BarHeight + 1", source)
+        self.assertIn("((height - rp->TxHeight) >> 1) + rp->TxBaseline", source)
+        self.assertNotIn("screen->BarVBorder + rp->TxBaseline", source)
+
+    def test_titlebar_metrics_are_cached_from_screen_height(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("struct ClockTitleBarMetrics clock_titlebar_metrics", source)
+        self.assertIn("clock_titlebar_set_metrics(screen, &clock_rp)", source)
+        self.assertIn("clock_titlebar_metrics.height = height", source)
+        self.assertIn("clock_titlebar_metrics.text_y = text_y", source)
+        self.assertIn("clock_titlebar_metrics.fill_bottom = fill_bottom", source)
+        self.assertIn("fill_bottom = height - 2", source)
+        self.assertNotIn("clock_titlebar_height(struct Screen *screen, struct RastPort *rp)", source)
+        self.assertNotIn("clock_titlebar_fill_height", source)
+
+    def test_screen_titlebar_draw_paths_use_centered_helpers(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("Move(&clock_rp, clock_x, clock_titlebar_metrics.text_y)", source)
+        self.assertIn("Move(rp, 5, clock_titlebar_metrics.text_y)", source)
+        self.assertIn("clock_titlebar_image_y(size)", source)
+        self.assertIn("RectFill(rp, rp->cp_x, 0, clock_x - 1, clock_titlebar_metrics.fill_bottom)", source)
+
+    def test_screen_titlebar_draw_paths_do_not_clear_full_width_on_refresh(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertNotIn("clock_clear_titlebar_region", source)
+
+    def test_os3_v47_erase_preserves_titlebar_trim_line(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("short fill_bottom = height - 1", source)
+        self.assertIn("fill_bottom = height - 2", source)
+
+    def test_titlebar_render_functions_do_not_recompute_screen_metrics(self):
+        source = read_source(CLOCK_TASK_C)
+        protos = read_source(PROTOS_H)
+
+        self.assertIn("void clock_show_memory(struct RastPort *, long, long, char *);", protos)
+        self.assertIn("clock_show_memory(&clock_rp", source)
+        self.assertIn("&clock_rp", source)
+        self.assertIn("clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)", source)
+        self.assertNotIn("clock_show_memory(struct Screen *screen", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Cache screen titlebar metrics when DOpus attaches to the screen bar, using Intuition's effective `Screen->BarHeight` value on OS3 v47+.
- Use the cached metrics for title text, clock text, moon image centering, and erase bounds so refreshes do not recalculate or redraw extra titlebar geometry.
- Remove two `clock_task.c` warnings by using `ULONG` for the `DivideU` remainder and deleting a dead custom-title `format` variable.
- Add focused regression checks for OS3 titlebar centering, trim-line preservation, cached metrics, and the warning fixes.

## Context

Related to #67. The root issue is that newer OS3 titlebar geometry can include extra titlebar height from system prefs, while DOpus was positioning its manually rendered titlebar text from fixed font-derived offsets. The fix reads the effective screen bar height once for the attached screen and keeps subsequent clock/title refreshes on stable cached coordinates to avoid bringing back flicker.

## Validation

- `python3 source/Program/tests/test_clock_task_warnings.py`
- `python3 source/Program/tests/test_screen_titlebar_offsets.py`
- `python3 source/Modules/format/tests/test_lnfs_gate.py`
- `git diff --cached --check`
- OS3 build via `docker run --rm -v "$PWD":/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make -C Program -f makefile.os3 debug=no`
- Targeted `clock_task.c` OS3 compile emitted no warnings after the warning cleanup

Visual validation still needs local OS3 testing with different Extra Title Bar Height prefs values.