### PR TITLE
Fix CX broker copyright text

### DIFF
--- a/source/Program/cx.c
+++ b/source/Program/cx.c
@@ -38,7 +38,7 @@ void cx_install(CxData *cx)
 	// Initialise broker
 	cx->nb.nb_Version = NB_VERSION;
 	cx->nb.nb_Name = "Directory Opus 5";
-	cx->nb.nb_Title = "�1998 Jonathan Potter & GPSoftware";
+	cx->nb.nb_Title = "(c) 1998 Jonathan Potter & GPSoftware";
 	cx->nb.nb_Descr = GetString(&locale, MSG_CX_DESC);
 	cx->nb.nb_Unique = 0;
 	cx->nb.nb_Flags = COF_SHOW_HIDE;

--- a/source/Program/tests/test_cx_broker_description.py
+++ b/source/Program/tests/test_cx_broker_description.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Regression checks for the Commodities Exchange broker text."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CX_C = ROOT / "source" / "Program" / "cx.c"
+
+
+class CommoditiesBrokerDescriptionTests(unittest.TestCase):
+    def test_broker_title_uses_ascii_copyright_text(self):
+        source = CX_C.read_bytes()
+
+        self.assertIn(
+            b'cx->nb.nb_Title = "(c) 1998 Jonathan Potter & GPSoftware";',
+            source,
+        )
+        self.assertNotIn(b"\xef\xbf\xbd", source)
+
+    def test_broker_description_uses_localized_workbench_replacement_text(self):
+        source = CX_C.read_text(encoding="utf-8")
+
+        self.assertIn("cx->nb.nb_Descr = GetString(&locale, MSG_CX_DESC);", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the corrupted Commodities Exchange broker title glyph with ASCII (c)
- add a source-level regression test for the broker title and localized description

Fixes #97

## Tests

- python3 -m unittest discover -s source/Program/tests -p "test_*.py"
- docker run --rm -v "$PWD":/work sacredbanana/amiga-compiler:m68k-amigaos sh -c "cd /work/source && make os3 clean && make os3 all"
