### PR TITLE
Fix AROS title memory and clock formatting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -164,6 +164,8 @@ AROS portability:
   into zero (issue #128).
 - Fix AROS title-bar clock formatting so locale `FormatDate()` hook
   output does not repeat one bogus character (issue #128).
+- Fix AROS title-bar clock 12-hour `%I`, `%Q` and `%r` format
+  tokens so noon and midnight render as 12 instead of 00.
 - diskinfo: resolve PI at runtime to dodge an AROS x86_64
   cross-compiler ICE under Rosetta.
 - ftp / diskinfo / icon / library: fix AROS x86_64 format-string

--- a/ChangeLog
+++ b/ChangeLog
@@ -159,6 +159,9 @@ AROS portability:
 - Fix AROS x86_64 FTP lister handles, AROS menu data IPTR casts,
   AROS-converted image data writable mapping, AROS debug builds
   and runtime init.
+- Fix AROS x86_64 title-bar memory reporting so the default title
+  shows fast/system memory as "other mem" instead of collapsing it
+  into zero (issue #128).
 - diskinfo: resolve PI at runtime to dodge an AROS x86_64
   cross-compiler ICE under Rosetta.
 - ftp / diskinfo / icon / library: fix AROS x86_64 format-string

--- a/ChangeLog
+++ b/ChangeLog
@@ -162,6 +162,8 @@ AROS portability:
 - Fix AROS x86_64 title-bar memory reporting so the default title
   shows fast/system memory as "other mem" instead of collapsing it
   into zero (issue #128).
+- Fix AROS title-bar clock formatting so locale `FormatDate()` hook
+  output does not repeat one bogus character (issue #128).
 - diskinfo: resolve PI at runtime to dodge an AROS x86_64
   cross-compiler ICE under Rosetta.
 - ftp / diskinfo / icon / library: fix AROS x86_64 format-string

--- a/catalogs/deutsch/dopus.ct
+++ b/catalogs/deutsch/dopus.ct
@@ -1454,20 +1454,20 @@ Versuche '%s' zu starten ...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld Chip-RAM  %ld sonstiges RAM
-; %s  %ld graphics mem  %ld other mem
+%s  %s Chip-RAM  %s sonstiges RAM
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU Chip-RAM  %lU sonstiges RAM
-; %s  %lU graphics mem  %lU other mem
+%s  %s Chip-RAM  %s sonstiges RAM
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld Chip-RAM  %ld Fast-RAM
-; %s  %ld graphics  %ld other
+%s  %s Chip-RAM  %s Fast-RAM
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU Chip-RAM  %lU Fast-RAM
-; %s  %lU graphics  %lU other
+%s  %s Chip-RAM  %s Fast-RAM
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 QUEL

--- a/catalogs/español/dopus.ct
+++ b/catalogs/español/dopus.ct
@@ -1453,20 +1453,20 @@ Intentando lanzar '%s'...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld memoria gráfica  %ld otra memoria
-; %s  %ld graphics mem  %ld other mem
+%s  %s memoria gráfica  %s otra memoria
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU memoria gráfica  %lU otra memoria
-; %s  %lU graphics mem  %lU other mem
+%s  %s memoria gráfica  %s otra memoria
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld gráfica  %ld otra
-; %s  %ld graphics  %ld other
+%s  %s gráfica  %s otra
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU gráfica  %lU otra
-; %s  %lU graphics  %lU other
+%s  %s gráfica  %s otra
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 FNTE

--- a/catalogs/greek/dopus.ct
+++ b/catalogs/greek/dopus.ct
@@ -1454,20 +1454,20 @@ MSG_LAUNCHING_PROGRAM
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld μνήμη γραφικών  %ld άλλη μνήμη
-; %s  %ld graphics mem  %ld other mem
+%s  %s μνήμη γραφικών  %s άλλη μνήμη
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU μνήμη γραφικών  %lU άλλη μνήμη
-; %s  %lU graphics mem  %lU other mem
+%s  %s μνήμη γραφικών  %s άλλη μνήμη
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld γραφική  %ld άλλη
-; %s  %ld graphics  %ld other
+%s  %s γραφική  %s άλλη
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU γραφική  %lU άλλη
-; %s  %lU graphics  %lU other
+%s  %s γραφική  %s άλλη
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 ΑΡΧΙΚΟ

--- a/catalogs/italiano/dopus.ct
+++ b/catalogs/italiano/dopus.ct
@@ -1454,20 +1454,20 @@ Sto cercando di lanciare '%s'...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld memoria grafica  %ld altra memoria
-; %s  %ld graphics mem  %ld other mem
+%s  %s memoria grafica  %s altra memoria
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU memoria grafica  %lU altra memoria
-; %s  %lU graphics mem  %lU other mem
+%s  %s memoria grafica  %s altra memoria
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld grafica  %ld altra
-; %s  %ld graphics  %ld other
+%s  %s grafica  %s altra
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU grafica  %lU altra
-; %s  %lU graphics  %lU other
+%s  %s grafica  %s altra
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 SORG

--- a/catalogs/magyar/dopus.ct
+++ b/catalogs/magyar/dopus.ct
@@ -1454,20 +1454,20 @@ Megpróbálom elindítani a(z) "%s" programot...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld grafikus memória  %ld egyéb memória
-; %s  %ld graphics mem  %ld other mem
+%s  %s grafikus memória  %s egyéb memória
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU grafikus memória  %lU egyéb memória
-; %s  %lU graphics mem  %lU other mem
+%s  %s grafikus memória  %s egyéb memória
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld grafikus  %ld egyéb
-; %s  %ld graphics  %ld other
+%s  %s grafikus  %s egyéb
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU grafikus  %lU egyéb
-; %s  %lU graphics  %lU other
+%s  %s grafikus  %s egyéb
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 FORR

--- a/catalogs/nederlands/dopus.ct
+++ b/catalogs/nederlands/dopus.ct
@@ -1454,20 +1454,20 @@ Probeer '%s' op te starten...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld grafisch geheugen  %ld overig geheugen
-; %s  %ld graphics mem  %ld other mem
+%s  %s grafisch geheugen  %s overig geheugen
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU grafisch geheugen  %lU overig geheugen
-; %s  %lU graphics mem  %lU other mem
+%s  %s grafisch geheugen  %s overig geheugen
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld grafisch  %ld overig
-; %s  %ld graphics  %ld other
+%s  %s grafisch  %s overig
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU grafisch  %lU overig
-; %s  %lU graphics  %lU other
+%s  %s grafisch  %s overig
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 BRON

--- a/catalogs/norsk/dopus.ct
+++ b/catalogs/norsk/dopus.ct
@@ -1454,20 +1454,20 @@ Forsøker å kjøre program '%s'...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld grafikkminne  %ld annet minne
-; %s  %ld graphics mem  %ld other mem
+%s  %s grafikkminne  %s annet minne
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU grafikkminne  %lU annet minne
-; %s  %lU graphics mem  %lU other mem
+%s  %s grafikkminne  %s annet minne
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld grafikk  %ld annet
-; %s  %ld graphics  %ld other
+%s  %s grafikk  %s annet
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU grafikk  %lU annet
-; %s  %lU graphics  %lU other
+%s  %s grafikk  %s annet
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 KILDE

--- a/catalogs/polski/dopus.ct
+++ b/catalogs/polski/dopus.ct
@@ -1472,20 +1472,20 @@ Wczytujë program "%s"...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld pamiëci graficznej, %ld pozostaîej.
-; %s  %ld graphics mem  %ld other mem
+%s  %s pamiëci graficznej, %s pozostaîej.
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU pamiëci graficznej, %lU pozostaîej.
-; %s  %lU graphics mem  %lU other mem
+%s  %s pamiëci graficznej, %s pozostaîej.
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld pamiëci graficznej, %ld pozostaîej.
-; %s  %ld graphics  %ld other
+%s  %s pamiëci graficznej, %s pozostaîej.
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU pamiëci graficznej, %lU pozostaîej.
-; %s  %lU graphics  %lU other
+%s  %s pamiëci graficznej, %s pozostaîej.
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 ÚR.

--- a/catalogs/português/dopus.ct
+++ b/catalogs/português/dopus.ct
@@ -1453,20 +1453,20 @@ A tentar lançar '%s'...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld de memória gráfica  %ld de outra memória
-; %s  %ld graphics mem  %ld other mem
+%s  %s de memória gráfica  %s de outra memória
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU de memória gráfica  %lU de outra memória
-; %s  %lU graphics mem  %lU other mem
+%s  %s de memória gráfica  %s de outra memória
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld gráfica  %ld outra
-; %s  %ld graphics  %ld other
+%s  %s gráfica  %s outra
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU gráfica  %lU outra
-; %s  %lU graphics  %lU other
+%s  %s gráfica  %s outra
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 FONT

--- a/catalogs/svenska/dopus.ct
+++ b/catalogs/svenska/dopus.ct
@@ -1465,20 +1465,20 @@ Försöker starta "%s"...
 ; Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER
-%s  %ld grafikminne  %ld övrigt minne
-; %s  %ld graphics mem  %ld other mem
+%s  %s grafikminne  %s övrigt minne
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC
-%s  %lU grafikminne  %lU övrigt minne
-; %s  %lU graphics mem  %lU other mem
+%s  %s grafikminne  %s övrigt minne
+; %s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK
-%s  %ld grafik  %ld övrigt
-; %s  %ld graphics  %ld other
+%s  %s grafik  %s övrigt
+; %s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK
-%s  %lU grafik  %lU övrigt
-; %s  %lU graphics  %lU other
+%s  %s grafik  %s övrigt
+; %s  %s graphics  %s other
 ;
 MSG_LISTER_STATUS_SOURCE
 FRÅN

--- a/documents/DOpus5.guide
+++ b/documents/DOpus5.guide
@@ -3805,9 +3805,10 @@ The different things that can be changed are:
   Clock Format:
     Lets you override the titlebar clock text with a locale.library
     FormatDate string.  For example, "%a %d-%b-%y  %H:%M" displays an
-    abbreviated weekday, date, and 24-hour time.  Leave this empty to use the
-    normal Date Format and 12 hour clock settings.  The button beside the
-    field lists the common FormatDate codes.
+    abbreviated weekday, date, and 24-hour time.  A time-only string such as
+    "%r" intentionally hides the date.  Leave this empty to use the normal
+    Date Format and 12 hour clock settings.  The button beside the field
+    lists the common FormatDate codes.
 
 @endnode
 

--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -276,10 +276,48 @@ static long clock_memory_message(struct RastPort *rp, short clock_x)
 
 	ptr = GetString(&locale, MSG_MEMORY_COUNTER);
 	width = TextLength(rp, ptr, (WORD)strlen(ptr));
-	width += TextLength(rp, "9999999999", 10);
+	width += TextLength(rp, "999999999999", 12);
 	width += TextLength(rp, dopus_name, strlen(dopus_name));
 
 	return (5 + width >= clock_x) ? MSG_MEMORY_COUNTER_CLOCK : MSG_MEMORY_COUNTER;
+}
+
+static IPTR clock_other_free_memory(IPTR graphics_mem)
+{
+	IPTR any_mem;
+#ifdef __AROS__
+	IPTR fast_mem;
+
+	fast_mem = AvailMem(MEMF_FAST);
+	if (fast_mem > 0)
+		return fast_mem;
+#endif
+
+	any_mem = AvailMem(MEMF_ANY);
+	if (any_mem > graphics_mem)
+		return any_mem - graphics_mem;
+
+	return AvailMem(MEMF_FAST);
+}
+
+static UQUAD clock_used_memory(UQUAD total_mem, UQUAD free_mem)
+{
+	return (total_mem > free_mem) ? total_mem - free_mem : 0;
+}
+
+static void clock_memory_percent_string(char *buf, int buf_size, UQUAD memval, UQUAD memtotal)
+{
+	UQUAD percent;
+
+	if (memtotal == 0)
+	{
+		strcpy(buf, "0");
+		return;
+	}
+
+	percent = (memval / memtotal) * 100;
+	percent += ((memval % memtotal) * 100) / memtotal;
+	ItoaU64(&percent, buf, buf_size, 0);
 }
 
 #ifdef __amigaos4__
@@ -921,7 +959,7 @@ IPC_EntryCode(clock_proc)
 void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 {
 #ifndef __amigaos4__
-	unsigned long chipmem;
+	IPTR graphics_mem;
 #endif
 
 	// Error text?
@@ -944,11 +982,13 @@ void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 		if (environment->env->settings.date_flags & DATE_1000SEP && GUI->flags & GUIF_LOCALE_OK)
 			++msg;
 
-		// Get chip memory
-		chipmem = AvailMem(MEMF_CHIP);
-
-		// Build string
-		lsprintf(GUI->screen_title, GetString(&locale, msg), dopus_name, chipmem, AvailMem(MEMF_ANY) - chipmem);
+		// Get graphics/chip memory and build title string
+		graphics_mem = AvailMem(MEMF_CHIP);
+		lsprintf(GUI->screen_title,
+				 GetString(&locale, msg),
+				 dopus_name,
+				 graphics_mem,
+				 clock_other_free_memory(graphics_mem));
 #endif
 	}
 
@@ -1031,7 +1071,8 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 	for (ptr = environment->env->scr_title_text; *ptr && pos < TITLE_SIZE - 1; ptr++)
 	{
 		short esc = 0;
-		unsigned long memval = (unsigned long)-1, memtotal = (unsigned long)-1;
+		UQUAD memval = 0, memtotal = 0;
+		BOOL got_memval = FALSE, got_memtotal = FALSE;
 		char buf[TITLE_SIZE];
 
 		// Clear buffer
@@ -1106,6 +1147,7 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			else if (*(ptr + 1) == 't' && *(ptr + 2) == 'm')
 			{
 				memval = AvailMem(MEMF_TOTAL | MEMF_ANY);
+				got_memval = TRUE;
 				esc = 2;
 			}
 
@@ -1113,6 +1155,7 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			else if (*(ptr + 1) == 't' && *(ptr + 2) == 'c')
 			{
 				memval = AvailMem(MEMF_TOTAL | MEMF_CHIP);
+				got_memval = TRUE;
 				esc = 2;
 			}
 
@@ -1120,6 +1163,7 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			else if (*(ptr + 1) == 't' && *(ptr + 2) == 'f')
 			{
 				memval = AvailMem(MEMF_TOTAL | MEMF_FAST);
+				got_memval = TRUE;
 				esc = 2;
 			}
 
@@ -1128,7 +1172,11 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			{
 				memval = AvailMem(MEMF_ANY);
 				if (*(ptr + 3) == '%')
+				{
 					memtotal = AvailMem(MEMF_ANY | MEMF_TOTAL);
+					got_memtotal = TRUE;
+				}
+				got_memval = TRUE;
 				esc = 2;
 			}
 
@@ -1137,7 +1185,11 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			{
 				memval = AvailMem(MEMF_CHIP);
 				if (*(ptr + 3) == '%')
+				{
 					memtotal = AvailMem(MEMF_CHIP | MEMF_TOTAL);
+					got_memtotal = TRUE;
+				}
+				got_memval = TRUE;
 				esc = 2;
 			}
 
@@ -1146,28 +1198,41 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			{
 				memval = AvailMem(MEMF_FAST);
 				if (*(ptr + 3) == '%')
+				{
 					memtotal = AvailMem(MEMF_FAST | MEMF_TOTAL);
+					got_memtotal = TRUE;
+				}
+				got_memval = TRUE;
 				esc = 2;
 			}
 
 			// Used memory
 			else if (*(ptr + 1) == 'u' && *(ptr + 2) == 'm')
 			{
-				memval = (memtotal = AvailMem(MEMF_TOTAL | MEMF_ANY)) - AvailMem(MEMF_ANY);
+				memtotal = AvailMem(MEMF_TOTAL | MEMF_ANY);
+				memval = clock_used_memory(memtotal, AvailMem(MEMF_ANY));
+				got_memval = TRUE;
+				got_memtotal = TRUE;
 				esc = 2;
 			}
 
 			// Used chip memory
 			else if (*(ptr + 1) == 'u' && *(ptr + 2) == 'c')
 			{
-				memval = (memtotal - AvailMem(MEMF_TOTAL | MEMF_CHIP)) - AvailMem(MEMF_CHIP);
+				memtotal = AvailMem(MEMF_TOTAL | MEMF_CHIP);
+				memval = clock_used_memory(memtotal, AvailMem(MEMF_CHIP));
+				got_memval = TRUE;
+				got_memtotal = TRUE;
 				esc = 2;
 			}
 
 			// Used fast memory
 			else if (*(ptr + 1) == 'u' && *(ptr + 2) == 'f')
 			{
-				memval = (memtotal - AvailMem(MEMF_TOTAL | MEMF_FAST)) - AvailMem(MEMF_FAST);
+				memtotal = AvailMem(MEMF_TOTAL | MEMF_FAST);
+				memval = clock_used_memory(memtotal, AvailMem(MEMF_FAST));
+				got_memval = TRUE;
+				got_memtotal = TRUE;
 				esc = 2;
 			}
 
@@ -1284,57 +1349,64 @@ BOOL clock_show_custom_title(struct RastPort *rp,
 			}
 
 			// Memory value?
-			if (memval != (unsigned long)-1)
+			if (got_memval)
 			{
 				// As kilobytes/megabytes/smart/bytes
 				if (*(ptr + 3) == 'K' || *(ptr + 3) == 'k')
 				{
-					DivideToString(buf,
-								   memval,
-								   1024,
-								   (*(ptr + 3) == 'K') ? 1 : 0,
-								   (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
+					DivideToString64(
+						buf,
+						sizeof(buf),
+						&memval,
+						1024,
+						(*(ptr + 3) == 'K') ? 1 : 0,
+						(environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 					++esc;
 				}
 				else if (*(ptr + 3) == 'M' || *(ptr + 3) == 'm')
 				{
-					DivideToString(buf,
-								   memval,
-								   1024 * 1024,
-								   (*(ptr + 3) == 'M') ? 1 : 0,
-								   (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
+					DivideToString64(
+						buf,
+						sizeof(buf),
+						&memval,
+						1024 * 1024,
+						(*(ptr + 3) == 'M') ? 1 : 0,
+						(environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 					++esc;
 				}
 				else if (*(ptr + 3) == 'G' || *(ptr + 3) == 'g')
 				{
-					DivideToString(buf,
-								   memval,
-								   1024 * 1024 * 1024,
-								   (*(ptr + 3) == 'G') ? 1 : 0,
-								   (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
+					DivideToString64(
+						buf,
+						sizeof(buf),
+						&memval,
+						1024 * 1024 * 1024,
+						(*(ptr + 3) == 'G') ? 1 : 0,
+						(environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 					++esc;
 				}
 				else if (*(ptr + 3) == 'S' || *(ptr + 3) == 's')
 				{
-					BytesToString(memval,
-								  buf,
-								  (*(ptr + 3) == 'S') ? 1 : 0,
-								  (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
+					BytesToString64(&memval,
+									buf,
+									sizeof(buf),
+									(*(ptr + 3) == 'S') ? 1 : 0,
+									(environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 					++esc;
 				}
-				else if (*(ptr + 3) == '%' && memtotal != (unsigned long)-1)
+				else if (*(ptr + 3) == '%' && got_memtotal)
 				{
 					// Get percentage string
-					if (memtotal < 100)
-						strcpy(buf, "100");
-					else
-						DivideToString(buf, memval, memtotal / 100, 0, 0);
+					clock_memory_percent_string(buf, sizeof(buf), memval, memtotal);
 					++esc;
 				}
 				else
 				{
 					// memory values should always be unsigned
-					ItoaU(memval, buf, (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
+					ItoaU64(&memval,
+							buf,
+							sizeof(buf),
+							(environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 				}
 			}
 

--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -171,7 +171,7 @@ static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a1, U
 }
 #endif
 
-static BOOL clock_format_date(char *buffer, short size, char *format, struct DateStamp *stamp)
+static BOOL clock_format_date_raw(char *buffer, short size, char *format, struct DateStamp *stamp)
 {
 	struct Hook hook;
 	struct ClockFormatBuffer data;
@@ -200,6 +200,124 @@ static BOOL clock_format_date(char *buffer, short size, char *format, struct Dat
 #undef LocaleBase
 
 	return (buffer[0] != 0);
+}
+
+#ifdef __AROS__
+static void clock_format_append_text(char *buffer, short size, short *pos, char *text)
+{
+	if (!buffer || !pos || !text)
+		return;
+
+	while (*text && *pos < size - 1)
+	{
+		buffer[(*pos)++] = *text++;
+		buffer[*pos] = 0;
+	}
+}
+
+static void clock_format_append_12hour(char *buffer, short size, short *pos, struct DateStamp *stamp, BOOL leading_zero)
+{
+	char timebuf[8];
+	short hour = (stamp->ds_Minute / 60) % 12;
+
+	if (hour == 0)
+		hour = 12;
+
+	if (leading_zero)
+		lsprintf(timebuf, "%02ld", (long)hour);
+	else
+		lsprintf(timebuf, "%ld", (long)hour);
+
+	clock_format_append_text(buffer, size, pos, timebuf);
+}
+
+static void clock_format_append_ampm(char *buffer, short size, short *pos, struct DateStamp *stamp)
+{
+	char *ampm = 0;
+
+#define LocaleBase locale.li_LocaleBase
+	ampm = (char *)GetLocaleStr(locale.li_Locale, ((stamp->ds_Minute / 60) > 11) ? PM_STR : AM_STR);
+#undef LocaleBase
+	if (!ampm)
+		ampm = "";
+
+	clock_format_append_text(buffer, size, pos, ampm);
+}
+
+// AROS locale.library expands 12-hour tokens as 0-11; patch those and delegate the rest.
+static BOOL clock_format_date_aros(char *buffer, short size, char *format, struct DateStamp *stamp)
+{
+	char *ptr;
+	short pos = 0;
+
+	if (!buffer || size < 1)
+		return FALSE;
+	buffer[0] = 0;
+
+	if (!format || !format[0] || !stamp || !locale.li_LocaleBase)
+		return FALSE;
+
+	for (ptr = format; *ptr && pos < size - 1; ptr++)
+	{
+		char token_format[3];
+		char tokenbuf[TITLE_SIZE];
+
+		if (*ptr != '%')
+		{
+			buffer[pos++] = *ptr;
+			buffer[pos] = 0;
+			continue;
+		}
+
+		if (!*(++ptr))
+			break;
+
+		switch (*ptr)
+		{
+		case '%':
+			buffer[pos++] = '%';
+			buffer[pos] = 0;
+			break;
+
+		case 'I':
+			clock_format_append_12hour(buffer, size, &pos, stamp, TRUE);
+			break;
+
+		case 'Q':
+			clock_format_append_12hour(buffer, size, &pos, stamp, FALSE);
+			break;
+
+		case 'r': {
+			char timebuf[16];
+
+			clock_format_append_12hour(buffer, size, &pos, stamp, TRUE);
+			lsprintf(timebuf, ":%02ld:%02ld ", stamp->ds_Minute % 60, stamp->ds_Tick / TICKS_PER_SECOND);
+			clock_format_append_text(buffer, size, &pos, timebuf);
+			clock_format_append_ampm(buffer, size, &pos, stamp);
+			break;
+		}
+
+		default:
+			token_format[0] = '%';
+			token_format[1] = *ptr;
+			token_format[2] = 0;
+			if (clock_format_date_raw(tokenbuf, sizeof(tokenbuf), token_format, stamp))
+				clock_format_append_text(buffer, size, &pos, tokenbuf);
+			break;
+		}
+	}
+
+	return (buffer[0] != 0);
+}
+#endif
+
+static BOOL clock_format_date(char *buffer, short size, char *format, struct DateStamp *stamp)
+{
+#ifdef __AROS__
+	return clock_format_date_aros(buffer, size, format, stamp);
+#else
+	return clock_format_date_raw(buffer, size, format, stamp);
+#endif
 }
 
 static void clock_build_manual_time(struct DateStamp *stamp, char *timebuf, BOOL show_seconds)

--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -145,7 +145,7 @@ struct ClockFormatBuffer
 	short pos;
 };
 
-static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a1, ULONG ch), REG(a2, APTR dummy))
+static unsigned long clock_format_append(struct Hook *hook, ULONG ch)
 {
 	struct ClockFormatBuffer *data = (struct ClockFormatBuffer *)hook->h_Data;
 
@@ -156,6 +156,20 @@ static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a1, U
 	}
 	return 0;
 }
+
+#ifdef __AROS__
+static unsigned long clock_format_hook(struct Hook *hook, APTR dummy, IPTR ch)
+{
+	(void)dummy;
+	return clock_format_append(hook, (ULONG)ch);
+}
+#else
+static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a1, ULONG ch), REG(a2, APTR dummy))
+{
+	(void)dummy;
+	return clock_format_append(hook, ch);
+}
+#endif
 
 static BOOL clock_format_date(char *buffer, short size, char *format, struct DateStamp *stamp)
 {
@@ -173,7 +187,7 @@ static BOOL clock_format_date(char *buffer, short size, char *format, struct Dat
 	data.size = size;
 	data.pos = 0;
 
-#if defined(__MORPHOS__)
+#if defined(__AROS__) || defined(__MORPHOS__)
 	hook.h_Entry = (HOOKFUNC)HookEntry;
 	hook.h_SubEntry = (HOOKFUNC)clock_format_hook;
 #else

--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -305,6 +305,44 @@ static UQUAD clock_used_memory(UQUAD total_mem, UQUAD free_mem)
 	return (total_mem > free_mem) ? total_mem - free_mem : 0;
 }
 
+static void clock_memory_value_string(char *buf, int buf_size, IPTR memory, char sep)
+{
+	UQUAD value = memory;
+
+	ItoaU64(&value, buf, buf_size, sep);
+}
+
+static void clock_memory_format_string(char *buf, int buf_size, char *format)
+{
+	char *out = buf;
+	char *end;
+
+	if (buf_size < 1)
+		return;
+
+	end = buf + buf_size - 1;
+
+	while (*format && out < end)
+	{
+		if (*format == '%' && *(format + 1) == '%' && out + 1 < end)
+		{
+			*out++ = *format++;
+			*out++ = *format++;
+		}
+		else if (*format == '%' && *(format + 1) == 'l' &&
+				 (*(format + 2) == 'd' || *(format + 2) == 'u' || *(format + 2) == 'U') && out + 1 < end)
+		{
+			*out++ = '%';
+			*out++ = 's';
+			format += 3;
+		}
+		else
+			*out++ = *format++;
+	}
+
+	*out = 0;
+}
+
 static void clock_memory_percent_string(char *buf, int buf_size, UQUAD memval, UQUAD memtotal)
 {
 	UQUAD percent;
@@ -960,6 +998,9 @@ void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 {
 #ifndef __amigaos4__
 	IPTR graphics_mem;
+	char graphics_buf[32], other_buf[32];
+	char format[TITLE_SIZE];
+	char sep = 0;
 #endif
 
 	// Error text?
@@ -980,15 +1021,21 @@ void clock_show_memory(struct RastPort *rp, long msg, long clock_x, char *error)
 #else
 		// Thousands separator?
 		if (environment->env->settings.date_flags & DATE_1000SEP && GUI->flags & GUIF_LOCALE_OK)
+		{
 			++msg;
+			sep = GUI->decimal_sep;
+		}
 
 		// Get graphics/chip memory and build title string
 		graphics_mem = AvailMem(MEMF_CHIP);
+		clock_memory_value_string(graphics_buf, sizeof(graphics_buf), graphics_mem, sep);
+		clock_memory_value_string(other_buf, sizeof(other_buf), clock_other_free_memory(graphics_mem), sep);
+		clock_memory_format_string(format, sizeof(format), GetString(&locale, msg));
 		lsprintf(GUI->screen_title,
-				 GetString(&locale, msg),
+				 format,
 				 dopus_name,
-				 graphics_mem,
-				 clock_other_free_memory(graphics_mem));
+				 graphics_buf,
+				 other_buf);
 #endif
 	}
 

--- a/source/Program/dopus.cd
+++ b/source/Program/dopus.cd
@@ -1193,16 +1193,16 @@ MSG_LAUNCHING_PROGRAM (3602//)
 Attempting to launch '%s'...
 ;
 MSG_MEMORY_COUNTER (//)
-%s  %ld graphics mem  %ld other mem
+%s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_LOC (//)
-%s  %lU graphics mem  %lU other mem
+%s  %s graphics mem  %s other mem
 ;
 MSG_MEMORY_COUNTER_CLOCK (//)
-%s  %ld graphics  %ld other
+%s  %s graphics  %s other
 ;
 MSG_MEMORY_COUNTER_LOC_CLOCK (//)
-%s  %lU graphics  %lU other
+%s  %s graphics  %s other
 ;
 ;
 ;

--- a/source/Program/string_data.h
+++ b/source/Program/string_data.h
@@ -960,10 +960,10 @@ For more information on Directory Opus for Windows please see:
 	#define MSG_ERROR_SAVING_ENV_STR "Error saving environment file!"
 	#define MSG_ERROR_SAVING_OPTS_STR "Error saving options file!"
 	#define MSG_LAUNCHING_PROGRAM_STR "Attempting to launch '%s'..."
-	#define MSG_MEMORY_COUNTER_STR "%s  %ld graphics mem  %ld other mem"
-	#define MSG_MEMORY_COUNTER_LOC_STR "%s  %lU graphics mem  %lU other mem"
-	#define MSG_MEMORY_COUNTER_CLOCK_STR "%s  %ld graphics  %ld other"
-	#define MSG_MEMORY_COUNTER_LOC_CLOCK_STR "%s  %lU graphics  %lU other"
+	#define MSG_MEMORY_COUNTER_STR "%s  %s graphics mem  %s other mem"
+	#define MSG_MEMORY_COUNTER_LOC_STR "%s  %s graphics mem  %s other mem"
+	#define MSG_MEMORY_COUNTER_CLOCK_STR "%s  %s graphics  %s other"
+	#define MSG_MEMORY_COUNTER_LOC_CLOCK_STR "%s  %s graphics  %s other"
 #define MSG_MEMORY_FREE_OS4_STR "%s  %s free"
 	#define MSG_LISTER_STATUS_SOURCE_STR "SRCE"
 	#define MSG_LISTER_STATUS_DEST_STR "DEST"
@@ -2417,13 +2417,13 @@ static const char CatCompBlock[] = {"\x00\x00\x00\x00\x00\x0C" MSG_ABORTED_STR
 									"\x00\x00"
 									"\x00\x00\x0E\x12\x00\x1E" MSG_LAUNCHING_PROGRAM_STR
 									"\x00\x00"
-									"\x00\x00\x0E\x13\x00\x24" MSG_MEMORY_COUNTER_STR
+									"\x00\x00\x0E\x13\x00\x22" MSG_MEMORY_COUNTER_STR
 									"\x00"
-									"\x00\x00\x0E\x14\x00\x24" MSG_MEMORY_COUNTER_LOC_STR
+									"\x00\x00\x0E\x14\x00\x22" MSG_MEMORY_COUNTER_LOC_STR
 									"\x00"
-									"\x00\x00\x0E\x15\x00\x1C" MSG_MEMORY_COUNTER_CLOCK_STR
+									"\x00\x00\x0E\x15\x00\x1A" MSG_MEMORY_COUNTER_CLOCK_STR
 									"\x00"
-									"\x00\x00\x0E\x16\x00\x1C" MSG_MEMORY_COUNTER_LOC_CLOCK_STR
+									"\x00\x00\x0E\x16\x00\x1A" MSG_MEMORY_COUNTER_LOC_CLOCK_STR
 									"\x00"
 									"\x00\x00\x0E\x17\x00\x0C" MSG_MEMORY_FREE_OS4_STR
 									"\x00"

--- a/source/Program/tests/test_clock_task_warnings.py
+++ b/source/Program/tests/test_clock_task_warnings.py
@@ -7,6 +7,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[3]
 CLOCK_TASK_C = ROOT / "source" / "Program" / "clock_task.c"
+PROGRAM_STRINGS_H = ROOT / "source" / "Program" / "string_data.h"
 
 
 def read_source(path):
@@ -44,6 +45,32 @@ class ClockTaskWarningTests(unittest.TestCase):
         self.assertIn("fast_mem = AvailMem(MEMF_FAST);", source)
         self.assertIn("clock_other_free_memory(graphics_mem)", source)
         self.assertNotIn("AvailMem(MEMF_ANY) - chipmem", source)
+
+    def test_default_title_memory_values_are_formatted_before_lsprintf(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("static void clock_memory_value_string(char *buf, int buf_size, IPTR memory, char sep)", source)
+        self.assertIn("static void clock_memory_format_string(char *buf, int buf_size, char *format)", source)
+        self.assertIn("(*(format + 2) == 'd' || *(format + 2) == 'u' || *(format + 2) == 'U')", source)
+        self.assertIn("clock_memory_value_string(graphics_buf, sizeof(graphics_buf), graphics_mem, sep);", source)
+        self.assertIn(
+            "clock_memory_value_string(other_buf, sizeof(other_buf), clock_other_free_memory(graphics_mem), sep);",
+            source,
+        )
+        self.assertIn("clock_memory_format_string(format, sizeof(format), GetString(&locale, msg));", source)
+        self.assertIn("graphics_buf,", source)
+        self.assertIn("other_buf);", source)
+        self.assertNotIn("dopus_name,\n\t\t\t\t graphics_mem,", source)
+
+    def test_default_title_memory_catalog_uses_string_placeholders(self):
+        source = read_source(PROGRAM_STRINGS_H)
+
+        self.assertIn('MSG_MEMORY_COUNTER_STR "%s  %s graphics mem  %s other mem"', source)
+        self.assertIn('MSG_MEMORY_COUNTER_LOC_STR "%s  %s graphics mem  %s other mem"', source)
+        self.assertIn('MSG_MEMORY_COUNTER_CLOCK_STR "%s  %s graphics  %s other"', source)
+        self.assertIn('MSG_MEMORY_COUNTER_LOC_CLOCK_STR "%s  %s graphics  %s other"', source)
+        self.assertNotIn("%ld graphics mem", source)
+        self.assertNotIn("%lU graphics mem", source)
 
     def test_custom_title_memory_values_use_64_bit_formatters(self):
         source = read_source(CLOCK_TASK_C)

--- a/source/Program/tests/test_clock_task_warnings.py
+++ b/source/Program/tests/test_clock_task_warnings.py
@@ -36,11 +36,33 @@ class ClockTaskWarningTests(unittest.TestCase):
         self.assertNotIn("format =", source)
         self.assertNotIn("lsprintf(buf,format,memval)", source)
 
-    def test_custom_title_plain_memory_values_use_locale_separator(self):
+    def test_titlebar_other_memory_uses_fast_pool_on_aros(self):
         source = read_source(CLOCK_TASK_C)
 
-        self.assertIn("ItoaU(memval,", source)
+        self.assertIn("static IPTR clock_other_free_memory(IPTR graphics_mem)", source)
+        self.assertIn("#ifdef __AROS__", source)
+        self.assertIn("fast_mem = AvailMem(MEMF_FAST);", source)
+        self.assertIn("clock_other_free_memory(graphics_mem)", source)
+        self.assertNotIn("AvailMem(MEMF_ANY) - chipmem", source)
+
+    def test_custom_title_memory_values_use_64_bit_formatters(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("ItoaU64(&memval,", source)
+        self.assertIn("clock_memory_percent_string(buf, sizeof(buf), memval, memtotal);", source)
+        self.assertIn("DivideToString64(", source)
+        self.assertIn("BytesToString64(&memval,", source)
+        self.assertNotIn("ItoaU(memval,", source)
         self.assertNotIn('lsprintf(buf, "%lu", memval);', source)
+
+    def test_custom_title_used_memory_values_do_not_wrap_under_zero(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("static UQUAD clock_used_memory(UQUAD total_mem, UQUAD free_mem)", source)
+        self.assertIn("memval = clock_used_memory(memtotal, AvailMem(MEMF_ANY));", source)
+        self.assertIn("memval = clock_used_memory(memtotal, AvailMem(MEMF_CHIP));", source)
+        self.assertIn("memval = clock_used_memory(memtotal, AvailMem(MEMF_FAST));", source)
+        self.assertNotIn("memval = (memtotal - AvailMem", source)
 
 
 if __name__ == "__main__":

--- a/source/Program/tests/test_os3_screentitle_clock.py
+++ b/source/Program/tests/test_os3_screentitle_clock.py
@@ -86,6 +86,18 @@ class OS3ScreenTitleClockTests(unittest.TestCase):
         self.assertIn("hook.h_Entry = (HOOKFUNC)HookEntry;", source)
         self.assertIn("hook.h_SubEntry = (HOOKFUNC)clock_format_hook;", source)
 
+    def test_aros_clock_format_corrects_12_hour_tokens(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("static BOOL clock_format_date_aros", source)
+        self.assertIn("AROS locale.library expands 12-hour tokens as 0-11", source)
+        self.assertIn("clock_format_append_12hour(buffer, size, &pos, stamp, TRUE);", source)
+        self.assertIn("clock_format_append_12hour(buffer, size, &pos, stamp, FALSE);", source)
+        self.assertIn("case 'r':", source)
+        self.assertIn('lsprintf(timebuf, ":%02ld:%02ld "', source)
+        self.assertIn("clock_format_append_ampm(buffer, size, &pos, stamp);", source)
+        self.assertIn("return clock_format_date_aros(buffer, size, format, stamp);", source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/source/Program/tests/test_os3_screentitle_clock.py
+++ b/source/Program/tests/test_os3_screentitle_clock.py
@@ -76,6 +76,16 @@ class OS3ScreenTitleClockTests(unittest.TestCase):
         self.assertIn("(custom_title_uses_clock) ? titlebuf : 0", source)
         self.assertIn("Clock text", source)
 
+    def test_aros_clock_format_uses_hookentry_argument_order(self):
+        source = read_source(CLOCK_TASK_C)
+
+        self.assertIn("#ifdef __AROS__", source)
+        self.assertIn("clock_format_hook(struct Hook *hook, APTR dummy, IPTR ch)", source)
+        self.assertIn("return clock_format_append(hook, (ULONG)ch);", source)
+        self.assertIn("#if defined(__AROS__) || defined(__MORPHOS__)", source)
+        self.assertIn("hook.h_Entry = (HOOKFUNC)HookEntry;", source)
+        self.assertIn("hook.h_SubEntry = (HOOKFUNC)clock_format_hook;", source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- report AROS title-bar "other mem" from the fast/system memory pool first
- keep the old `MEMF_ANY - graphics` calculation as a fallback for targets that do not report fast memory
- use 64-bit formatting for custom title memory values and percentages

## Notes
This addresses the AROS x86_64 memory reporting part of #128. The clock/date part appears to be covered by the recent clock-format work, but still needs reporter confirmation on a fresh master build.

## Validation
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s source/Program/tests`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s source/Modules/configopus/tests`
- `podman run --rm -v /home/midwan/Github/dopus5:/work midwan/aros-compiler:x86_64-aros make -C /work/source x86_64-aros program`
- `podman run --rm -v /home/midwan/Github/dopus5:/work sacredbanana/amiga-compiler:m68k-amigaos make -C /work/source os3 program`
