### PR TITLE
Fix AROS64 XADOpen, File Types and CLI issues

### DIFF
--- a/source/Modules/configopus/config_filetypes.c
+++ b/source/Modules/configopus/config_filetypes.c
@@ -1,6 +1,26 @@
 #include "config_lib.h"
 #include "config_filetypes.h"
 
+static BOOL filetypes_saved_size_matches_font(struct Screen *screen, short fontsize)
+{
+	struct Screen *pub = 0;
+	short current_size = 0;
+
+	if (!screen)
+	{
+		if (!(pub = LockPubScreen(0)))
+			return FALSE;
+		screen = pub;
+	}
+
+	current_size = screen->RastPort.TxHeight;
+
+	if (pub)
+		UnlockPubScreen(0, pub);
+
+	return (current_size == fontsize);
+}
+
 short LIBFUNC L_Config_Filetypes(REG(a0, struct Screen *screen),
 								 REG(a1, IPCData *ipc),
 								 REG(a2, IPCData *owner_ipc),
@@ -40,7 +60,7 @@ short LIBFUNC L_Config_Filetypes(REG(a0, struct Screen *screen),
 	dims = _config_filetypes_window;
 
 	// Get saved position
-	if (LoadPos("dopus/windows/filetypes", &pos, &fontsize))
+	if (LoadPos("dopus/windows/filetypes", &pos, &fontsize) && filetypes_saved_size_matches_font(screen, fontsize))
 	{
 		dims.char_dim.Width = 0;
 		dims.char_dim.Height = 0;

--- a/source/Modules/configopus/tests/test_filetypes_window_restore.py
+++ b/source/Modules/configopus/tests/test_filetypes_window_restore.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Regression checks for File Types saved window size handling."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[4]
+FILETYPES_C = ROOT / "source" / "Modules" / "configopus" / "config_filetypes.c"
+
+
+def read_source():
+    return FILETYPES_C.read_text(encoding="latin-1")
+
+
+class FiletypesWindowRestoreTests(unittest.TestCase):
+    def test_saved_size_is_used_only_for_matching_font_size(self):
+        source = read_source()
+        load_pos = source.index('LoadPos("dopus/windows/filetypes"')
+        saved_width = source.index("dims.fine_dim.Width = pos.Width;", load_pos)
+        guarded_block = source[load_pos:saved_width]
+
+        self.assertIn("filetypes_saved_size_matches_font(screen, fontsize)", guarded_block)
+        self.assertIn("screen->RastPort.TxHeight", source)
+
+    def test_filetypes_window_size_is_still_persisted(self):
+        source = read_source()
+
+        self.assertIn('LoadPos("dopus/windows/filetypes"', source)
+        self.assertIn('SavePos("dopus/windows/filetypes"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/Modules/xadopus/XADopus.c
+++ b/source/Modules/xadopus/XADopus.c
@@ -23,6 +23,38 @@ char *viewcmds = "Read Play Show HexRead AnsiRead IconInfo";
 
 LIBFUNC ULONG ASM SAVEDS L_ProgressHook(REG(a0, struct Hook *), REG(a2, int skip), REG(a1, struct xadProgressInfo *));
 
+static IPTR xad_parse_handle(const char *text)
+{
+	UQUAD value = 0;
+
+	if (!text)
+		return 0;
+
+	while (*text >= '0' && *text <= '9')
+	{
+		value = (value * 10) + (*text - '0');
+		++text;
+	}
+
+	return (IPTR)value;
+}
+
+static void xad_format_handle(char *buf, IPTR handle)
+{
+	char tmp[24];
+	int pos = sizeof(tmp) - 1;
+	UQUAD value = (UQUAD)handle;
+
+	tmp[pos] = 0;
+	do
+	{
+		tmp[--pos] = '0' + (value % 10);
+		value /= 10;
+	} while (value && pos > 0);
+
+	strcpy(buf, tmp + pos);
+}
+
 /// Error Requester
 void ErrorReq(struct xoData *data, char *Mess)
 {
@@ -1204,10 +1236,10 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 		/*if(!(data.destp = data.hook.dc_GetDest(IPCDATA(ipc), data.listpath))) return(0);
 		data.hook.dc_EndDest(IPCDATA(ipc), 0);*/
 
-		data.listh = (ULONG)data.listp2->lister;
+		data.listh = (IPTR)data.listp2->lister;
 		data.listw = (APTR)DC_CALL1(infoptr, dc_GetWindow, DC_REGA0, data.listp2);
 		// data.listw = data.hook.dc_GetWindow(data.listp2);
-		sprintf(data.lists, "%lu", data.listh);
+		xad_format_handle(data.lists, data.listh);
 
 		sprintf(buf, "lister query %s numselentries", data.lists);
 		total = DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(ipc), DC_REGA1, buf, DC_REGA2, NULL, DC_REGD0, 0);
@@ -1283,7 +1315,7 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 					default:
 						xadFreeInfo(data.ArcInf);
 						ti[0].ti_Tag = XAD_INFILENAME;
-						ti[0].ti_Data = (ULONG)arcname;
+						ti[0].ti_Data = (IPTR)arcname;
 						ti[1].ti_Tag = TAG_DONE;
 						if (!(err = xadGetDiskInfo(data.ArcInf, XAD_INDISKARCHIVE, (IPTR)ti, TAG_DONE)))
 							over = ExtractF(&data);
@@ -1308,7 +1340,8 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 					AddPart(arcname, Entry->name, 512);
 				}
 			}
-			sprintf(buf, "command source %lu ScanDir %s", (ULONG)data.destp->lister, data.destp->path);
+			xad_format_handle(data.lists, (IPTR)data.destp->lister);
+			sprintf(buf, "command source %s ScanDir %s", data.lists, data.destp->path);
 			DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(ipc), DC_REGA1, buf, DC_REGA2, NULL, DC_REGD0, 0);
 			// data.hook.dc_SendCommand(IPCDATA(ipc),buf,NULL,NULL);
 
@@ -1327,7 +1360,7 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 	data.hook.dc_EndEntry(IPCDATA(ipc), Entry, TRUE);
 	data.hook.dc_UnlockSource(IPCDATA(ipc));*/
 
-	//		data.listh = (ULONG)data.listp2->lister;
+	//		data.listh = (IPTR)data.listp2->lister;
 	//		sprintf(data.lists, "%d", data.listh);
 
 	if (!DC_CALL4(infoptr,
@@ -1342,9 +1375,24 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 				  COMMANDF_RESULT))
 	// if(!data.hook.dc_SendCommand(IPCDATA(ipc), "lister new", &result, COMMANDF_RESULT))
 	{
-		strcpy(data.lists, result);
-		data.listh = atol(result);
+		if (!result)
+		{
+			FreeMemHandle(data.rhand);
+			RemoveTemp(&data);
+			return 0;
+		}
+
+		data.listh = xad_parse_handle(result);
 		FreeVec(result);
+
+		if (!data.listh)
+		{
+			FreeMemHandle(data.rhand);
+			RemoveTemp(&data);
+			return 0;
+		}
+
+		xad_format_handle(data.lists, data.listh);
 
 		//		ErrorReq(&data, data.lists); // *********************
 
@@ -1399,7 +1447,7 @@ int LIBFUNC L_Module_Entry(REG(a0, char *args),
 
 					xadFreeInfo(data.ArcInf);
 					ti[0].ti_Tag = XAD_INFILENAME;
-					ti[0].ti_Data = (ULONG)arcname;
+					ti[0].ti_Data = (IPTR)arcname;
 					ti[1].ti_Tag = TAG_DONE;
 					err = xadGetDiskInfo(data.ArcInf, XAD_INDISKARCHIVE, (IPTR)ti, TAG_DONE);
 				}

--- a/source/Modules/xadopus/XADopus.h
+++ b/source/Modules/xadopus/XADopus.h
@@ -35,7 +35,7 @@
 
 struct function_entry
 {
-	ULONG pad[2];
+	struct MinNode node;
 	char *name;	  // File name
 	APTR entry;	  // Entry pointer (don't touch!)
 	short type;	  // Type of file
@@ -44,7 +44,7 @@ struct function_entry
 
 struct path_node
 {
-	ULONG pad[2];
+	struct MinNode node;
 	char buffer[512];  // Contains path string
 	char *path;		   // Points to path string
 	APTR lister;	   // Lister pointer
@@ -62,8 +62,9 @@ struct Tree
 
 struct xoData
 {
-	ULONG ArcMode, listh;
-	char lists[20], listpath[512], rootpath[108];
+	ULONG ArcMode;
+	IPTR listh;
+	char lists[24], listpath[512], rootpath[108];
 	struct xadArchiveInfo *ArcInf;
 	struct MsgPort *mp;
 	char mp_name[20];

--- a/source/Modules/xadopus/tests/test_aros64_callback_layout.py
+++ b/source/Modules/xadopus/tests/test_aros64_callback_layout.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression checks for xadopus callback structures on pointer-sized ABIs."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[4]
+XADOPUS_H = ROOT / "source" / "Modules" / "xadopus" / "XADopus.h"
+XADOPUS_C = ROOT / "source" / "Modules" / "xadopus" / "XADopus.c"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+def struct_body(source, name):
+    pattern = r"struct\s+" + re.escape(name) + r"\s*\{(?P<body>.*?)\n\};"
+    match = re.search(pattern, source, re.S)
+    if not match:
+        raise AssertionError(f"Could not find struct {name}")
+    return match.group("body")
+
+
+class XADopusAROS64LayoutTests(unittest.TestCase):
+    def test_callback_nodes_use_real_min_nodes(self):
+        source = read_source(XADOPUS_H)
+
+        for name in ("function_entry", "path_node"):
+            body = struct_body(source, name)
+            self.assertIn("struct MinNode node;", body)
+            self.assertNotIn("ULONG pad[2]", body)
+
+    def test_lister_handle_is_not_truncated_to_ulong(self):
+        header = read_source(XADOPUS_H)
+        source = read_source(XADOPUS_C)
+        data_body = struct_body(header, "xoData")
+
+        self.assertRegex(data_body, r"\bIPTR\s+listh\s*;")
+        self.assertIn("char lists[24]", data_body)
+        self.assertIn("data.listh = (IPTR)data.listp2->lister;", source)
+        self.assertIn("xad_format_handle(data.lists, data.listh);", source)
+        self.assertIn("data.listh = xad_parse_handle(result);", source)
+        self.assertNotIn("data.listh = (ULONG)data.listp2->lister;", source)
+        self.assertNotIn('sprintf(data.lists, "%lu"', source)
+        self.assertNotIn('"command source %lu', source)
+        self.assertNotIn("atol(result)", source)
+        self.assertNotIn("(ULONG)data.destp->lister", source)
+        self.assertNotIn("ti_Data = (ULONG)arcname", source)
+
+    def test_lister_handle_text_helpers_use_full_pointer_width(self):
+        source = read_source(XADOPUS_C)
+
+        self.assertRegex(source, r"static\s+IPTR\s+xad_parse_handle\(const char \*text\)")
+        self.assertRegex(source, r"static\s+void\s+xad_format_handle\(char \*buf, IPTR handle\)")
+        self.assertIn("UQUAD value = 0;", source)
+        self.assertIn("UQUAD value = (UQUAD)handle;", source)
+
+    def test_new_lister_result_is_checked_before_use(self):
+        source = read_source(XADOPUS_C)
+        result_pos = source.index('"lister new"')
+        parse_pos = source.index("data.listh = xad_parse_handle(result);")
+        block = source[result_pos : source.index("if (AllocPort(&data))", parse_pos)]
+
+        self.assertIn("if (!result)", block)
+        self.assertIn("if (!data.listh)", block)
+        self.assertIn("FreeMemHandle(data.rhand);", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/Program/function_cli.c
+++ b/source/Program/function_cli.c
@@ -51,7 +51,7 @@ void cli_free(CLIData *);
 // Internal command line interpreter
 DOPUS_FUNC(function_cli)
 {
-	CLIData data;
+	CLIData data = {0};
 	short pos = 0;
 	char ch;
 	CommandList *last_cmd = 0;
@@ -487,6 +487,9 @@ BOOL cli_open(CLIData *data)
 	// Duplicate output channel for input
 	if (!(data->input = Open("console:", MODE_OLDFILE)))
 	{
+		SelectOutput(data->old_output);
+		SelectInput(data->old_input);
+		SetConsoleTask(data->old_console);
 		Close(data->output);
 		data->output = 0;
 		return 0;
@@ -507,8 +510,10 @@ void cli_close(CLIData *data)
 	SetConsoleTask(data->old_console);
 
 	// Close input/output channels
-	Close(data->input);
-	Close(data->output);
+	if (data->input)
+		Close(data->input);
+	if (data->output)
+		Close(data->output);
 
 	// Clear handles
 	data->input = 0;
@@ -518,6 +523,8 @@ void cli_close(CLIData *data)
 // Free CLI
 void cli_free(CLIData *data)
 {
-	DeleteMsgPort(data->reply_port);
-	FreeVec(data->name);
+	if (data->reply_port)
+		DeleteMsgPort(data->reply_port);
+	if (data->name)
+		FreeVec(data->name);
 }

--- a/source/Program/tests/test_cli_console_cleanup.py
+++ b/source/Program/tests/test_cli_console_cleanup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Regression checks for the internal CLI console setup failure paths."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+FUNCTION_CLI_C = ROOT / "source" / "Program" / "function_cli.c"
+
+
+def read_source():
+    return FUNCTION_CLI_C.read_text(encoding="latin-1")
+
+
+def function_body(source, name):
+    pattern = r"\n(?:BOOL|void)\s+" + re.escape(name) + r"\([^)]*\)\s*\{(?P<body>.*?)\n\}"
+    match = re.search(pattern, source, re.S)
+    if not match:
+        raise AssertionError(f"Could not find {name}")
+    return match.group("body")
+
+
+class CLIConsoleCleanupTests(unittest.TestCase):
+    def test_cli_data_starts_zeroed(self):
+        source = read_source()
+
+        self.assertIn("CLIData data = {0};", source)
+
+    def test_input_open_failure_restores_console_state(self):
+        source = read_source()
+        body = function_body(source, "cli_open")
+        failure = body[body.index("if (!(data->input = Open(\"console:\", MODE_OLDFILE)))") :]
+
+        for expected in (
+            "SelectOutput(data->old_output);",
+            "SelectInput(data->old_input);",
+            "SetConsoleTask(data->old_console);",
+            "Close(data->output);",
+        ):
+            self.assertIn(expected, failure)
+
+    def test_cli_close_ignores_unopened_handles(self):
+        source = read_source()
+        body = function_body(source, "cli_close")
+
+        self.assertIn("if (data->input)", body)
+        self.assertIn("if (data->output)", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix XADOpen 64-bit pointer handling by using real MinNode list nodes and IPTR-safe lister handle formatting/parsing.
- Avoid restoring stale File Types window dimensions when the saved font size does not match the current screen font.
- Harden the internal CLI console setup and cleanup paths so partial open failures restore console state safely.

## Root Cause
AROS 64-bit exposed pointer-width assumptions in xadopus lister handles and callback list nodes. The File Types settings window could reuse saved dimensions from a different font scale. The CLI path could continue cleanup with uninitialized or partially initialized fields after console setup failed.

## Validation
- Ran all source Python regression tests with PYTHONDONTWRITEBYTECODE=1.
- Ran git diff --check --cached.
- Forced rebuilt Program for AROS x86_64 and i386 via Docker.
- Forced rebuilt configopus.module for AROS x86_64 and i386 via Docker.
- Attempted xadopus AROS64 Docker build; current compiler image is missing proto/xadmaster.h before module source compilation.

Fixes #90