### PR TITLE
ViewFont extended character preview

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -141,6 +141,8 @@ Documentation:
 - Refreshed every per-tab Environment editor description in
   DOpus5.guide; full @$VER bump and 2026 copyright extension
   (issue #58).
+- Added a ViewFont help node covering the optional extended-character
+  preview and the Save Settings behaviour (issue #124).
 - Refreshed Format Requester for FFS-LNFS + PFS-family detection
   and File Type Editor for the icon-menu Up/Down + drag rework.
 - Documented dopus/PopUpDelay, dopus/CommandLineLength and the
@@ -167,6 +169,9 @@ AROS portability:
 Other fixes:
 - DOpus5: path casing normalised across hardcoded literals
   (issue #36 / PR #43).
+- ViewFont: optional "Extended chars" preview shows printable high
+  characters for international-font checks and is persisted by Save
+  Settings (issue #124).
 - xadopus: unstick lister after view / doubleclick commands.
 - Lister free space display and Edit menu behaviour fix.
 - Button image fallback length guard.
@@ -199,6 +204,31 @@ Versioning notes:
 
 Detailed per-feature entries and late-cycle maintenance notes follow.
 2026-05-09 by Dimitris Panokostas <midwan@gmail.com>
+
+[dopus5 5.101] ViewFont: optional extended character preview
+Ships in 5.101.  Commands remain at v65r3 under the existing 5.101
+release bump.
+
+source/Misc/C/ViewFont:
+- Added an opt-in "Extended chars" checkbox to ViewFont.  The default
+  preview remains the existing printable ASCII range; when enabled, the
+  preview also includes printable character codes 160-255, avoiding the
+  127-159 control range.
+- Save Settings now persists the checkbox in the existing
+  "dopus/Font Viewer" environment setting as an optional fifth flags
+  field.  Existing four-field geometry settings remain valid and read
+  as before.
+- Updated built-in catalog strings and the checked-in French ViewFont
+  catalog translations.
+
+Documentation:
+- Added a ViewFont help node in DOpus5.guide and bumped the guide to
+  v58.3.
+
+Build verification:
+- Built ViewFont for AmigaOS 3, AmigaOS 4, MorphOS, AROS i386 and
+  AROS x86_64 with the project Docker/Podman compiler images.
+2026-05-14 by Dimitris Panokostas <midwan@gmail.com>
 
 [dopus5 5.101] os3-68000: fix odd-aligned CatComp string lookup
 Ships in 5.101.  dopus5.library at v73r5 (with the global

--- a/catalogs/français/font.ct
+++ b/catalogs/français/font.ct
@@ -66,3 +66,7 @@ MSG_MENU_ABOUT
 A propos...
 ; About...
 ;
+MSG_FONT_EXTENDED
+Caracteres _etendus
+; _Extended chars
+;

--- a/catalogs/français/font.ct
+++ b/catalogs/français/font.ct
@@ -66,3 +66,7 @@ MSG_MENU_ABOUT
 A propos...
 ; About...
 ;
+MSG_FONT_EXTENDED
+Caracteres _etendus
+; _Extended chars
+;

--- a/documents/DOpus5.guide
+++ b/documents/DOpus5.guide
@@ -1,6 +1,6 @@
 @database dopus5
 @master dopus5.guide
-@$VER: Dopus5Guide 58.2 (7.5.2026)
+@$VER: Dopus5Guide 58.3 (14.5.2026)
 @author "Mark Anderson, Andrew Dunbar, Dr Greg Perry, Leo Davidson and Dave Clarke"
 @(c) "Directory Opus 5 Help Guide (c) GPSoftware 1999"
 @(c) "Directory Opus 5 Help Guide (c) DOPUS5 Open Source Team 2012-2026"
@@ -30,6 +30,8 @@
 @remark v58.2 - Format Requester follow-up: Long File Names is only
                 offered when the selected FastFileSystem is new enough
                 to support DOS\7 / LNFS.
+@remark v58.3 - ViewFont now documents the optional extended-character
+                preview and how Save Settings persists it.
 
 @node "Main" "dopus5.guide"
 Help Introduction for Directory Opus 5
@@ -186,7 +188,7 @@ that item and then press the help key before selecting it.
   @{" ToolBar Button                 " link "ToolbarButton"}  @{" User                           " link "User"}
   @{" User1                          " link "User1"}  @{" User2                          " link "User2"}
   @{" User3                          " link "User3"}  @{" User4                          " link "User4"}
-  @{" UserMenu                       " link "UserMenu"}
+  @{" UserMenu                       " link "UserMenu"}  @{" ViewFont                       " link "ViewFont"}
 @endnode
 
 @node "Commands" "Commands"
@@ -2120,6 +2122,22 @@ This is a user-editable user menu entry.  It currently has either no
 function set or has a custom function calling external programs.
 
 To @{" Edit " link "Menu Editor"} this entry, select "User Menu" from the Settings menu.
+
+@endnode
+
+@node "ViewFont" "ViewFont"
+ViewFont is the font viewer installed in DOpus5:C.  It can be used to
+preview Amiga bitmap fonts at different sizes and styles.
+
+The font name and size gadgets select the font to preview.  The B, I and U
+buttons preview bold, italic and underlined styles.  The Extended chars
+checkbox adds the high printable character range to the preview, so fonts
+with international characters can be checked without changing the default
+ASCII-only display.
+
+The Save Settings menu item stores the ViewFont window position and size.
+It also stores whether Extended chars is enabled, so the checkbox state is
+restored the next time ViewFont opens.
 
 @endnode
 

--- a/source/Misc/C/ViewFont/font.c
+++ b/source/Misc/C/ViewFont/font.c
@@ -25,6 +25,11 @@ For more information on Directory Opus for Windows please see:
 
 #include "font.h"
 
+#define FONT_SETTINGF_EXTENDED (1 << 0)
+
+static void font_build_text(font_data *data);
+static void font_append_text(font_data *data, short *pos, short first, short last);
+
 int main(int argc, char **argv)
 {
 	font_data *data;
@@ -291,6 +296,15 @@ int main(int argc, char **argv)
 						font_show_font(data, FALSE);
 						break;
 
+					// Extended characters changed
+					case GAD_FONT_EXTENDED:
+
+						// Rebuild preview and redraw font
+						data->extended = (BOOL)GetGadgetValue(data->list, GAD_FONT_EXTENDED);
+						font_build_text(data);
+						font_show_font(data, FALSE);
+						break;
+
 					// Save settings
 					case MENU_SAVE_SETTINGS:
 						font_save_settings(data);
@@ -367,6 +381,7 @@ int main(int argc, char **argv)
 BOOL font_open(font_data *data)
 {
 	struct Screen *screen = NULL;
+	short min_width, min_height;
 
 	// Screen supplied?
 	if (data->arg_array[ARG_SCREEN])
@@ -396,12 +411,24 @@ BOOL font_open(font_data *data)
 	if (!data->list)
 		return FALSE;
 
+	// Restore saved settings
+	SetGadgetValue(data->list, GAD_FONT_EXTENDED, data->extended);
+
 	// Fix sizing limits
-	WindowLimits(data->window,
-				 (font_window.char_dim.Width * data->window->RPort->TxWidth) + font_window.fine_dim.Width,
-				 (font_window.char_dim.Height * data->window->RPort->TxHeight) + font_window.fine_dim.Height,
-				 ~0,
-				 ~0);
+	min_width = (font_window.char_dim.Width * data->window->RPort->TxWidth) + font_window.fine_dim.Width;
+	min_height = (font_window.char_dim.Height * data->window->RPort->TxHeight) + font_window.fine_dim.Height;
+	WindowLimits(data->window, min_width, min_height, ~0, ~0);
+
+	// Expand older saved settings that are now below the minimum
+	if (data->window->Width < min_width || data->window->Height < min_height)
+	{
+		ChangeWindowBox(data->window,
+						data->window->LeftEdge,
+						data->window->TopEdge,
+						(data->window->Width < min_width) ? min_width : data->window->Width,
+						(data->window->Height < min_height) ? min_height : data->window->Height);
+		LayoutResize(data->window);
+	}
 
 	// Add menus
 	AddWindowMenus(data->window, font_menus);
@@ -556,22 +583,10 @@ void font_get_font(font_data *data)
 	// Got font?
 	if (data->font)
 	{
-		short ch, pos, hi;
-
-		// First character
-		ch = data->font->tf_LoChar;
-		if (ch < 33)
-			ch = 33;
-
-		// Hi character
-		hi = data->font->tf_HiChar;
-		if (hi > 126 && ch < 127)
-			hi = 127;
+		short pos;
 
 		// Build display text
-		for (pos = 0; ch < hi; ch++, pos++)
-			data->font_text[pos] = ch;
-		data->font_text[pos] = 0;
+		font_build_text(data);
 
 		// Got labels?
 		if (data->size_labels)
@@ -601,6 +616,67 @@ void font_get_font(font_data *data)
 
 	// Clear window busy
 	ClearWindowBusy(data->window);
+}
+
+// Build display text
+static void font_build_text(font_data *data)
+{
+	short pos = 0, ch, hi;
+
+	data->font_text[0] = 0;
+
+	// Got font?
+	if (!data->font)
+		return;
+
+	// Extended range?
+	if (data->extended)
+	{
+		// Keep the normal printable ASCII sample, and add high printable characters
+		font_append_text(data, &pos, 33, 126);
+		font_append_text(data, &pos, 160, 255);
+	}
+
+	// Normal range
+	else
+	{
+		// First character
+		ch = data->font->tf_LoChar;
+		if (ch < 33)
+			ch = 33;
+
+		// Hi character
+		hi = data->font->tf_HiChar;
+		if (hi > 126 && ch < 127)
+			hi = 127;
+
+		// Add existing preview range
+		font_append_text(data, &pos, ch, hi - 1);
+	}
+
+	data->font_text[pos] = 0;
+}
+
+// Append a character range to the display text
+static void font_append_text(font_data *data, short *pos, short first, short last)
+{
+	short ch;
+
+	// Clamp to font range
+	if (first < data->font->tf_LoChar)
+		first = data->font->tf_LoChar;
+	if (last > data->font->tf_HiChar)
+		last = data->font->tf_HiChar;
+	if (last > 255)
+		last = 255;
+
+	// Valid range?
+	if (first > last)
+		return;
+
+	// Append characters
+	for (ch = first; ch <= last && *pos < (short)sizeof(data->font_text) - 1; ch++, (*pos)++)
+		data->font_text[*pos] = ch;
 }
 
 // Show font example
@@ -1010,17 +1086,24 @@ void font_show_about(font_data *data)
 void font_save_settings(font_data *data)
 {
 	char buf[80];
+	ULONG flags = 0;
 
 	// Set busy pointer
 	SetWindowBusy(data->window);
 
+	// Get settings
+	data->extended = (BOOL)GetGadgetValue(data->list, GAD_FONT_EXTENDED);
+	if (data->extended)
+		flags |= FONT_SETTINGF_EXTENDED;
+
 	// Build settings string
 	lsprintf(buf,
-			 "%ld/%ld/%ld/%ld\n",
+			 "%ld/%ld/%ld/%ld/%ld\n",
 			 data->window->LeftEdge,
 			 data->window->TopEdge,
 			 data->window->GZZWidth,
-			 data->window->Height - data->window->BorderTop - 2);
+			 data->window->Height - data->window->BorderTop - 2,
+			 flags);
 
 	// Set variable
 	if (SetVar("dopus/Font Viewer", buf, -1, GVF_GLOBAL_ONLY))
@@ -1038,6 +1121,7 @@ void font_read_settings(font_data *data)
 {
 	char buf[80], *ptr;
 	struct IBox dims;
+	UWORD flags = 0;
 
 	// Get environment variable
 	if (GetVar("dopus/Font Viewer", buf, sizeof(buf), GVF_GLOBAL_ONLY) <= 0)
@@ -1051,6 +1135,8 @@ void font_read_settings(font_data *data)
 	read_parse_set(&ptr, (UWORD *)&dims.Top);
 	read_parse_set(&ptr, (UWORD *)&dims.Width);
 	read_parse_set(&ptr, (UWORD *)&dims.Height);
+	read_parse_set(&ptr, &flags);
+	data->extended = (BOOL)(flags & FONT_SETTINGF_EXTENDED);
 
 	// Got valid size?
 	if (dims.Height > 0)

--- a/source/Misc/C/ViewFont/font.cd
+++ b/source/Misc/C/ViewFont/font.cd
@@ -48,3 +48,6 @@ Quit
 MSG_MENU_ABOUT (//)
 About...
 ;
+MSG_FONT_EXTENDED (//)
+_Extended chars
+;

--- a/source/Misc/C/ViewFont/font.h
+++ b/source/Misc/C/ViewFont/font.h
@@ -65,6 +65,7 @@ typedef struct
 	struct RDArgs *args;
 	BOOL resized;
 	BOOL first;
+	BOOL extended;
 
 	struct Hook refresh_hook;
 
@@ -98,6 +99,7 @@ enum {
 	GAD_FONT_BOLD,
 	GAD_FONT_ITALIC,
 	GAD_FONT_ULINE,
+	GAD_FONT_EXTENDED,
 	GAD_FONT_DISPLAY,
 	GAD_FONT_FONT_POPUP,
 	GAD_FONT_CYCLE,

--- a/source/Misc/C/ViewFont/font.strings
+++ b/source/Misc/C/ViewFont/font.strings
@@ -47,6 +47,7 @@
 #define MSG_MENU_SAVE_SETTINGS 1012
 #define MSG_MENU_QUIT 1013
 #define MSG_MENU_ABOUT 1014
+#define MSG_FONT_EXTENDED 1015
 
 #endif /* CATCOMP_NUMBERS */
 
@@ -71,6 +72,7 @@
 #define MSG_MENU_SAVE_SETTINGS_STR "Save Settings"
 #define MSG_MENU_QUIT_STR "Quit"
 #define MSG_MENU_ABOUT_STR "About..."
+#define MSG_FONT_EXTENDED_STR "_Extended chars"
 
 #endif /* CATCOMP_STRINGS */
 
@@ -103,6 +105,7 @@ static const struct CatCompArrayType CatCompArray[] =
     {MSG_MENU_SAVE_SETTINGS,(STRPTR)MSG_MENU_SAVE_SETTINGS_STR},
     {MSG_MENU_QUIT,(STRPTR)MSG_MENU_QUIT_STR},
     {MSG_MENU_ABOUT,(STRPTR)MSG_MENU_ABOUT_STR},
+    {MSG_FONT_EXTENDED,(STRPTR)MSG_FONT_EXTENDED_STR},
 };
 
 #endif /* CATCOMP_ARRAY */
@@ -145,6 +148,8 @@ static const char CatCompBlock[] =
     MSG_MENU_QUIT_STR "\x00\x00"
     "\x00\x00\x03\xF6\x00\x0A"
     MSG_MENU_ABOUT_STR "\x00\x00"
+    "\x00\x00\x03\xF7\x00\x10"
+    MSG_FONT_EXTENDED_STR "\x00"
 };
 
 #endif /* CATCOMP_BLOCK */

--- a/source/Misc/C/ViewFont/font_data.c
+++ b/source/Misc/C/ViewFont/font_data.c
@@ -2,7 +2,7 @@
 
 const char USED_VAR version[] = "\0$VER: ViewFont " CMD_STRING;
 
-const ConfigWindow font_window = {{POS_CENTER, POS_CENTER, 40, 9}, {0, 0, 44, 67}};
+const ConfigWindow font_window = {{POS_CENTER, POS_CENTER, 48, 9}, {0, 0, 44, 67}};
 
 const static char *dummy_labels[] = {"", 0};
 
@@ -79,6 +79,16 @@ const ObjectDef
 
 		// Size cycle
 		{OD_GADGET, CYCLE_KIND, {POS_REL_RIGHT, 1, 6, 1}, {0, 14, 28, 6}, 0, 0, GAD_FONT_CYCLE, font_cycle_tags},
+
+		// Extended characters
+		{OD_GADGET,
+		 CHECKBOX_KIND,
+		 {POS_REL_RIGHT, 1, 0, 1},
+		 {2, 14, 26, 6},
+		 MSG_FONT_EXTENDED,
+		 PLACETEXT_RIGHT,
+		 GAD_FONT_EXTENDED,
+		 0},
 
 		// Bold
 		{OD_GADGET,


### PR DESCRIPTION
## Summary
- add an opt-in Extended chars checkbox to ViewFont
- include printable high characters 160-255 in the preview while preserving the default ASCII view
- persist the checkbox through Save Settings and document the behavior

Fixes #124.

## Validation
- git diff --check
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Misc/C/ViewFont docker.io/sacredbanana/amiga-compiler:m68k-amigaos make -f makefile.os3 debug=no
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Misc/C/ViewFont docker.io/sacredbanana/amiga-compiler:ppc-amigaos make -f makefile.os4 debug=no
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Misc/C/ViewFont docker.io/sacredbanana/amiga-compiler:ppc-morphos make -f makefile.mos debug=no
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Misc/C/ViewFont docker.io/midwan/aros-compiler:i386-aros make -f makefile.aros arch=i386
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Misc/C/ViewFont docker.io/midwan/aros-compiler:x86_64-aros make -f makefile.aros arch=x86_64