### PR TITLE
Fix no-unselect function arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ Lister UI:
 - Function argument expansion can now read selected entries from the
   destination lister with `{df}` / `{dF}` (with paths) and `{do}` / `{dO}`
   (names only), including the inactive panel in Dual Lister mode (issue #77).
+- Fix `{fu}` and `{ou}` source argument expansion so consumed entries remain
+  selected after the function completes (issue #113).
 - Dual Lister setup now rolls back partially-created path field and
   scrollbar gadgets if allocation fails.
 - Environment / Lister Display now has an "Open New Listers in Dual Mode"

--- a/source/Program/function_data.h
+++ b/source/Program/function_data.h
@@ -190,6 +190,8 @@ extern CommandList commandlist_internal[];
 #define FUNC_DEST_ALL_FILES 27
 #define FUNC_DEST_ONE_PATH 28
 #define FUNC_DEST_ALL_PATHS 29
+#define FUNC_ONE_FILE_NO_UNSELECT 30
+#define FUNC_ONE_PATH_NO_UNSELECT 31
 
 // Function types
 enum {

--- a/source/Program/function_files.c
+++ b/source/Program/function_files.c
@@ -1282,8 +1282,9 @@ int function_end_entry(FunctionHandle *handle, FunctionEntry *entry, int deselec
 		else
 		{
 			// Deselect if required
-			if (deselect)
+			if (deselect && !(entry->flags & FUNCENTF_NO_UNSELECT))
 				entry->flags |= FUNCENTF_UNSELECT;
+			entry->flags &= ~FUNCENTF_NO_UNSELECT;
 
 			// Clear entered flag
 			entry->flags &= ~FUNCENTF_ENTERED;

--- a/source/Program/function_launch.h
+++ b/source/Program/function_launch.h
@@ -96,6 +96,7 @@ typedef struct _InstructionParsed
 #define FUNCENTF_ICON_ONLY (1 << 10)
 #define FUNCENTF_LINK (1 << 11)	 // Link
 #define FUNCENTF_FAKE_ICON (1 << 12)
+#define FUNCENTF_NO_UNSELECT (1 << 13)
 
 #ifndef __amigaos3__
 	#pragma pack(2)

--- a/source/Program/function_parse.c
+++ b/source/Program/function_parse.c
@@ -387,7 +387,7 @@ void function_parse_instruction(FunctionHandle *handle, char *string, unsigned c
 					// Current file
 					else
 					{
-						buffer[parse_pos] = FUNC_ONE_FILE;
+						buffer[parse_pos] = FUNC_ONE_FILE_NO_UNSELECT;
 						handle->func_flags |= FUNCF_LAST_FILE_FLAG;
 
 						// Need or want?
@@ -500,7 +500,7 @@ void function_parse_instruction(FunctionHandle *handle, char *string, unsigned c
 					// Current file
 					else
 					{
-						buffer[parse_pos] = FUNC_ONE_PATH;
+						buffer[parse_pos] = FUNC_ONE_PATH_NO_UNSELECT;
 						handle->func_flags |= FUNCF_LAST_FILE_FLAG;
 
 						// Need or want?
@@ -1042,10 +1042,12 @@ int function_build_instruction(FunctionHandle *handle,
 		break;
 
 		// Single pathname
+		case FUNC_ONE_PATH_NO_UNSELECT:
 		case FUNC_ONE_PATH:
 			path_str = handle->source_path;
 
 		// Single filename
+		case FUNC_ONE_FILE_NO_UNSELECT:
 		case FUNC_ONE_FILE:
 
 			// Quotes?
@@ -1089,6 +1091,8 @@ int function_build_instruction(FunctionHandle *handle,
 				}
 
 				// Say we're done with this entry
+				if (ch == FUNC_ONE_PATH_NO_UNSELECT || ch == FUNC_ONE_FILE_NO_UNSELECT)
+					entry->flags |= FUNCENTF_NO_UNSELECT;
 				function_end_entry(handle, entry, 1);
 			}
 

--- a/source/Program/tests/test_function_argument_no_unselect.py
+++ b/source/Program/tests/test_function_argument_no_unselect.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Static checks for source argument no-unselect expansion."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PROGRAM = ROOT / "source" / "Program"
+
+
+def read_program_source(name):
+    return (PROGRAM / name).read_text(encoding="latin-1")
+
+
+class FunctionArgumentNoUnselectTests(unittest.TestCase):
+    def test_source_no_unselect_tokens_are_distinct(self):
+        function_data_h = read_program_source("function_data.h")
+        function_launch_h = read_program_source("function_launch.h")
+        function_parse_c = read_program_source("function_parse.c")
+
+        self.assertIn("#define FUNC_ONE_FILE_NO_UNSELECT", function_data_h)
+        self.assertIn("#define FUNC_ONE_PATH_NO_UNSELECT", function_data_h)
+        self.assertIn("#define FUNCENTF_NO_UNSELECT", function_launch_h)
+        self.assertRegex(
+            function_parse_c,
+            r"(?s)case 'o':.*"
+            r"string\[func_pos \+ 1\] == 'u'.*"
+            r"buffer\[parse_pos\] = FUNC_ONE_FILE_NO_UNSELECT",
+        )
+        self.assertRegex(
+            function_parse_c,
+            r"(?s)case 'f':.*"
+            r"string\[func_pos \+ 1\] == 'u'.*"
+            r"buffer\[parse_pos\] = FUNC_ONE_PATH_NO_UNSELECT",
+        )
+
+    def test_source_no_unselect_tokens_do_not_mark_entries_for_deselect(self):
+        function_files_c = read_program_source("function_files.c")
+        function_parse_c = read_program_source("function_parse.c")
+        source_one_entry_section = re.search(
+            r"(?s)// Single pathname.*?"
+            r"// Last pathname",
+            function_parse_c,
+        ).group(0)
+
+        self.assertIn("case FUNC_ONE_PATH_NO_UNSELECT:", source_one_entry_section)
+        self.assertIn("case FUNC_ONE_FILE_NO_UNSELECT:", source_one_entry_section)
+        self.assertIn("entry->flags |= FUNCENTF_NO_UNSELECT;", source_one_entry_section)
+        self.assertIn("function_end_entry(handle, entry, 1);", source_one_entry_section)
+        self.assertIn("deselect && !(entry->flags & FUNCENTF_NO_UNSELECT)", function_files_c)
+        self.assertIn("entry->flags &= ~FUNCENTF_NO_UNSELECT;", function_files_c)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Parse {fu} and {ou} into no-unselect source argument tokens.
- Keep consumed entries on the successful entry path while suppressing deselect cleanup.
- Add static regression coverage and a ChangeLog note.

## Root cause
{fu} and {ou} were parsed as the same internal tokens as {f} and {o}, so cleanup treated them as normal consumed source entries and deselected them.

Fixes #113.

## Validation
- python3 -m unittest discover -s source/Program/tests
- podman run --rm --security-opt label=disable -v /home/midwan/Github/dopus5:/work -w /work/source sacredbanana/amiga-compiler:m68k-amigaos make os3 program