### PR TITLE
Auto-scale device Size/Used/Free in Icon Info requester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ releases
 local-notes/
 notes/
 source/Modules/ftp/third_party/libssh2/build/
+docs/superpowers

--- a/source/Modules/icon/icon.c
+++ b/source/Modules/icon/icon.c
@@ -739,26 +739,22 @@ int openwindow(icon_data *data, int next)
 #ifdef USE_64BIT
 	{
 		UQUAD tmp = (UQUAD)data->info.id_NumBlocks * (UQUAD)data->info.id_BytesPerBlock;
-		tmp >>= 10;
-		ItoaU64(&tmp, buf, sizeof(buf), data->decimal_sep);
+		BytesToString64(&tmp, buf, sizeof(buf), 1, data->decimal_sep);
 	}
 #else
-	Itoa((data->info.id_NumBlocks * data->info.id_BytesPerBlock) >> 10, buf, data->decimal_sep);
+	BytesToString(data->info.id_NumBlocks * data->info.id_BytesPerBlock, buf, 1, data->decimal_sep);
 #endif
-	strcat(buf, "K");
 	SetGadgetValue(data->list, GAD_ICON_SIZE, (IPTR)buf);
 
 // Disk used
 #ifdef USE_64BIT
 	{
 		UQUAD tmp = (UQUAD)data->info.id_NumBlocksUsed * (UQUAD)data->info.id_BytesPerBlock;
-		tmp >>= 10;
-		ItoaU64(&tmp, buf, sizeof(buf), data->decimal_sep);
+		BytesToString64(&tmp, buf, sizeof(buf), 1, data->decimal_sep);
 	}
 #else
-	Itoa((data->info.id_NumBlocksUsed * data->info.id_BytesPerBlock) >> 10, buf, data->decimal_sep);
+	BytesToString(data->info.id_NumBlocksUsed * data->info.id_BytesPerBlock, buf, 1, data->decimal_sep);
 #endif
-	strcat(buf, "K");
 	SetGadgetValue(data->list, GAD_ICON_USED, (IPTR)buf);
 
 // Disk free
@@ -766,15 +762,14 @@ int openwindow(icon_data *data, int next)
 	{
 		UQUAD tmp =
 			((UQUAD)data->info.id_NumBlocks - (UQUAD)data->info.id_NumBlocksUsed) * (UQUAD)data->info.id_BytesPerBlock;
-		tmp >>= 10;
-		ItoaU64(&tmp, buf, sizeof(buf), data->decimal_sep);
+		BytesToString64(&tmp, buf, sizeof(buf), 1, data->decimal_sep);
 	}
 #else
-	Itoa(((data->info.id_NumBlocks - data->info.id_NumBlocksUsed) * data->info.id_BytesPerBlock) >> 10,
-		 buf,
-		 data->decimal_sep);
+	BytesToString((data->info.id_NumBlocks - data->info.id_NumBlocksUsed) * data->info.id_BytesPerBlock,
+				  buf,
+				  1,
+				  data->decimal_sep);
 #endif
-	strcat(buf, "K");
 	SetGadgetValue(data->list, GAD_ICON_FREE, (IPTR)buf);
 
 	// Disk type

--- a/source/Modules/icon/tests/test_icon_disk_scaling.py
+++ b/source/Modules/icon/tests/test_icon_disk_scaling.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Regression checks for auto-scaling disk values in the Icon Info (device) requester."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[4]
+ICON_C = ROOT / "source" / "Modules" / "icon" / "icon.c"
+
+
+def read_source(path):
+    return path.read_text(encoding="latin-1")
+
+
+def disk_info_block(source):
+    """The Size/Used/Free region only, so negative checks aren't fooled by
+    unrelated code elsewhere in the file."""
+    start = source.index("// Disk size")
+    end = source.index("// Disk type", start)
+    return source[start:end]
+
+
+class IconDiskScalingTests(unittest.TestCase):
+    def test_disk_fields_use_bytestostring64_in_64bit_branch(self):
+        source = read_source(ICON_C)
+
+        self.assertEqual(
+            source.count("BytesToString64(&tmp, buf, sizeof(buf), 1, data->decimal_sep);"),
+            3,
+        )
+
+    def test_disk_fields_use_bytestostring_in_32bit_branch(self):
+        source = read_source(ICON_C)
+
+        self.assertIn(
+            "BytesToString(data->info.id_NumBlocks * data->info.id_BytesPerBlock, buf, 1, data->decimal_sep);",
+            source,
+        )
+        self.assertIn(
+            "BytesToString(data->info.id_NumBlocksUsed * data->info.id_BytesPerBlock, buf, 1, data->decimal_sep);",
+            source,
+        )
+        self.assertIn(
+            "BytesToString((data->info.id_NumBlocks - data->info.id_NumBlocksUsed) * data->info.id_BytesPerBlock,",
+            source,
+        )
+
+    def test_old_kilobyte_formatting_removed_from_disk_fields(self):
+        block = disk_info_block(read_source(ICON_C))
+
+        self.assertNotIn("tmp >>= 10;", block)
+        self.assertNotIn('strcat(buf, "K");', block)
+        self.assertNotIn("(data->info.id_NumBlocks * data->info.id_BytesPerBlock) >> 10", block)
+        self.assertNotIn("(data->info.id_NumBlocksUsed * data->info.id_BytesPerBlock) >> 10", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- The Icon Info requester (Information on a device/disk icon) displayed disk Size/Used/Free as raw kilobytes (e.g.
7,824,746K). It now auto-scales to K/M/G/T with one decimal place via the existing BytesToString/BytesToString64
helpers — the same formatting already used by the lister title bar, device list, and DiskInfo module.
- Replaced the manual >> 10 + "K" formatting in the three disk blocks of source/Modules/icon/icon.c.
- Added a source-level regression test (source/Modules/icon/tests/test_icon_disk_scaling.py) following the repo's
existing unittest convention.

Also includes a small housekeeping commit ignoring the local docs/superpowers scratch directory.

Closes #140.

Note: a RAM disk under 4 MB still shows in K (the shared scaler only switches to M above 4 MB), consistent with the rest of DOpus5.