### PR TITLE
Fix icon layout title ellipsis

### DIFF
--- a/source/Modules/configopus/configopus.cd
+++ b/source/Modules/configopus/configopus.cd
@@ -894,7 +894,7 @@ MSG_ENVIRONMENT_SUB_ICON_LAYOUT (//)
 Icon Layout
 ;
 MSG_ENVIRONMENT_ICON_LAYOUT_TITLE (//)
-Desktop Icon Arrangement
+Desktop Icon Arrangement...
 ;
 MSG_ENVIRONMENT_ICON_SPACE_X (//)
 Icon Spacing _X:

--- a/source/Modules/configopus/string_data.h
+++ b/source/Modules/configopus/string_data.h
@@ -910,7 +910,7 @@
 	#define MSG_ENVIRONMENT_OPTIONS_WB_TITLE_STR "_Workbench-Compatible Title Bar"
 	#define MSG_ENVIRONMENT_OPTIONS_USE_WBINFO_STR "_Use Workbench Icon Information"
 	#define MSG_ENVIRONMENT_SUB_ICON_LAYOUT_STR "Icon Layout"
-	#define MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR "Desktop Icon Arrangement"
+	#define MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR "Desktop Icon Arrangement..."
 	#define MSG_ENVIRONMENT_ICON_SPACE_X_STR "Icon Spacing _X:"
 	#define MSG_ENVIRONMENT_ICON_SPACE_Y_STR "Icon Spacing _Y:"
 	#define MSG_ENVIRONMENT_ICON_GRID_X_STR "Icon Grid X:"
@@ -2396,7 +2396,7 @@ STATIC CONST UBYTE CatCompBlock[] = {"\x00\x00\x00\x01\x00\x04" MSG_OKAY_STR
 									 "\x00\x00"
 									 "\x00\x00\x59\xF3\x00\x0D" MSG_ENVIRONMENT_SUB_ICON_LAYOUT_STR
 									 "\x00\x00"
-									 "\x00\x00\x59\xF4\x00\x1A" MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR
+									 "\x00\x00\x59\xF4\x00\x1D" MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR
 									 "\x00\x00"
 									 "\x00\x00\x59\xF5\x00\x12" MSG_ENVIRONMENT_ICON_SPACE_X_STR
 									 "\x00\x00"

--- a/source/Modules/configopus/tests/test_lister_options_layout.py
+++ b/source/Modules/configopus/tests/test_lister_options_layout.py
@@ -133,6 +133,22 @@ class ListerOptionsLayoutTests(unittest.TestCase):
                 source = (CONFIGOPUS_DIR / makefile).read_text(encoding="latin-1")
                 self.assertRegex(source, r"\$\(OBJDIR\)/string_data\.o\s*:\s*string_data\.h")
 
+    def test_icon_layout_title_keeps_panel_title_ellipsis(self):
+        cd_source = (CONFIGOPUS_DIR / "configopus.cd").read_text(encoding="latin-1")
+        string_source = CONFIGOPUS_STRINGS_H.read_text(encoding="latin-1")
+
+        self.assertIn("Desktop Icon Arrangement...", cd_source)
+        self.assertIn(
+            '#define MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR "Desktop Icon Arrangement..."',
+            string_source,
+        )
+        self.assertRegex(
+            string_source,
+            r'"\\x00\\x00\\x59\\xF4\\x00\\x1D" MSG_ENVIRONMENT_ICON_LAYOUT_TITLE_STR\s*\n'
+            r'\s*"\\x00\\x00"\s*\n'
+            r'\s*"\\x00\\x00\\x59\\xF5\\x00\\x12" MSG_ENVIRONMENT_ICON_SPACE_X_STR',
+        )
+
     def test_dual_lister_default_catalog_block_has_even_string_padding(self):
         source = CONFIGOPUS_STRINGS_H.read_text(encoding="latin-1")
 


### PR DESCRIPTION
## Summary

- Add the missing ellipsis to the Environment > Icon Layout panel title.
- Update the built-in ConfigOpus string data and catalog block length to match.
- Add regression coverage for the label and embedded catalog entry.

## Validation

- `python3 -m unittest discover source/Modules/configopus/tests`

Closes #103
