### PR TITLE
Fix deleting left-out commands

### DIFF
--- a/source/Program/backdrop_popup.c
+++ b/source/Program/backdrop_popup.c
@@ -1502,6 +1502,7 @@ MatchHandle *popup_build_icon_menu(BackdropInfo *info,
 								   PopUpHandle *menu)
 {
 	unsigned short bad, app, group, leftout, assign, nosnap, noinfo, templeft, realleft, nodev;
+	BOOL command = 0;
 	long object_type = 0;
 	PopUpExt *ext;
 	MatchHandle *handle = 0;
@@ -1565,6 +1566,7 @@ MatchHandle *popup_build_icon_menu(BackdropInfo *info,
 				? POPUPF_DISABLED
 				: 0;
 		templeft = (realleft && object->flags & BDOF_TEMP_LEFTOUT) ? POPUPF_DISABLED : 0;
+		command = (realleft && !templeft && command_filetype_match(object));
 		assign = (object->flags & BDOF_ASSIGN) ? POPUPF_DISABLED : 0;
 		nosnap = (flags & BPF_DISK && info->lister) ? POPUPF_DISABLED : 0;
 		noinfo = (object->type == BDO_APP_ICON && !(flags & BPF_CANINFO)) ? POPUPF_DISABLED : 0;
@@ -1692,10 +1694,17 @@ MatchHandle *popup_build_icon_menu(BackdropInfo *info,
 	{
 		// Delete
 		if (!(flags & BPF_TRASH))
-			PopUpNewItem(menu,
-						 (realleft) ? MSG_ICON_PUT_AWAY_MENU : MSG_DELETE,
-						 (realleft) ? MENU_ICON_PUT_AWAY : MENU_ICON_DELETE,
-						 0);
+		{
+			if (realleft)
+			{
+				PopUpNewItem(menu, MSG_ICON_PUT_AWAY_MENU, MENU_ICON_PUT_AWAY, 0);
+
+				if (command)
+					PopUpNewItem(menu, MSG_DELETE, MENU_ICON_DELETE, 0);
+			}
+			else
+				PopUpNewItem(menu, MSG_DELETE, MENU_ICON_DELETE, 0);
+		}
 	}
 
 	// Disk?

--- a/source/Program/commands.c
+++ b/source/Program/commands.c
@@ -786,6 +786,17 @@ void command_new(BackdropInfo *info, IPCData *ipc, char *filename)
 		// Set the comment
 		SetComment(buffer, fib->fib_Comment);
 
+		// Write the default command icon if there isn't one already
+		{
+			BPTR icon_lock;
+
+			StrCombine(info->buffer, buffer, ".info", sizeof(info->buffer));
+			if ((icon_lock = Lock(info->buffer, ACCESS_READ)))
+				UnLock(icon_lock);
+			else
+				icon_write(ICONTYPE_PROJECT, buffer, 0, 0, 0, 0);
+		}
+
 		// Only add as a leftout if not editing an existing function
 		if (!edit_func)
 		{
@@ -838,4 +849,34 @@ void command_remove(char *name)
 
 	// Unlock command list
 	unlock_listlock(&GUI->command_list);
+}
+
+// See if a backdrop object is an Opus command file
+BOOL command_filetype_match(BackdropObject *object)
+{
+	BPTR lock, old, commands_lock;
+	BOOL match = 0;
+
+	if (!object || object->type != BDO_LEFT_OUT || object->flags & BDOF_DESKTOP_FOLDER)
+		return 0;
+
+	if ((lock = backdrop_icon_lock(object)))
+	{
+		old = CurrentDir(lock);
+
+		if (command_filetype)
+			match = filetype_match_type(object->name, command_filetype);
+
+		if (!match && object->icon && object->icon->do_Type == WBPROJECT &&
+			(commands_lock = Lock("DOpus5:Commands", ACCESS_READ)))
+		{
+			if (SameLock(lock, commands_lock) == LOCK_SAME)
+				match = 1;
+			UnLock(commands_lock);
+		}
+
+		UnLock(CurrentDir(old));
+	}
+
+	return match;
 }

--- a/source/Program/desktop_delete.c
+++ b/source/Program/desktop_delete.c
@@ -25,7 +25,7 @@ For more information on Directory Opus for Windows please see:
 
 void desktop_delete(IPCData *ipc, BackdropInfo *info, BackdropObject *only_one)
 {
-	short groupcount = 0, filecount = 0, assigncount = 0, othercount = 0, dircount = 0;
+	short groupcount = 0, filecount = 0, assigncount = 0, othercount = 0, dircount = 0, commandcount = 0;
 	BackdropObject *object = 0;
 	Att_List *list;
 	Att_Node *node;
@@ -60,6 +60,11 @@ void desktop_delete(IPCData *ipc, BackdropInfo *info, BackdropObject *only_one)
 			if (object->icon->do_Type == WBDRAWER)
 				++dircount;
 		}
+
+		// Command left-out?
+		else if (object->type == BDO_LEFT_OUT && info->flags & BDIF_MAIN_DESKTOP &&
+				 !(object->flags & BDOF_TEMP_LEFTOUT) && command_filetype_match(object))
+			++commandcount;
 
 		// Something else
 		else
@@ -104,19 +109,20 @@ void desktop_delete(IPCData *ipc, BackdropInfo *info, BackdropObject *only_one)
 		strcat(info->buffer, buf);
 	}
 
-	// Desktop objects?
-	if (othercount > 0)
+	// Desktop objects or command left-outs?
+	if (othercount > 0 || commandcount > 0)
 	{
 		BOOL cr = 0;
+		short total_files = commandcount + othercount - dircount;
 
 		// Add CR?
 		if (groupcount > 0 || assigncount > 0 || filecount > 0)
 			cr = 1;
 
 		// Add files
-		if (othercount > dircount)
+		if (total_files > 0)
 		{
-			lsprintf(buf, GetString(&locale, MSG_DESKTOP_DELETE_DESKTOP_FILES), othercount - dircount);
+			lsprintf(buf, GetString(&locale, MSG_DESKTOP_DELETE_DESKTOP_FILES), total_files);
 			if (cr)
 				strcat(info->buffer, "\n");
 			strcat(info->buffer, buf);
@@ -191,6 +197,39 @@ void desktop_delete(IPCData *ipc, BackdropInfo *info, BackdropObject *only_one)
 					{
 						// Erase object
 						backdrop_erase_icon(info, object, 0);
+
+						// Remove object
+						backdrop_remove_object(info, object);
+					}
+				}
+
+				// Command left-out?
+				else if (object->type == BDO_LEFT_OUT && info->flags & BDIF_MAIN_DESKTOP &&
+						 !(object->flags & BDOF_TEMP_LEFTOUT) && command_filetype_match(object))
+				{
+					char path[256];
+
+					// Get full path
+					stccpy(path, object->path, sizeof(path));
+					AddPart(path, object->name, sizeof(path));
+
+					// Delete command file, or clean up an orphaned left-out
+					if (DeleteFile(path) || IoErr() == ERROR_OBJECT_NOT_FOUND)
+					{
+						// Delete icon if present
+						DeleteDiskObject(path);
+
+						// Remove command from the command list
+						command_remove(object->name);
+
+						// Erase object
+						backdrop_erase_icon(info, object, 0);
+
+						// Remove left-out record
+						lock_listlock(&GUI->positions, TRUE);
+						if (backdrop_remove_leftout(object))
+							SavePositions(&GUI->positions.list, GUI->position_name);
+						unlock_listlock(&GUI->positions);
 
 						// Remove object
 						backdrop_remove_object(info, object);

--- a/source/Program/protos.h
+++ b/source/Program/protos.h
@@ -76,6 +76,7 @@ void command_expunge(char *name);
 CommandList *add_command(char *, char *, char *, char *, ULONG, char *, Att_List *, char *, ULONG);
 void command_new(BackdropInfo *, IPCData *, char *);
 void command_remove(char *);
+BOOL command_filetype_match(BackdropObject *);
 
 // event_loop.c
 void event_loop(void);


### PR DESCRIPTION
## Summary
- add a Delete menu item for permanent left-out Opus command icons while keeping Put Away available
- delete command files, optional icons, command-list entries, and saved left-out records from the desktop delete path
- clean up orphaned command left-outs whose command file was already removed from DOpus5:Commands
- write the default command icon when saving a command that has no .info file

## Root Cause
Desktop left-outs intentionally showed Put Away instead of Delete, and the delete handler only processed groups, assigns, group objects, and desktop-folder files. Normal command left-outs therefore had no built-in path to remove the underlying command file or clear the saved left-out entry.

## Validation
- git diff --check
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Program sacredbanana/amiga-compiler:m68k-amigaos make -f makefile.os3

Fixes #92