### PR TITLE
Fix listview title backfill

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,8 @@ Environment editor / configopus.module:
 - Requester control labels in Environment and ftp.module configs no
   longer paint flat backdrops over patterned backgrounds, while the
   checkbox controls keep their normal fill (issue #101 / PR #102).
+- Listview titles in config requesters now preserve patterned requester
+  backfills instead of painting a flat text background (issue #129).
 - ftp.module's NoBeeGees migration is one-shot now: imported on
   first launch and then DeleteVar'd from ENV: / ENVARC:.
 - configopus: clean up ghost filetype data, surface missing icons,

--- a/source/Library/listview_class.c
+++ b/source/Library/listview_class.c
@@ -27,6 +27,16 @@ For more information on Directory Opus for Windows please see:
 
 char *lv_FilePart(char *name);
 
+static BOOL listview_has_custom_backfill(struct gpRender *render)
+{
+	struct Window *window;
+
+	if (!render || !render->gpr_GInfo || !(window = render->gpr_GInfo->gi_Window) || !window->WLayer)
+		return FALSE;
+
+	return (window->WLayer->BackFill && window->WLayer->BackFill != LAYERS_BACKFILL);
+}
+
 // Listview dispatcher
 IPTR LIBFUNC listview_dispatch(REG(a0, Class *cl), REG(a2, Object *obj), REG(a1, Msg msg))
 {
@@ -1195,15 +1205,18 @@ void listview_render(Class *cl, struct Gadget *gadget, ListViewData *data, struc
 		// Valid title?
 		if (data->title[0])
 		{
-			short y, x, len;
+			BOOL custom_backfill_title;
+			short y, x, len, str_len;
 
 			// Get title length
-			len = strlen(data->title);
+			str_len = strlen(data->title);
+			len = TextLength(rp, data->title, str_len);
+			custom_backfill_title = listview_has_custom_backfill(render);
 
 			// Get x and y position for title
 			if (data->layout_flags & PLACETEXT_LEFT)
 			{
-				x = gadget->LeftEdge - TextLength(rp, data->title, len) - 8;
+				x = gadget->LeftEdge - len - 8;
 				y = gadget->TopEdge + 2 + rp->TxBaseline;
 			}
 			else
@@ -1215,9 +1228,11 @@ void listview_render(Class *cl, struct Gadget *gadget, ListViewData *data, struc
 			// Draw title
 			SetAPen(rp, pens[TEXTPEN]);
 			SetBPen(rp, pens[BACKGROUNDPEN]);
-			SetDrMd(rp, JAM2);
+			SetDrMd(rp, (custom_backfill_title) ? JAM1 : JAM2);
+			if (custom_backfill_title)
+				EraseRect(rp, x, y - rp->TxBaseline, x + len - 1, y - rp->TxBaseline + rp->TxHeight - 1);
 			Move(rp, x, y);
-			Text(rp, data->title, len);
+			Text(rp, data->title, str_len);
 
 			// Underscore?
 			if (data->title_uscore > -1)


### PR DESCRIPTION
## Summary

Fixes issue #129 by making custom listview titles preserve requester wallpaper/backfill patterns instead of painting a flat `BACKGROUNDPEN` text background.

## Root Cause

The earlier issue #101 fix covered custom button labels, but `dopuslistviewgclass` still rendered its title with `JAM2`. That caused labels such as "Lister Element Colours..." to fill the text rectangle with the requester background pen over patterned requester backfills.

## Changes

- Detect custom window layer backfills while rendering listview titles.
- Repaint the title text bounds through `EraseRect()` when a custom backfill is present.
- Draw listview title text with `JAM1` in that case, preserving the textured requester background.
- Document the fix in `ChangeLog`.

## Validation

- `git diff --check HEAD~1..HEAD`
- `podman run --rm -v /home/midwan/Github/dopus5:/work sacredbanana/amiga-compiler:m68k-amigaos make -C /work/source os3 library`
