### PR TITLE
Fix FTP MLSD recursive copy paths

### DIFF
--- a/source/Modules/ftp/ftp_recursive.c
+++ b/source/Modules/ftp/ftp_recursive.c
@@ -37,6 +37,7 @@ For more information on Directory Opus for Windows please see:
 #include "ftp_opusftp.h"
 #include "ftp_util.h"
 #include "ftp_list.h"
+#include "ftp_listcmd.h"
 #include "ftp_ipc.h"
 #include "ftp_utf8.h"
 
@@ -952,6 +953,26 @@ struct copy_locals
 	char myfulldirname[PATHLEN + 1];
 };
 
+static int recursive_use_cwd_first(struct hook_rec_data *hc)
+{
+	if (!hc)
+		return 0;
+
+	if (hc->hc_recur_flags & RECURF_BROKEN_LS)
+		return 1;
+
+	if (!hc->hc_source || hc->hc_source->ep_type != ENDPOINT_FTP || !hc->hc_source->ep_ftpnode)
+		return 0;
+
+	/*
+	 * Some MLSD servers return names prefixed by the directory argument.
+	 * The cwd-first path lists the current directory instead, so recursive
+	 * children are handled as basenames.
+	 */
+	return hc->hc_source->ep_ftpnode->fn_protocol != FTP_PROTOCOL_SFTP &&
+		   ftp_listcmd_is_mlsd(hc->hc_source->ep_ftpnode->fn_lscmd);
+}
+
 //
 //	The faster, less accurate method
 //
@@ -1402,7 +1423,7 @@ int recursive_copy(struct hook_rec_data *hc,
 			l->destname = entry->ei_name;
 		}
 
-		if (hc->hc_recur_flags & RECURF_BROKEN_LS)
+		if (recursive_use_cwd_first(hc))
 			retval = do_broken_rec_copy(hc, l, entry, dest_list, retval);
 		else
 			retval = do_normal_rec_copy(hc, l, entry, dest_list, retval);
@@ -1823,7 +1844,7 @@ int recursive_delete(struct hook_rec_data *hc, char *startdir, struct entry_info
 			break;
 		}
 
-		if (hc->hc_recur_flags & RECURF_BROKEN_LS)
+		if (recursive_use_cwd_first(hc))
 			retval = do_broken_rec_delete(hc, l, entry, retval);
 		else
 			retval = do_normal_rec_delete(hc, l, entry, retval);
@@ -2022,7 +2043,7 @@ int recursive_protect(struct hook_rec_data *hc, struct entry_info *entry, LONG s
 		// If recursive, get list of entry_infos from FTP server
 		if (!(hc->hc_recur_flags & RECURF_NORECUR))
 		{
-			if (hc->hc_recur_flags & RECURF_BROKEN_LS)
+			if (recursive_use_cwd_first(hc))
 				retval = do_broken_rec_protect(hc, l, entry, set, clr, retval);
 			else
 				retval = do_normal_rec_protect(hc, l, entry, set, clr, retval);
@@ -2228,7 +2249,7 @@ int recursive_getsizes(struct hook_rec_data *hc, struct entry_info *entry)
 			break;
 		}
 
-		if (hc->hc_recur_flags & RECURF_BROKEN_LS)
+		if (recursive_use_cwd_first(hc))
 			retval = do_broken_rec_getsizes(hc, l, entry, retval);
 		else
 			retval = do_normal_rec_getsizes(hc, l, entry, retval);
@@ -2527,7 +2548,7 @@ int recursive_findfile(struct hook_rec_data *hc, char *fulldirname, struct entry
 			break;
 		}
 
-		if (hc->hc_recur_flags & RECURF_BROKEN_LS)
+		if (recursive_use_cwd_first(hc))
 			retval = do_broken_rec_findfile(hc, l, entry, retval);
 		else
 			retval = do_normal_rec_findfile(hc, l, entry, retval);
@@ -2560,6 +2581,12 @@ free_locals:
 /**
  }{	Support functions for recursive stuff
  **/
+
+static void rec_filesys_set_ioerr(endpoint *ep, LONG ioerr)
+{
+	if (ep && ep->ep_ftpnode)
+		ep->ep_ftpnode->fn_ftp.fi_ioerr = ioerr;
+}
 
 //
 //	Get a list of entries from a file system
@@ -2847,6 +2874,7 @@ int rec_filesys_cwd(endpoint *ep, char *dirname)
 	BPTR lock;
 
 	D(bug("FS  CWD  %s\n", dirname));
+	rec_filesys_set_ioerr(ep, 0);
 
 	if ((lock = Lock(dirname, ACCESS_READ)))
 	{
@@ -2854,6 +2882,7 @@ int rec_filesys_cwd(endpoint *ep, char *dirname)
 		return 1;
 	}
 
+	rec_filesys_set_ioerr(ep, IoErr());
 	return 0;
 }
 
@@ -2891,6 +2920,8 @@ int rec_filesys_cdup(endpoint *ep)
 	if (!ep)
 		return 0;
 
+	rec_filesys_set_ioerr(ep, 0);
+
 	/******************************
 	Problems with this code. It does not check first lock is 0 i.e. on a root
 	 filesystem. This results in the currentdir being set to sys:
@@ -2911,6 +2942,9 @@ int rec_filesys_cdup(endpoint *ep)
 		}
 		UnLock(lock);
 	}
+
+	if (!ret_val)
+		rec_filesys_set_ioerr(ep, IoErr());
 
 	return (ret_val);
 }
@@ -2977,8 +3011,10 @@ int rec_filesys_mkdir(endpoint *ep, char *dirname)
 	BPTR lock;
 	D_S(struct FileInfoBlock, fib)
 	int retval = 0;
+	LONG ioerr = 0;
 
 	D(bug("FS  MKD  <%s>\n", dirname));
+	rec_filesys_set_ioerr(ep, 0);
 
 	// Try to create dir
 	if ((lock = CreateDir(dirname)))
@@ -2990,7 +3026,10 @@ int rec_filesys_mkdir(endpoint *ep, char *dirname)
 	// Already existed?
 	else
 	{
-		if (IoErr() == ERROR_OBJECT_EXISTS)
+		ioerr = IoErr();
+		rec_filesys_set_ioerr(ep, ioerr);
+
+		if (ioerr == ERROR_OBJECT_EXISTS)
 		{
 			// Yes but is it a dir?
 			if ((lock = Lock(dirname, ACCESS_READ)))
@@ -3003,8 +3042,13 @@ int rec_filesys_mkdir(endpoint *ep, char *dirname)
 				}
 				UnLock(lock);
 			}
+			else
+				rec_filesys_set_ioerr(ep, IoErr());
 		}
 	}
+
+	if (retval)
+		rec_filesys_set_ioerr(ep, 0);
 
 	D(bug("** FS MKDIR = %ld\n", (long)retval));
 
@@ -3523,7 +3567,18 @@ int rec_ftp_errorreq(endpoint *ep, struct ftp_node *prognode, ULONG flags)
 //
 int rec_filesys_errorreq(endpoint *ep, struct ftp_node *prognode, ULONG flags)
 {
-	return lst_dos_err(prognode->fn_og, prognode, flags, prognode->fn_ftp.fi_ioerr);
+	LONG ioerr = 0;
+
+	if (!prognode)
+		return 0;
+
+	if (ep && ep->ep_ftpnode)
+		ioerr = ep->ep_ftpnode->fn_ftp.fi_ioerr;
+
+	if (!ioerr)
+		ioerr = prognode->fn_ftp.fi_ioerr;
+
+	return lst_dos_err(prognode->fn_og, prognode, flags, ioerr);
 }
 
 //

--- a/source/Modules/ftp/ftp_recursive.h
+++ b/source/Modules/ftp/ftp_recursive.h
@@ -152,7 +152,7 @@ enum {
 	RECURF_SKIPALL = 1 << 1,	 // Like pressing 'Skip' on each requester
 	RECURF_RESUMEALL = 1 << 2,	 // Like pressing 'Resume' on each requester
 	RECURF_NORECUR = 1 << 3,	 // Act on dir only, not subentries
-	RECURF_BROKEN_LS = 1 << 4,	 // Workaround for server where names containing spaces break their ls
+	RECURF_BROKEN_LS = 1 << 4,	 // Workaround for servers that need cwd-before-list recursion
 };
 
 //

--- a/source/Modules/ftp/ftp_util.c
+++ b/source/Modules/ftp/ftp_util.c
@@ -979,6 +979,7 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 	char *pair;
 	struct ClockData filedate = {0};
 	int length;
+	BOOL skip_entry = FALSE;
 
 	if (!str || !strchr(str, ';'))
 		return 0;
@@ -1011,10 +1012,19 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 
 		if (!value)
 		{
+			size_t name_len;
+
 			// skip the leading space separator
-			factname++;
+			if (*factname == ' ')
+				factname++;
+
 			// copy the name minus the linefeeds
-			strncpy(entry->ei_name, factname, min(strlen(factname) - 2, FILENAMELEN + 1));
+			name_len = strlen(factname);
+			while (name_len && (factname[name_len - 1] == '\n' || factname[name_len - 1] == '\r'))
+				--name_len;
+			name_len = min(name_len, FILENAMELEN);
+			memcpy(entry->ei_name, factname, name_len);
+			entry->ei_name[name_len] = 0;
 			D(bug(" -> filename '%s'\n", entry->ei_name));
 		}
 		else if (!stricmp(factname, "size"))
@@ -1029,10 +1039,16 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 				entry->ei_type = -1;
 				D(bug(" -> file (type %d)\n", entry->ei_type));
 			}
-			else if (!stricmp(value, "dir") || !stricmp(value, "cdir") || !stricmp(value, "pdir"))
+			else if (!stricmp(value, "dir"))
 			{
 				entry->ei_type = 1;
 				D(bug(" -> directory (type %d)\n", entry->ei_type));
+			}
+			else if (!stricmp(value, "cdir") || !stricmp(value, "pdir"))
+			{
+				// MLSD cdir/pdir describe the listed directory and its parent, not children.
+				skip_entry = TRUE;
+				D(bug(" -> current/parent directory marker\n"));
 			}
 		}
 		else if (!stricmp(factname, "modify"))
@@ -1068,6 +1084,9 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 	}
 
 	FreeVec(pair);
+
+	if (skip_entry)
+		return 0;
 
 	// . and .. are not supported!
 	if (!strcmp(entry->ei_name, ".") || !strcmp(entry->ei_name, ".."))

--- a/source/Modules/ftp/ftp_util.c
+++ b/source/Modules/ftp/ftp_util.c
@@ -975,13 +975,16 @@ void fileinfoblock_to_entryinfo(struct entry_info *ei, struct FileInfoBlock *fib
 int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG flags)
 {
 	const char *str = line;
+	const char *facts_end;
+	const char *name;
 	// char pair[256];
 	char *pair;
 	struct ClockData filedate = {0};
 	int length;
 	BOOL skip_entry = FALSE;
+	size_t name_len;
 
-	if (!str || !strchr(str, ';'))
+	if (!str || !strchr(str, ';') || !(facts_end = strchr(str, ' ')))
 		return 0;
 
 	length = strlen(line) + 1;
@@ -992,10 +995,27 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 	D(bug("line <%s>\n", line));
 
 	// partially based on the yafc parser
-	while (str && stptok(str, pair, length, ";"))
+	while (str < facts_end)
 	{
+		const char *next = strchr(str, ';');
 		char *factname;
 		char *value;
+		size_t pair_len;
+
+		if (!next || next > facts_end)
+			next = facts_end;
+
+		pair_len = min((size_t)(next - str), (size_t)length - 1);
+		memcpy(pair, str, pair_len);
+		pair[pair_len] = 0;
+
+		if (next < facts_end && *next == ';')
+			str = next + 1;
+		else
+			str = next;
+
+		if (!*pair)
+			continue;
 
 		D(bug("pair '%s'\n", pair));
 
@@ -1011,22 +1031,7 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 		D(bug("factname '%s' value '%s'\n", factname, value));
 
 		if (!value)
-		{
-			size_t name_len;
-
-			// skip the leading space separator
-			if (*factname == ' ')
-				factname++;
-
-			// copy the name minus the linefeeds
-			name_len = strlen(factname);
-			while (name_len && (factname[name_len - 1] == '\n' || factname[name_len - 1] == '\r'))
-				--name_len;
-			name_len = min(name_len, FILENAMELEN);
-			memcpy(entry->ei_name, factname, name_len);
-			entry->ei_name[name_len] = 0;
-			D(bug(" -> filename '%s'\n", entry->ei_name));
-		}
+			continue;
 		else if (!stricmp(factname, "size"))
 		{
 			entry->ei_size = atoi(value);
@@ -1078,14 +1083,23 @@ int mlsd_line_to_entryinfo(struct entry_info *entry, const char *line, ULONG fla
 			// entry->ei_prot = FIBF_READ|FIBF_WRITE|FIBF_EXECUTE|FIBF_DELETE;
 			D(bug(" -> unix protection bits %d amiga protection bits %d\n", entry->ei_unixprot, entry->ei_prot));
 		}
-
-		if ((str = strchr(str, ';')))
-			str++;
 	}
 
 	FreeVec(pair);
 
 	if (skip_entry)
+		return 0;
+
+	name = facts_end + 1;
+	name_len = strlen(name);
+	while (name_len && (name[name_len - 1] == '\n' || name[name_len - 1] == '\r'))
+		--name_len;
+	name_len = min(name_len, FILENAMELEN);
+	memcpy(entry->ei_name, name, name_len);
+	entry->ei_name[name_len] = 0;
+	D(bug(" -> filename '%s'\n", entry->ei_name));
+
+	if (!entry->ei_name[0])
 		return 0;
 
 	// . and .. are not supported!


### PR DESCRIPTION
## Summary
- Use cwd-first recursion automatically for plain FTP MLSD listings.
- Preserve the existing Special Recursive Copy path while extending it to MLSD servers that return path-prefixed child names.
- Store filesystem endpoint IoErr values before showing DOS error requesters.

## Root cause
Issue #120 points at local DOS requesters during FTP directory copies into RAM subdirectories. The suspicious path was recursive FTP copy using MLSD <dirname> before changing into that directory. Some servers can return child names prefixed by the requested directory, which leaves the local filesystem side trying to create path-like names instead of basenames.

## Validation
- make -C source/Modules/ftp -f makefile.tests test
- podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Modules/ftp sacredbanana/amiga-compiler:m68k-amigaos make -f makefile.os3

Related to #120.