### PR TITLE
Fix OS3 titlebar clock trim erase

### DIFF
--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -58,6 +58,7 @@ static void clock_titlebar_set_metrics(struct Screen *screen, struct RastPort *r
 	if (screen && ((struct Library *)IntuitionBase)->lib_Version >= 47 && screen->BarHeight > 0)
 	{
 		height = screen->BarHeight + 1;
+		fill_bottom = height - 2;
 
 		if (height > rp->TxHeight)
 		{

--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -41,15 +41,17 @@ struct ClockTitleBarMetrics
 {
 	short height;
 	short text_y;
+	short fill_top;
 	short fill_bottom;
 };
 
-static struct ClockTitleBarMetrics clock_titlebar_metrics = {0, 0, 0};
+static struct ClockTitleBarMetrics clock_titlebar_metrics = {0, 0, 0, 0};
 
 static void clock_titlebar_set_metrics(struct Screen *screen, struct RastPort *rp)
 {
 	short height = rp->TxHeight + 2;
 	short text_y = rp->TxBaseline + 1;
+	short fill_top = 0;
 	short fill_bottom = height - 1;
 
 #ifdef __amigaos3__
@@ -58,14 +60,17 @@ static void clock_titlebar_set_metrics(struct Screen *screen, struct RastPort *r
 		height = screen->BarHeight + 1;
 
 		if (height > rp->TxHeight)
-			text_y = ((height - rp->TxHeight) >> 1) + rp->TxBaseline;
-
-		fill_bottom = height - 2;
+		{
+			fill_top = (height - rp->TxHeight) >> 1;
+			text_y = fill_top + rp->TxBaseline;
+			fill_bottom = fill_top + rp->TxHeight - 1;
+		}
 	}
 #endif
 
 	clock_titlebar_metrics.height = height;
 	clock_titlebar_metrics.text_y = text_y;
+	clock_titlebar_metrics.fill_top = fill_top;
 	clock_titlebar_metrics.fill_bottom = fill_bottom;
 }
 
@@ -707,7 +712,7 @@ void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 		// Save front pen
 		fp = rp->FgPen;
 		SetAPen(rp, rp->BgPen);
-		RectFill(rp, rp->cp_x, 0, clock_x - 1, clock_titlebar_metrics.fill_bottom);
+		RectFill(rp, rp->cp_x, clock_titlebar_metrics.fill_top, clock_x - 1, clock_titlebar_metrics.fill_bottom);
 		SetAPen(rp, fp);
 	}
 #endif
@@ -1163,7 +1168,7 @@ APTR clock_show_custom_title(struct RastPort *rp,
 		// Save front pen
 		fp = rp->FgPen;
 		SetAPen(rp, rp->BgPen);
-		RectFill(rp, rp->cp_x, 0, clock_x - 1, clock_titlebar_metrics.fill_bottom);
+		RectFill(rp, rp->cp_x, clock_titlebar_metrics.fill_top, clock_x - 1, clock_titlebar_metrics.fill_bottom);
 		SetAPen(rp, fp);
 	}
 #endif

--- a/source/Program/tests/test_screen_titlebar_offsets.py
+++ b/source/Program/tests/test_screen_titlebar_offsets.py
@@ -60,8 +60,18 @@ class ScreenTitleBarOffsetTests(unittest.TestCase):
 
         self.assertIn("short fill_top = 0", source)
         self.assertIn("short fill_bottom = height - 1", source)
+        self.assertIn("fill_bottom = height - 2", source)
         self.assertIn("fill_top = (height - rp->TxHeight) >> 1", source)
         self.assertIn("fill_bottom = fill_top + rp->TxHeight - 1", source)
+
+    def test_os3_v47_erase_preserves_trim_when_bar_is_not_taller_than_font(self):
+        source = read_source(CLOCK_TASK_C)
+
+        height_from_screen = source.index("height = screen->BarHeight + 1")
+        trim_preserve = source.index("fill_bottom = height - 2", height_from_screen)
+        centering_check = source.index("if (height > rp->TxHeight)", height_from_screen)
+
+        self.assertLess(trim_preserve, centering_check)
 
     def test_titlebar_render_functions_do_not_recompute_screen_metrics(self):
         source = read_source(CLOCK_TASK_C)

--- a/source/Program/tests/test_screen_titlebar_offsets.py
+++ b/source/Program/tests/test_screen_titlebar_offsets.py
@@ -22,7 +22,8 @@ class ScreenTitleBarOffsetTests(unittest.TestCase):
         self.assertIn("clock_titlebar_set_metrics(struct Screen *screen, struct RastPort *rp)", source)
         self.assertIn("((struct Library *)IntuitionBase)->lib_Version >= 47", source)
         self.assertIn("height = screen->BarHeight + 1", source)
-        self.assertIn("((height - rp->TxHeight) >> 1) + rp->TxBaseline", source)
+        self.assertIn("fill_top = (height - rp->TxHeight) >> 1", source)
+        self.assertIn("text_y = fill_top + rp->TxBaseline", source)
         self.assertNotIn("screen->BarVBorder + rp->TxBaseline", source)
 
     def test_titlebar_metrics_are_cached_from_screen_height(self):
@@ -32,8 +33,9 @@ class ScreenTitleBarOffsetTests(unittest.TestCase):
         self.assertIn("clock_titlebar_set_metrics(screen, &clock_rp)", source)
         self.assertIn("clock_titlebar_metrics.height = height", source)
         self.assertIn("clock_titlebar_metrics.text_y = text_y", source)
+        self.assertIn("clock_titlebar_metrics.fill_top = fill_top", source)
         self.assertIn("clock_titlebar_metrics.fill_bottom = fill_bottom", source)
-        self.assertIn("fill_bottom = height - 2", source)
+        self.assertIn("fill_bottom = fill_top + rp->TxHeight - 1", source)
         self.assertNotIn("clock_titlebar_height(struct Screen *screen, struct RastPort *rp)", source)
         self.assertNotIn("clock_titlebar_fill_height", source)
 
@@ -43,7 +45,10 @@ class ScreenTitleBarOffsetTests(unittest.TestCase):
         self.assertIn("Move(&clock_rp, clock_x, clock_titlebar_metrics.text_y)", source)
         self.assertIn("Move(rp, 5, clock_titlebar_metrics.text_y)", source)
         self.assertIn("clock_titlebar_image_y(size)", source)
-        self.assertIn("RectFill(rp, rp->cp_x, 0, clock_x - 1, clock_titlebar_metrics.fill_bottom)", source)
+        self.assertIn(
+            "RectFill(rp, rp->cp_x, clock_titlebar_metrics.fill_top, clock_x - 1, clock_titlebar_metrics.fill_bottom)",
+            source,
+        )
 
     def test_screen_titlebar_draw_paths_do_not_clear_full_width_on_refresh(self):
         source = read_source(CLOCK_TASK_C)
@@ -53,8 +58,10 @@ class ScreenTitleBarOffsetTests(unittest.TestCase):
     def test_os3_v47_erase_preserves_titlebar_trim_line(self):
         source = read_source(CLOCK_TASK_C)
 
+        self.assertIn("short fill_top = 0", source)
         self.assertIn("short fill_bottom = height - 1", source)
-        self.assertIn("fill_bottom = height - 2", source)
+        self.assertIn("fill_top = (height - rp->TxHeight) >> 1", source)
+        self.assertIn("fill_bottom = fill_top + rp->TxHeight - 1", source)
 
     def test_titlebar_render_functions_do_not_recompute_screen_metrics(self):
         source = read_source(CLOCK_TASK_C)


### PR DESCRIPTION
## Summary
- keep OS3 v47+ titlebar gap erases inside the centered text band
- preserve NewLook titlebar trim lines when the DOpus clock is enabled
- update titlebar offset regression checks for the erase band

## Issue
Refs #67

## Validation
- python3 -B -m unittest discover source/Program/tests
- docker run --rm -v /Users/midwan/Github/dopus5:/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 all