### PR TITLE
Fix defensive environment loading

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -80,6 +80,10 @@ Library / dopus5.library:
   extension (was ".bac_5_90_cfg" since the 5.90-era schema
   migration); existing legacy backups are folded into the new
   scheme automatically on next save.
+- Environment loading now uses the environment being opened when
+  clamping filename length, cleans up failed legacy conversion paths,
+  zeroes short EPUS environment chunks, and bounds sound-event chunk
+  reads to the on-disk payload.
 
 LoadDB / display / off-screen dragging:
 - LoadDB: detach launched DOpus from caller's CLI streams so the

--- a/source/Library/config_open.c
+++ b/source/Library/config_open.c
@@ -25,6 +25,7 @@ For more information on Directory Opus for Windows please see:
 #include "config.h"
 #include <Program/dopus_config.h>
 #include "config_open.h"
+#include <stddef.h>
 
 #ifndef __amigaos3__
 	#pragma pack(2)
@@ -180,7 +181,10 @@ Cfg_Lister *LIBFUNC L_ReadListerDef(REG(a0, struct _IFFHandle *iff), REG(d0, ULO
 			if (iff_file_id == ID_OPUS)
 			{
 				if (!convert_open_lister(iff, &lister->lister))
+				{
+					L_FreeListerDef(lister);
 					return NULL;
+				}
 			}
 			else
 				L_IFFReadChunkBytes(iff, &lister->lister, sizeof(CFG_LSTR));
@@ -1424,10 +1428,17 @@ BOOL LIBFUNC L_OpenEnvironment(REG(a0, char *name), REG(a1, struct OpenEnvironme
 			if (iff_file_id == ID_OPUS)
 			{
 				if (!convert_env(iff, &data->env))
+				{
+					L_IFFClose(iff);
+					iff_file_id = 0;
 					return 0;
+				}
 			}
 			else
+			{
+				memset(&data->env, 0, sizeof(data->env));
 				L_IFFReadChunkBytes(iff, &data->env, sizeof(CFG_ENVR));
+			}
 #ifdef __AROS__
 			{
 				int i;
@@ -1632,8 +1643,19 @@ BOOL LIBFUNC L_OpenEnvironment(REG(a0, char *name), REG(a1, struct OpenEnvironme
 				// Allocate entry
 				if ((sound = L_AllocMemH(data->memory, sizeof(Cfg_SoundEntry))))
 				{
+					long sndbytes = L_IFFChunkSize(iff);
+					long sndmax = (long)(offsetof(Cfg_SoundEntry, dse_Random) - offsetof(Cfg_SoundEntry, dse_Name));
+
 					// Read data, add to list
-					L_IFFReadChunkBytes(iff, (char *)sound->dse_Name, L_IFFChunkSize(iff));
+					memset(sound, 0, sizeof(Cfg_SoundEntry));
+					if (sndbytes < 0)
+						sndbytes = 0;
+					else if (sndbytes > sndmax)
+						sndbytes = sndmax;
+
+					L_IFFReadChunkBytes(iff, (char *)sound->dse_Name, sndbytes);
+					sound->dse_Name[sizeof(sound->dse_Name) - 1] = 0;
+					sound->dse_Sound[sizeof(sound->dse_Sound) - 1] = 0;
 
 #ifdef __AROS__
 					sound->dse_Volume = AROS_BE2WORD(sound->dse_Volume);
@@ -1853,7 +1875,7 @@ int convert_env(struct _IFFHandle *iff, CFG_ENVR *env)
 	env->settings.pri_main[0] = oldenv->settings.pri_main[0];
 	env->settings.pri_main[1] = oldenv->settings.pri_main[1];
 	env->settings.pri_lister[0] = oldenv->settings.pri_lister[0];
-	env->settings.pri_lister[0] = oldenv->settings.pri_lister[0];
+	env->settings.pri_lister[1] = oldenv->settings.pri_lister[1];
 	env->settings.flags = oldenv->settings.flags;
 	env->settings.pop_code = oldenv->settings.pop_code;
 	env->settings.pop_qual = oldenv->settings.pop_qual;

--- a/source/Library/tests/test_environment_loading_guards.py
+++ b/source/Library/tests/test_environment_loading_guards.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Regression checks for defensive environment loading paths."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CONFIG_OPEN_C = ROOT / "source" / "Library" / "config_open.c"
+ENVIRONMENT_C = ROOT / "source" / "Program" / "environment.c"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+def slice_between(source, start, end):
+    start_at = source.index(start)
+    end_at = source.index(end, start_at)
+    return source[start_at:end_at]
+
+
+class EnvironmentLoadingGuardTests(unittest.TestCase):
+    def test_environment_open_uses_loaded_env_for_max_filename(self):
+        source = read_source(ENVIRONMENT_C)
+        block = slice_between(source, "// Get maximum filename length", "// Successful?")
+
+        self.assertIn("GUI->def_filename_length = env->env->settings.max_filename;", block)
+        self.assertNotIn("environment->env->settings.max_filename", block)
+        self.assertIn("else if (GUI->def_filename_length > MAX_FILENAME_LEN)", block)
+
+    def test_failed_old_lister_conversion_frees_lister_def(self):
+        source = read_source(CONFIG_OPEN_C)
+        function = slice_between(source, "Cfg_Lister *LIBFUNC L_ReadListerDef", "// Read a button bank")
+
+        self.assertRegex(
+            function,
+            r"if \(!convert_open_lister\(iff, &lister->lister\)\)\s*\{\s*"
+            r"L_FreeListerDef\(lister\);\s*return NULL;\s*\}",
+        )
+
+    def test_failed_old_env_conversion_closes_iff(self):
+        source = read_source(CONFIG_OPEN_C)
+        function = slice_between(source, "BOOL LIBFUNC L_OpenEnvironment", "// Read info on a button bank")
+
+        self.assertRegex(
+            function,
+            r"if \(!convert_env\(iff, &data->env\)\)\s*\{\s*"
+            r"L_IFFClose\(iff\);\s*iff_file_id = 0;\s*return 0;\s*\}",
+        )
+
+    def test_epus_env_read_zeros_destination_for_short_chunks(self):
+        source = read_source(CONFIG_OPEN_C)
+        function = slice_between(source, "BOOL LIBFUNC L_OpenEnvironment", "// Read info on a button bank")
+
+        self.assertRegex(
+            function,
+            r"else\s*\{\s*memset\(&data->env, 0, sizeof\(data->env\)\);\s*"
+            r"L_IFFReadChunkBytes\(iff, &data->env, sizeof\(CFG_ENVR\)\);\s*\}",
+        )
+
+    def test_sndx_read_stays_within_saved_payload_and_terminates_strings(self):
+        source = read_source(CONFIG_OPEN_C)
+        sndx_case = slice_between(source, "case ID_SNDX:", "break;\n\t\t}")
+
+        self.assertIn("offsetof(Cfg_SoundEntry, dse_Random)", sndx_case)
+        self.assertIn("offsetof(Cfg_SoundEntry, dse_Name)", sndx_case)
+        self.assertIn("memset(sound, 0, sizeof(Cfg_SoundEntry));", sndx_case)
+        self.assertIn("sound->dse_Name[sizeof(sound->dse_Name) - 1] = 0;", sndx_case)
+        self.assertIn("sound->dse_Sound[sizeof(sound->dse_Sound) - 1] = 0;", sndx_case)
+
+    def test_old_env_conversion_copies_both_lister_priorities(self):
+        source = read_source(CONFIG_OPEN_C)
+        function = slice_between(
+            source,
+            "int convert_env(struct _IFFHandle *iff, CFG_ENVR *env)\n{",
+            "void convert_list_format",
+        )
+
+        self.assertIn("env->settings.pri_lister[0] = oldenv->settings.pri_lister[0];", function)
+        self.assertIn("env->settings.pri_lister[1] = oldenv->settings.pri_lister[1];", function)
+        self.assertEqual(
+            function.count("env->settings.pri_lister[0] = oldenv->settings.pri_lister[0];"),
+            1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/Program/environment.c
+++ b/source/Program/environment.c
@@ -482,11 +482,11 @@ BOOL environment_open(Cfg_Environment *env, char *name, BOOL first, APTR prog)
 
 		// Get maximum filename length
 		// we have to do this before the listers are opened
-		GUI->def_filename_length = environment->env->settings.max_filename;
+		GUI->def_filename_length = env->env->settings.max_filename;
 		if (GUI->def_filename_length < FILENAME_LEN)
 			GUI->def_filename_length = FILENAME_LEN;
-	else if (GUI->def_filename_length > MAX_FILENAME_LEN)
-		GUI->def_filename_length = MAX_FILENAME_LEN;
+		else if (GUI->def_filename_length > MAX_FILENAME_LEN)
+			GUI->def_filename_length = MAX_FILENAME_LEN;
 	}
 	// Successful?
 	if (success || first)


### PR DESCRIPTION
## Summary
- Fix environment opening to use the environment being loaded when clamping the default filename length.
- Harden legacy environment/lister loading failure paths and short EPUS environment chunks.
- Bound sound-event chunk reads to the saved on-disk payload, zero runtime-only fields, and terminate loaded strings.
- Copy both old lister priority slots during old environment conversion.
- Add source-level regression guards and update the release changelog.

This makes PR #105 obsolete while keeping the useful fixes from it in a tighter implementation.

## Validation
- `python3 source/Library/tests/test_environment_loading_guards.py`
- `git diff --check`
- `docker run --rm -v /Users/midwan/Github/dopus5:/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 clean`
- `docker run --rm -v /Users/midwan/Github/dopus5:/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 all debug=yes`
- `docker run --rm --platform linux/amd64 -v /Users/midwan/Github/dopus5:/work -w /work/source/Program midwan/aros-compiler:i386-aros make -f makefile.aros all arch=i386 debug=yes`
- `docker run --rm --platform linux/amd64 -v /Users/midwan/Github/dopus5:/work -w /work/source/Library midwan/aros-compiler:i386-aros make -f makefile.aros all arch=i386 debug=yes`
