### PR TITLE
Fix control label backfill on config requesters

### DIFF
--- a/source/Library/button_class.c
+++ b/source/Library/button_class.c
@@ -25,6 +25,16 @@ For more information on Directory Opus for Windows please see:
 #define BOOPSI_LIBS
 #include "boopsi.h"
 
+static BOOL button_has_custom_backfill(struct gpRender *render)
+{
+	struct Window *window;
+
+	if (!render || !render->gpr_GInfo || !(window = render->gpr_GInfo->gi_Window) || !window->WLayer)
+		return FALSE;
+
+	return (window->WLayer->BackFill && window->WLayer->BackFill != LAYERS_BACKFILL);
+}
+
 // Button dispatcher
 IPTR LIBFUNC button_dispatch(REG(a0, Class *cl), REG(a2, Object *obj), REG(a1, Msg msg))
 {
@@ -1194,9 +1204,12 @@ void button_render(Class *cl, struct Gadget *gadget, ButtonData *data, struct gp
 		short len, str_len;
 		short x, y;
 		UBYTE old_style;
+		BOOL custom_backfill_text;
 
 		// Remember old style
 		old_style = rp->AlgoStyle;
+		// Outside labels should not paint BACKGROUNDPEN over requester backfills.
+		custom_backfill_text = (data->place != PLACETEXT_IN && button_has_custom_backfill(render));
 
 		// Set pen for text
 		if (data->place == PLACETEXT_IN)
@@ -1209,7 +1222,7 @@ void button_render(Class *cl, struct Gadget *gadget, ButtonData *data, struct gp
 			SetAPen(rp, pens[TEXTPEN]);
 			SetBPen(rp, pens[BACKGROUNDPEN]);
 		}
-		SetDrMd(rp, JAM2);
+		SetDrMd(rp, (custom_backfill_text) ? JAM1 : JAM2);
 		if (data->font)
 			SetFont(rp, data->font);
 		if (data->flags & BUTTONF_BOLD)
@@ -1250,6 +1263,8 @@ void button_render(Class *cl, struct Gadget *gadget, ButtonData *data, struct gp
 		}
 
 		// Draw text
+		if (custom_backfill_text)
+			EraseRect(rp, x, y - rp->TxBaseline, x + len - 1, y - rp->TxBaseline + rp->TxHeight);
 		Move(rp, x, y);
 		Text(rp, data->title, str_len);
 

--- a/source/Library/button_class.c
+++ b/source/Library/button_class.c
@@ -1264,7 +1264,7 @@ void button_render(Class *cl, struct Gadget *gadget, ButtonData *data, struct gp
 
 		// Draw text
 		if (custom_backfill_text)
-			EraseRect(rp, x, y - rp->TxBaseline, x + len - 1, y - rp->TxBaseline + rp->TxHeight);
+			EraseRect(rp, x, y - rp->TxBaseline, x + len - 1, y - rp->TxBaseline + rp->TxHeight - 1);
 		Move(rp, x, y);
 		Text(rp, data->title, str_len);
 


### PR DESCRIPTION
## Summary
- Restore patterned requester backgrounds behind outside control labels in config requesters.
- Keep checkbox/control body rendering unchanged so their normal backdrop/fill is retained.
- Apply the transparent-label path only when the window layer uses a custom backfill.

## Root cause
Commit 3c7815e switched button labels to JAM2 to avoid repeated anti-aliased text blending, but outside labels then painted BACKGROUNDPEN over requester backfills. Environment and FTP module config requesters use patterned/custom requester backfills, so checkbox labels appeared with a flat filled rectangle.

## Validation
- git diff --check
- podman run --rm -v /home/midwan/Github/dopus5:/work:Z -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 library

Fixes #101