### PR TITLE
Fix FTP module type and initializer defects surfaced by GCC 13

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -56,11 +56,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The sacredbanana/amiga-compiler tags are mutable and are rebuilt in
+        # place, so CI can break on commits that change nothing relevant. An
+        # upstream rebuild on 2026-07-04 shipped a ppc-morphos image whose amd64
+        # cc1 cannot be executed ("posix_spawn: Exec format error"), which broke
+        # every MorphOS build. Pin by digest instead; bump these deliberately
+        # after verifying a newer image builds.
+        #
+        # m68k-amigaos / ppc-amigaos: current images (2026-07-04), verified green.
+        # ppc-morphos: last known-good image (2025-08-31, GCC 15.1.0). The
+        #   2026-07-04 rebuild (GCC 15.2.0) is broken - see above.
         platform:
-          - { name: os3, image: "sacredbanana/amiga-compiler:m68k-amigaos" }
-          - { name: os3-68000, image: "sacredbanana/amiga-compiler:m68k-amigaos" }
-          - { name: os4, image: "sacredbanana/amiga-compiler:ppc-amigaos" }
-          - { name: mos, image: "sacredbanana/amiga-compiler:ppc-morphos" }
+          - { name: os3, image: "sacredbanana/amiga-compiler@sha256:7fa7056330ce0e7b31b5e497070b3380b4f672d7d6f169ac5b3003c1af483215" }
+          - { name: os3-68000, image: "sacredbanana/amiga-compiler@sha256:7fa7056330ce0e7b31b5e497070b3380b4f672d7d6f169ac5b3003c1af483215" }
+          - { name: os4, image: "sacredbanana/amiga-compiler@sha256:7cd544cdbd6bf58a552e93183cc58e6268800305c10d5913dac96f2433c33d24" }
+          - { name: mos, image: "sacredbanana/amiga-compiler@sha256:464de9e085367f16605c34cb8c544a3ab1dcb92f494e826a004a12a501a83829" }
           - { name: i386-aros, image: "midwan/aros-compiler:i386-aros" }
           - { name: x86_64-aros, image: "midwan/aros-compiler:x86_64-aros" }
         variant:

--- a/source/Modules/ftp/ftp.c
+++ b/source/Modules/ftp/ftp.c
@@ -1448,7 +1448,7 @@ static int iread(struct ftp_info *info, int skt, BOOL checkbreak, struct ftp_tls
 	int retval = -1;
 	fd_set rd, ex;
 	ULONG flags;
-	struct timeval timer = {0, 0};
+	struct timeval timer = {0};
 
 	retval = ftp_socket_read_pending(tls_session, skt, info->fi_bufiobuf, BUFIOBUFSIZE);
 	if (retval != -2)

--- a/source/Modules/ftp/ftp_lister.c
+++ b/source/Modules/ftp/ftp_lister.c
@@ -963,8 +963,9 @@ int lst_dos_err(struct opusftp_globals *og, struct ftp_node *ftpnode, ULONG flag
 //
 //	Callback hook for connect and login
 //
-int message_update(struct message_update_info *mu, int num, char *text)
+int message_update(void *update_info, int num, char *text)
 {
+	struct message_update_info *mu = update_info;
 	Att_Node *node;
 	char *p;
 

--- a/source/Modules/ftp/ftp_lister.h
+++ b/source/Modules/ftp/ftp_lister.h
@@ -245,7 +245,8 @@ struct message_update_info
 	#pragma pack()
 #endif
 
-int message_update(struct message_update_info *, int num, char *text);
+// Matches the int (*)(void *, int, char *) callback type used by ftp.c
+int message_update(void *update_info, int num, char *text);
 
 /***********************
 

--- a/source/Modules/ftp/ftp_lister_connect.c
+++ b/source/Modules/ftp/ftp_lister_connect.c
@@ -315,24 +315,15 @@ static int systype_lookup(char *text)
 	};
 
 	static struct ftpsystem sys_types[] = {
-		"UNIX",
-		FTP_UNIX,  // Check Unix before OS/2 - "Unix type OS/2"
-		"AMIGA",
-		FTP_AMIGA,
-		"WINDOWS_NT",
-		FTP_WINDOWSNT,
-		"WIN32",
-		FTP_WIN32,	// NT or Win95/98
-		"OS/2",
-		FTP_OS2,
-		"MACOS",
-		FTP_MACOS,
-		"VMS",
-		FTP_VAX_VMS,  // Check VMS before VM
-		"VM",
-		FTP_VM_CMS,
-		NULL,
-		FTP_UNKNOWN,
+		{"UNIX", FTP_UNIX},  // Check Unix before OS/2 - "Unix type OS/2"
+		{"AMIGA", FTP_AMIGA},
+		{"WINDOWS_NT", FTP_WINDOWSNT},
+		{"WIN32", FTP_WIN32},  // NT or Win95/98
+		{"OS/2", FTP_OS2},
+		{"MACOS", FTP_MACOS},
+		{"VMS", FTP_VAX_VMS},  // Check VMS before VM
+		{"VM", FTP_VM_CMS},
+		{NULL, FTP_UNKNOWN},
 	};
 	struct ftpsystem *p = sys_types;
 	int type = FTP_UNKNOWN;
@@ -1244,7 +1235,7 @@ struct ftp_node *lister_new_connection(struct opusftp_globals *ogp, struct msg_l
 
 	if (imsg && (cm = imsg->data_free))
 	{
-		if (cm->cm_opus && *cm->cm_opus && lister_get_args(ogp, mld, imsg))
+		if (*cm->cm_opus && lister_get_args(ogp, mld, imsg))
 		{
 			if ((node = lister_create_node(ogp, mld->mld_ipc, cm)))
 			{


### PR DESCRIPTION
Building the OS3 target with GCC 13.4 (via `stefanreinauer/amiga-gcc:gcc-v13.4`) surfaced several latent defects in the FTP module that GCC 6.5 does not diagnose. No functional change intended.

## Changes

**Function pointer type mismatch (the one with teeth)** — `message_update()` was declared taking `struct message_update_info *`, but every consumer types the callback as `int (*)(void *, int, char *)`: the signature used by `ftp_cwd()`, `connect_host()`, `login()` and `_getreply()` in `ftp.h`, and by the `updatefn`/`startupfn`/`cwdfn` locals. Calling through a mismatched function pointer is undefined behaviour, and it was happening at **five** sites — `ftp_lister.c:1004,1125,2051` and `ftp_lister_connect.c:620,624`.

Fixed at the definition so all five sites are well typed with no casts. Worth doing regardless of toolchain: GCC 14 rejects this outright, and mismatched indirect calls are a known hazard under `-flto`, which the OS3 build uses.

**Always-true guard** — `lister_new_connection()` tested `cm->cm_opus &&` before dereferencing, but `cm_opus` is a `char[]` member so the test can never be false; `cm` itself is already checked one line above. Dead term removed.

**Brace elision** — `systype_lookup()`'s `sys_types[]` initialized an array of two-member structs from a flat list. Legal C and behaviourally correct, but fragile. Now braced per element.

**`struct timeval` initializer** — `iread()` used `{0, 0}`. The NDK 3.2 definition wraps both fields in anonymous unions (`tv_sec`/`tv_secs`, `tv_usec`/`tv_micro`), so the flat form warns. Changed to `{0}`, which is already the idiom at `ftp.c:1213,1613,1867` and `ftp_recursive.c:3477` — this line was the lone deviation.

## Verification

| Check | Result |
|---|---|
| GCC 6.5 (`sacredbanana/amiga-compiler:m68k-amigaos`) `make os3 all debug=no` | exit 0, no new warnings in touched files |
| GCC 13.4, the seven target warnings | all resolved; zero `ftp_lister_connect.c` warnings remain |

CI exercises the GCC 6.5 path, which is what the regression build above covers.

## Not included

A GCC 13 baseline over the whole codebase shows 261 unique warnings. Among them are **11 more `-Waddress` always-true tests** of exactly the class fixed here — `buffers_sort.c` (8, lines 536-581), `config_environment.c:1521`, `filetype.c:2290`, `ftp_main.c:1189`. Each needs individual reading to tell whether the intended check was something else, so they are left for a follow-up rather than bundled in.