### PR TITLE
Honor Create Icons for command icons

### DIFF
--- a/documents/DOpus5.guide
+++ b/documents/DOpus5.guide
@@ -2505,9 +2505,12 @@ RMB popup menu. This will not delete the command itself; you must delete
 it manually from the DOpus5:Commands directory if you want to get rid of
 it permanently.
 
-Left-out commands use the default icon command.info from DOpus5:Icons but
-you can give individual commands their own icons by just adding an icon
-(.info) to the file in the DOpus5:Commands directory.
+When the @{" Create Icons " link "Settings - Create Icons"} setting is enabled,
+Opus writes the default command.info icon from DOpus5:Icons for new command
+files that do not already have an icon. If the setting is disabled, the
+left-out is still created but no on-disk .info file is written. You can give
+individual commands their own icons by just adding an icon (.info) to the file
+in the DOpus5:Commands directory.
 
 Command files may also be added to a standard Opus group.
 @endnode

--- a/source/Program/commands.c
+++ b/source/Program/commands.c
@@ -786,7 +786,8 @@ void command_new(BackdropInfo *info, IPCData *ipc, char *filename)
 		// Set the comment
 		SetComment(buffer, fib->fib_Comment);
 
-		// Write the default command icon if there isn't one already
+		// Write the default command icon if enabled and there isn't one already
+		if (GUI->flags & GUIF_SAVE_ICONS)
 		{
 			BPTR icon_lock;
 

--- a/source/Program/tests/test_command_create_icons_setting.py
+++ b/source/Program/tests/test_command_create_icons_setting.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Regression checks for New Command icon creation."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PROGRAM = ROOT / "source" / "Program"
+GUIDE = ROOT / "documents" / "DOpus5.guide"
+
+
+def read_text(path):
+    return path.read_text(encoding="latin-1")
+
+
+def command_icon_block():
+    source = read_text(PROGRAM / "commands.c")
+    match = re.search(
+        r"\s*// Write the default command icon if .*there isn't one already\n"
+        r"(?P<block>.*?)"
+        r"\n\s*// Only add as a leftout if not editing an existing function",
+        source,
+        re.S,
+    )
+    if not match:
+        raise AssertionError("Could not find command icon creation block")
+    return match.group("block")
+
+
+def guide_node(name):
+    source = read_text(GUIDE)
+    match = re.search(rf'@node "{re.escape(name)}".*?(?=\n@endnode)', source, re.S)
+    if not match:
+        raise AssertionError(f"Could not find guide node {name}")
+    return match.group(0)
+
+
+class CommandCreateIconsSettingTests(unittest.TestCase):
+    def test_new_command_only_writes_default_icon_when_create_icons_is_enabled(self):
+        block = command_icon_block()
+
+        self.assertIn("GUI->flags & GUIF_SAVE_ICONS", block)
+        self.assertIn('StrCombine(info->buffer, buffer, ".info", sizeof(info->buffer));', block)
+        self.assertIn("Lock(info->buffer, ACCESS_READ)", block)
+        self.assertIn("icon_write(ICONTYPE_PROJECT, buffer, 0, 0, 0, 0)", block)
+        self.assertRegex(
+            block,
+            r"(?s)if \(GUI->flags & GUIF_SAVE_ICONS\)\s*\{.*"
+            r"if \(\(icon_lock = Lock\(info->buffer, ACCESS_READ\)\)\).*"
+            r"else\s*icon_write\(ICONTYPE_PROJECT, buffer, 0, 0, 0, 0\);",
+        )
+
+    def test_new_command_documentation_mentions_create_icons_setting(self):
+        node = guide_node("Icons - New Command")
+
+        self.assertIn("left-out is still created", node)
+        self.assertIn("Create Icons", node)
+        self.assertIn("on-disk .info", node)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Gate default `.info` creation for new command files behind the global Create Icons? setting.
- Keep command file creation and desktop left-out creation unchanged.
- Document how New Command interacts with Create Icons? and add a regression test for the command save path.

## Root Cause
The issue #92 follow-up made new command saves always write a default command `.info` when one was missing. That bypassed the existing global Create Icons? behavior used by other icon-writing paths.

## Testing
- python3 -m unittest discover -s source/Program/tests
- git diff --check HEAD~1..HEAD