### PR TITLE
Fix localized DateStamp parsing

### DIFF
--- a/source/Library/dates.c
+++ b/source/Library/dates.c
@@ -25,6 +25,8 @@ For more information on Directory Opus for Windows please see:
 
 #include "dopuslib.h"
 
+#define DATE_PARSE_MAX_CHARS 30
+
 static char *date_english_months[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 										"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
@@ -241,7 +243,7 @@ getout:
 	temp = 0;
 
 	// Valid date string supplied?
-	if (date_ptr && (str_pos = strlen(date_ptr)) < 12 && str_pos > 4)
+	if (date_ptr && (str_pos = strlen(date_ptr)) < DATE_PARSE_MAX_CHARS && str_pos > 4)
 		strcpy(date_buffer, date_ptr);
 
 	// Otherwise

--- a/source/Library/dates.c
+++ b/source/Library/dates.c
@@ -25,6 +25,87 @@ For more information on Directory Opus for Windows please see:
 
 #include "dopuslib.h"
 
+static char *date_english_months[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+										"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+static BOOL date_is_token_boundary(struct Locale *locale, char ch)
+{
+	if (!ch)
+		return 1;
+
+	if (LocaleBase)
+		return !IsAlNum(locale, (UBYTE)ch);
+
+	return !isalnum((unsigned char)ch);
+}
+
+static BOOL date_replace_locale_month(struct Locale *locale,
+									  char *date,
+									  char *buffer,
+									  ULONG buffer_size,
+									  ULONG locale_id,
+									  char *english)
+{
+	char *month, *ptr;
+	long month_len, prefix_len, replace_len, suffix_len;
+
+	if (!date || !buffer || !buffer_size)
+		return 0;
+
+	if (!(month = (char *)GetLocaleStr(locale, locale_id)) || !*month)
+		return 0;
+
+	month_len = strlen(month);
+	replace_len = strlen(english);
+
+	for (ptr = date; *ptr; ptr++)
+	{
+		if (!date_is_token_boundary(locale, (ptr == date) ? 0 : *(ptr - 1)) ||
+			strnicmp(ptr, month, month_len) != 0 || !date_is_token_boundary(locale, ptr[month_len]))
+			continue;
+
+		prefix_len = ptr - date;
+		suffix_len = strlen(ptr + month_len);
+		if (prefix_len + replace_len + suffix_len >= buffer_size)
+			return 0;
+
+		strncpy(buffer, date, prefix_len);
+		buffer[prefix_len] = 0;
+		strcat(buffer, english);
+		strcat(buffer, ptr + month_len);
+		return 1;
+	}
+
+	return 0;
+}
+
+static BOOL date_normalise_locale_month(char *date, char *buffer, ULONG buffer_size)
+{
+	struct Locale *locale;
+	short month;
+	BOOL ret = 0;
+
+	if (!LocaleBase || !(locale = OpenLocale(0)))
+		return 0;
+
+	for (month = 0; month < 12 && !ret; month++)
+	{
+		ret = date_replace_locale_month(locale, date, buffer, buffer_size, MON_1 + month, date_english_months[month]);
+
+#ifdef ALTMON_1
+		if (!ret)
+			ret = date_replace_locale_month(
+				locale, date, buffer, buffer_size, ALTMON_1 + month, date_english_months[month]);
+#endif
+
+		if (!ret)
+			ret = date_replace_locale_month(locale, date, buffer, buffer_size, ABMON_1 + month, date_english_months[month]);
+	}
+
+	CloseLocale(locale);
+	return ret;
+}
+
 // Parse a date/time string into separate date and time buffers
 char *LIBFUNC L_ParseDateStrings(REG(a0, char *string),
 								 REG(a1, char *date_buffer),
@@ -219,7 +300,7 @@ BOOL LIBFUNC L_DateFromStringsNew(REG(a0, char *date),
 								  REG(d0, ULONG method))
 {
 	struct DateTime datetime;
-	char temptime[12], *ptr;
+	char tempdate[80], temptime[12], *ptr;
 	BOOL ret;
 
 	// Initialise DateTime structure
@@ -260,6 +341,15 @@ BOOL LIBFUNC L_DateFromStringsNew(REG(a0, char *date),
 
 	// Do conversion
 	ret = StrToDate(&datetime);
+	if (!ret && date_normalise_locale_month(date, tempdate, sizeof(tempdate)))
+	{
+#if defined(__amigaos4__)
+		datetime.dat_StrDate = (STRPTR)tempdate;
+#else
+		datetime.dat_StrDate = (UBYTE *)tempdate;
+#endif
+		ret = StrToDate(&datetime);
+	}
 
 	// Copy stamp
 	*ds = datetime.dat_Stamp;

--- a/source/Library/tests/test_date_locale_parsing.py
+++ b/source/Library/tests/test_date_locale_parsing.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Regression checks for locale-aware date parsing fallback."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DATES_C = ROOT / "source" / "Library" / "dates.c"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+class DateLocaleParsingTests(unittest.TestCase):
+    def test_date_parser_retries_with_localised_month_normalised(self):
+        source = read_source(DATES_C)
+        function = source[source.index("BOOL LIBFUNC L_DateFromStringsNew") :]
+
+        self.assertIn("ret = StrToDate(&datetime);", function)
+        self.assertRegex(
+            function,
+            re.compile(
+                r"if \(!ret && date_normalise_locale_month"
+                r"\(date, tempdate, sizeof\(tempdate\)\)\)\s*\{\s*"
+                r"(?:#if defined\(__amigaos4__\)\s*)?"
+                r"datetime\.dat_StrDate = \([^)]*\)tempdate;\s*"
+                r"(?:#else\s*datetime\.dat_StrDate = \([^)]*\)tempdate;\s*#endif\s*)?"
+                r"ret = StrToDate\(&datetime\);",
+                re.S,
+            ),
+        )
+
+    def test_locale_month_normaliser_uses_locale_month_names(self):
+        source = read_source(DATES_C)
+
+        self.assertIn("date_english_months[12]", source)
+        self.assertIn("GetLocaleStr(locale, locale_id)", source)
+        self.assertIn("MON_1 + month", source)
+        self.assertIn("ABMON_1 + month", source)
+        self.assertIn("date_is_token_boundary", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/Library/tests/test_date_locale_parsing.py
+++ b/source/Library/tests/test_date_locale_parsing.py
@@ -42,6 +42,17 @@ class DateLocaleParsingTests(unittest.TestCase):
         self.assertIn("ABMON_1 + month", source)
         self.assertIn("date_is_token_boundary", source)
 
+    def test_date_token_limit_allows_localised_full_month_names(self):
+        source = read_source(DATES_C)
+        parse_function = source[
+            source.index("char *LIBFUNC L_ParseDateStrings") :
+            source.index("// Convert a string to a datestamp")
+        ]
+
+        self.assertIn("#define DATE_PARSE_MAX_CHARS 30", source)
+        self.assertIn("strlen(date_ptr)) < DATE_PARSE_MAX_CHARS", parse_function)
+        self.assertNotIn("strlen(date_ptr)) < 12", parse_function)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/source/Program/function_change.c
+++ b/source/Program/function_change.c
@@ -27,6 +27,7 @@ For more information on Directory Opus for Windows please see:
 static int function_change_get_comment(FunctionHandle *handle, char *file, char *buffer);
 static int function_change_get_protect(FunctionHandle *handle, char *file, ULONG old_prot, unsigned char *masks);
 static int function_change_get_date(FunctionHandle *handle, char *file, struct DateStamp *date);
+static BOOL function_change_date_arg_empty(char *date);
 
 #ifndef __amigaos3__
 	#pragma pack(2)
@@ -139,7 +140,7 @@ DOPUS_FUNC(function_change)
 			if (instruction->funcargs->FA_Arguments[2])
 			{
 				// Null date?
-				if (((char *)instruction->funcargs->FA_Arguments[2])[0] == 0)
+				if (function_change_date_arg_empty((char *)instruction->funcargs->FA_Arguments[2]))
 					DateStamp(&data->date);
 
 				// Otherwise
@@ -758,6 +759,40 @@ static int function_change_get_protect(FunctionHandle *handle, char *file, ULONG
 	if (break_flag == GAD_PROTECT_ALL)
 		return 2;
 	return 1;
+}
+
+// Check for an empty date argument, including DATE="" if quotes survive parsing
+static BOOL function_change_date_arg_empty(char *date)
+{
+	char *end;
+
+	if (!date)
+		return 0;
+
+	while (*date && isspace(*date))
+		++date;
+
+	end = date + strlen(date);
+	while (end > date && isspace(*(end - 1)))
+		--end;
+
+	if (end == date)
+		return 1;
+
+	if ((*date == '"' || *date == '\'') && end > date && *(end - 1) == *date)
+	{
+		++date;
+		--end;
+
+		while (date < end && isspace(*date))
+			++date;
+		while (end > date && isspace(*(end - 1)))
+			--end;
+
+		return (end == date);
+	}
+
+	return 0;
 }
 
 // Get date

--- a/source/Program/tests/test_datestamp_date_args.py
+++ b/source/Program/tests/test_datestamp_date_args.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Regression checks for DateStamp date argument handling."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+FUNCTION_CHANGE_C = ROOT / "source" / "Program" / "function_change.c"
+
+
+def read_source():
+    return FUNCTION_CHANGE_C.read_text(encoding="latin-1")
+
+
+class DateStampDateArgumentTests(unittest.TestCase):
+    def test_empty_date_argument_uses_current_datestamp_before_parsing(self):
+        source = read_source()
+        setup = source[source.index("// Arguments supplied?") : source.index("// Any directories selected?")]
+
+        self.assertIn("function_change_date_arg_empty", source)
+        self.assertIn("if (function_change_date_arg_empty((char *)instruction->funcargs->FA_Arguments[2]))", setup)
+        self.assertRegex(
+            setup,
+            re.compile(
+                r"function_change_date_arg_empty\(\(char \*\)instruction->funcargs->FA_Arguments\[2\]\)\)\s*"
+                r"DateStamp\(&data->date\);.*?"
+                r"else\s*\{.*?ParseDateStrings",
+                re.S,
+            ),
+        )
+
+    def test_empty_date_argument_helper_handles_quoted_empty_strings(self):
+        source = read_source()
+        helper = source[source.index("static BOOL function_change_date_arg_empty") :]
+
+        self.assertIn("*date == '\"'", helper)
+        self.assertIn("*date == '\\''", helper)
+        self.assertRegex(helper, r"while \(\*date && isspace\(\*date\)\)")
+        self.assertRegex(helper, r"return \(end == date\);")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a shared date parser fallback that normalises localized month names to English abbreviations before retrying `StrToDate()`.
- Cover both full and abbreviated locale month strings, including alternate month forms when the SDK exposes them.
- Add a source-level regression test for the fallback path.

## Root Cause

DateStamp editing displays dates with `DateToStr()` using the configured locale, then validates the edited value through `StrToDate()`. On systems where localized month names are emitted but `StrToDate()` only accepts English month names for the selected date format, unchanged requester or lister date text is rejected as an invalid date.

## Validation

- `python3 -m unittest discover source/Library/tests`
- `podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Library sacredbanana/amiga-compiler:m68k-amigaos make -f makefile.os3 .objects/os3/dates.o debug=no`
- `podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Library sacredbanana/amiga-compiler:ppc-amigaos make -f makefile.os4 .objects/os4/dates.o debug=no`
- `podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Library sacredbanana/amiga-compiler:ppc-morphos make -f makefile.mos .objects/mos/dates.o debug=no`
- `podman run --rm -v /home/midwan/Github/dopus5:/work -w /work/source/Library midwan/aros-compiler:i386-aros make -f makefile.aros .objects/i386-aros/dates.o debug=no arch=i386`

Addresses #121.
