### PR TITLE
Clarify WB title-bar option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,10 @@ Environment editor / configopus.module:
   the Benify checkbox.
 - Surfaced the existing dopus/DOSPatch ENVARC: variable as a "Live
   Folder Updates (DOS Patches)" checkbox.
+- Renamed the WB Emulation "Suppress DOpus Title Bar Clock" checkbox
+  to "Workbench-Compatible Title Bar" and expanded the guide text to
+  make clear that it enables Workbench-style title-bar patch
+  compatibility, not just the clock toggle (issue #94).
 - ftp.module's NoBeeGees migration is one-shot now: imported on
   first launch and then DeleteVar'd from ENV: / ENVARC:.
 - configopus: clean up ghost filetype data, surface missing icons,

--- a/documents/DOpus5.guide
+++ b/documents/DOpus5.guide
@@ -3800,11 +3800,12 @@ layer.
     When enabled, Opus also shows Workbench "leftout" icons on its
     desktop.
 
-  Suppress DOpus Title Bar Clock:
-    Stops Opus from drawing its own clock in the screen title bar so
-    that other Workbench-style title-bar patches (e.g. ToolManager,
-    custom-clock commodities) can use the space.  Replaces the legacy
-    dopus/WorkbenchTitle env variable.
+  Workbench-Compatible Title Bar:
+    Stops Opus from drawing/updating its own screen-title contents
+    (memory counter, custom title text, and optional clock).  Opus
+    instead publishes a Workbench-style title so other title-bar patches
+    (e.g. ToolManager, custom-clock commodities) can intercept it.
+    Replaces the legacy dopus/WorkbenchTitle env variable.
 
   Use Workbench Icon Information:
     When set, the icon-information popup is routed through
@@ -4202,7 +4203,7 @@ system.
 @{b}@{fg shine}@{bg text} dopus/WorkbenchTitle @{bg background}@{fg text}@{ub}
 
        Now: Environment editor -> WB Emulation ->
-       "Suppress DOpus Title Bar Clock".
+       "Workbench-Compatible Title Bar".
 
 @{b}@{fg shine}@{bg text} dopus/UseWBInfo @{bg background}@{fg text}@{ub}
 

--- a/source/Include/libraries/dopus5.h
+++ b/source/Include/libraries/dopus5.h
@@ -400,7 +400,7 @@ enum {
 #define DISPOPTF_REALTIME_SCROLL (1 << 10)	// Real-time icon scrolling
 #define DISPOPTF_THIN_BORDERS (1 << 11)		// Thin borders
 #define DISPOPTF_SHOW_WBLEFTOUTS (1 << 12)	// show workbench's leftout icons from the .backdrop files
-#define DISPOPTF_WB_TITLE (1 << 13)			// Suppress DOpus title-bar clock so WB-style patches can use it
+#define DISPOPTF_WB_TITLE (1 << 13)			// Workbench-compatible title bar mode for WB-style patches
 #define DISPOPTF_USE_WBINFO (1 << 14)		// Route Information requests through OS WBInfo() (e.g. SwazInfo / RAWBInfo)
 #define DISPOPTF_SHOW_DATATYPES_FIRST (1 << 15)	// show.module: prefer datatypes IFF over its built-in IFF reader
 

--- a/source/Modules/configopus/config_environment_data.c
+++ b/source/Modules/configopus/config_environment_data.c
@@ -680,7 +680,7 @@ const ObjectDef _config_environment_objects[] =
 						 GAD_ENVIRONMENT_OPTIONS_SHOW_WBLEFTOUTS,
 						 _environment_relative_taglist},
 
-						// Suppress DOpus title bar clock (lets WB-style patches use it)
+						// Workbench-compatible title bar mode (lets WB-style patches use it)
 						{OD_GADGET,
 						 CHECKBOX_KIND,
 						 {4, 7, 0, 1},

--- a/source/Modules/configopus/configopus.cd
+++ b/source/Modules/configopus/configopus.cd
@@ -882,7 +882,7 @@ MSG_ENVIRONMENT_HIDE_PADLOCK (//)
 _Hide Padlock In Lister Title
 ;
 MSG_ENVIRONMENT_OPTIONS_WB_TITLE (//)
-_Suppress DOpus Title Bar Clock
+_Workbench-Compatible Title Bar
 ;
 MSG_ENVIRONMENT_OPTIONS_USE_WBINFO (//)
 _Use Workbench Icon Information

--- a/source/Modules/configopus/string_data.h
+++ b/source/Modules/configopus/string_data.h
@@ -897,7 +897,7 @@
 	#define MSG_ENVIRONMENT_VOSTY_ZOOM_STR "Window _Zooms to Title Bar"
 #define MSG_ENVIRONMENT_FULL_PATH_STR "Show Full _Path in Lister Title"
 	#define MSG_ENVIRONMENT_HIDE_PADLOCK_STR "_Hide Padlock In Lister Title"
-	#define MSG_ENVIRONMENT_OPTIONS_WB_TITLE_STR "_Suppress DOpus Title Bar Clock"
+	#define MSG_ENVIRONMENT_OPTIONS_WB_TITLE_STR "_Workbench-Compatible Title Bar"
 	#define MSG_ENVIRONMENT_OPTIONS_USE_WBINFO_STR "_Use Workbench Icon Information"
 	#define MSG_ENVIRONMENT_SUB_ICON_LAYOUT_STR "Icon Layout"
 	#define MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR "Desktop Icon Arrangement"

--- a/source/Modules/configopus/tests/test_wb_title_label.py
+++ b/source/Modules/configopus/tests/test_wb_title_label.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Regression checks for the WB title-bar compatibility option label."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[4]
+CONFIGOPUS_CD = ROOT / "source" / "Modules" / "configopus" / "configopus.cd"
+STRING_DATA_H = ROOT / "source" / "Modules" / "configopus" / "string_data.h"
+GUIDE = ROOT / "documents" / "DOpus5.guide"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+class WBTitleLabelTests(unittest.TestCase):
+    def test_option_label_describes_workbench_title_bar_compatibility(self):
+        expected = "Workbench-Compatible Title Bar"
+
+        self.assertIn(f"_{expected}", read_source(CONFIGOPUS_CD))
+        self.assertIn(f"_{expected}", read_source(STRING_DATA_H))
+        self.assertIn(expected, read_source(GUIDE))
+
+    def test_option_is_not_presented_as_a_clock_only_toggle(self):
+        misleading = "Suppress DOpus Title Bar Clock"
+
+        self.assertNotIn(misleading, read_source(CONFIGOPUS_CD))
+        self.assertNotIn(misleading, read_source(STRING_DATA_H))
+        self.assertNotIn(misleading, read_source(GUIDE))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/Program/dopus_config.h
+++ b/source/Program/dopus_config.h
@@ -584,7 +584,7 @@ enum {
 #define DISPOPTF_REALTIME_SCROLL (1 << 10)	// Real-time icon scrolling
 #define DISPOPTF_THIN_BORDERS (1 << 11)		// Thin borders
 #define DISPOPTF_SHOW_WBLEFTOUTS (1 << 12)	// show workbench's leftout icons from the .backdrop files
-#define DISPOPTF_WB_TITLE (1 << 13)			// Suppress DOpus title-bar clock so WB-style patches can use it
+#define DISPOPTF_WB_TITLE (1 << 13)			// Workbench-compatible title bar mode for WB-style patches
 #define DISPOPTF_USE_WBINFO (1 << 14)		// Route Information requests through OS WBInfo() (e.g. SwazInfo / RAWBInfo)
 #define DISPOPTF_SHOW_DATATYPES_FIRST (1 << 15)	// show.module: prefer datatypes IFF over its built-in IFF reader
 


### PR DESCRIPTION
## Summary
- Rename the WB Emulation option to "Workbench-Compatible Title Bar".
- Clarify the guide and changelog text that this is title-bar patch compatibility, not a duplicate Clock menu toggle.
- Add a regression test for the option wording.

Refs #94.

## Validation
- python3 -m unittest discover source/Modules/configopus/tests
- python3 -m unittest discover source/Program/tests
- git diff --cached --check
