### PR TITLE
Fix env loading

### DIFF
--- a/source/Library/config_open.c
+++ b/source/Library/config_open.c
@@ -25,6 +25,8 @@ For more information on Directory Opus for Windows please see:
 #include "config.h"
 #include <Program/dopus_config.h>
 #include "config_open.h"
+#include <stddef.h>
+#include <string.h>
 
 #ifndef __amigaos3__
 	#pragma pack(2)
@@ -180,7 +182,10 @@ Cfg_Lister *LIBFUNC L_ReadListerDef(REG(a0, struct _IFFHandle *iff), REG(d0, ULO
 			if (iff_file_id == ID_OPUS)
 			{
 				if (!convert_open_lister(iff, &lister->lister))
+				{
+					L_FreeListerDef(lister);
 					return NULL;
+				}
 			}
 			else
 				L_IFFReadChunkBytes(iff, &lister->lister, sizeof(CFG_LSTR));
@@ -1424,10 +1429,17 @@ BOOL LIBFUNC L_OpenEnvironment(REG(a0, char *name), REG(a1, struct OpenEnvironme
 			if (iff_file_id == ID_OPUS)
 			{
 				if (!convert_env(iff, &data->env))
+				{
+					L_IFFClose(iff);
+					iff_file_id = 0;
 					return 0;
+				}
 			}
 			else
+			{
+				memset(&data->env, 0, sizeof(data->env));
 				L_IFFReadChunkBytes(iff, &data->env, sizeof(CFG_ENVR));
+			}
 #ifdef __AROS__
 			{
 				int i;
@@ -1632,8 +1644,13 @@ BOOL LIBFUNC L_OpenEnvironment(REG(a0, char *name), REG(a1, struct OpenEnvironme
 				// Allocate entry
 				if ((sound = L_AllocMemH(data->memory, sizeof(Cfg_SoundEntry))))
 				{
+					ULONG sndbytes = L_IFFChunkSize(iff);
+					ULONG sndmax = (ULONG)(sizeof(Cfg_SoundEntry) - offsetof(Cfg_SoundEntry, dse_Name));
+
 					// Read data, add to list
-					L_IFFReadChunkBytes(iff, (char *)sound->dse_Name, L_IFFChunkSize(iff));
+					if (sndbytes > sndmax)
+						sndbytes = sndmax;
+					L_IFFReadChunkBytes(iff, (char *)sound->dse_Name, (long)sndbytes);
 
 #ifdef __AROS__
 					sound->dse_Volume = AROS_BE2WORD(sound->dse_Volume);
@@ -1853,7 +1870,7 @@ int convert_env(struct _IFFHandle *iff, CFG_ENVR *env)
 	env->settings.pri_main[0] = oldenv->settings.pri_main[0];
 	env->settings.pri_main[1] = oldenv->settings.pri_main[1];
 	env->settings.pri_lister[0] = oldenv->settings.pri_lister[0];
-	env->settings.pri_lister[0] = oldenv->settings.pri_lister[0];
+	env->settings.pri_lister[1] = oldenv->settings.pri_lister[1];
 	env->settings.flags = oldenv->settings.flags;
 	env->settings.pop_code = oldenv->settings.pop_code;
 	env->settings.pop_qual = oldenv->settings.pop_qual;

--- a/source/Program/environment.c
+++ b/source/Program/environment.c
@@ -482,11 +482,11 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 
 		// Get maximum filename length
 		// we have to do this before the listers are opened
-		GUI->def_filename_length = environment->env->settings.max_filename;
+		GUI->def_filename_length = env->env->settings.max_filename;
 		if (GUI->def_filename_length < FILENAME_LEN)
 			GUI->def_filename_length = FILENAME_LEN;
-	else if (GUI->def_filename_length > MAX_FILENAME_LEN)
-		GUI->def_filename_length = MAX_FILENAME_LEN;
+		else if (GUI->def_filename_length > MAX_FILENAME_LEN)
+			GUI->def_filename_length = MAX_FILENAME_LEN;
 	}
 	// Successful?
 	if (success || first)


### PR DESCRIPTION
<!--
Thanks for opening a PR!  Please fill in the sections below so the
review goes smoothly.  See CONTRIBUTING.md for the full expectations.
-->

## Summary

<!-- One or two sentences on what this PR does and why. -->

## Issue

<!-- Reference the related issue, e.g. "Resolves #42" or "Refs #42". -->

## Changes

<!-- Bullet-point list of the user-visible / behavioural changes. -->
- 

## Affected platforms

<!-- Tick the platforms you've actually built / tested.  CI will cover
the rest, but please be honest about what you exercised locally. -->
- [ ] AmigaOS 3 (`os3`)
- [ ] AmigaOS 3 / 68000 (`os3-68000`)
- [ ] AmigaOS 4 (`os4`)
- [ ] MorphOS (`mos`)
- [ ] AROS i386 (`i386-aros`)
- [ ] AROS x86_64 (`x86_64-aros`)

## Verification

<!-- How did you verify this works?  e.g. "Booted on real A1200, opened
a lister, dragged 50 icons", "ran make -C source/Modules/ftp -f
makefile.tests test", "smoke-tested under WinUAE 4.10.x", etc. -->

## Checklist

- [ ] CI is green (or expected failures are explained).
- [ ] `ChangeLog` updated with a `[dopus5 next]` entry.
- [ ] `documents/DOpus5.guide` updated and `@$VER` bumped if user-visible
      behaviour changed.
- [ ] Relevant `*_REVISION` in `source/Include/dopus/version.h` bumped if
      a versioned binary changed.
- [ ] No new compiler warnings introduced on any platform.
- [ ] No drive-by reformatting of unrelated code.
