### PR TITLE
Use locale separator for title memory values

### DIFF
--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -1060,7 +1060,7 @@ APTR clock_show_custom_title(struct RastPort *rp,
 				else
 				{
 					// memory values should always be unsigned
-					lsprintf(buf, "%lu", memval);
+					ItoaU(memval, buf, (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 				}
 			}
 

--- a/source/Program/tests/test_clock_task_warnings.py
+++ b/source/Program/tests/test_clock_task_warnings.py
@@ -29,6 +29,12 @@ class ClockTaskWarningTests(unittest.TestCase):
         self.assertNotIn("format =", source)
         self.assertNotIn("lsprintf(buf,format,memval)", source)
 
+    def test_custom_title_plain_memory_values_use_locale_separator(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("ItoaU(memval,", source)
+        self.assertNotIn('lsprintf(buf, "%lu", memval);', source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Apply the locale thousands separator setting to plain Custom Title Format memory values, matching the scaled K/M/G/S forms.
- Add regression coverage for the raw byte memory formatting path.

## Root cause
Plain memory values in the custom title formatter used lsprintf("%lu"), bypassing the existing DATE_1000SEP and GUI->decimal_sep formatting path.

## Issue
Addresses #81.

## Testing
- python3 source/Program/tests/test_clock_task_warnings.py
- python3 source/Program/tests/test_resize_to_fit_menu.py
- python3 source/Program/tests/test_screen_titlebar_offsets.py
- python3 source/Modules/configopus/tests/test_screen_title_codes.py
- python3 source/Modules/configopus/tests/test_lister_options_layout.py
- python3 source/Modules/format/tests/test_lnfs_gate.py
- python3 source/Modules/about/tests/test_about_requester.py
- docker run --rm -v /Users/midwan/Github/dopus5:/work sacredbanana/amiga-compiler:m68k-amigaos sh -c 'cd /work/source && make os3 clean && make os3 all'