### PR TITLE
Accept console handlers with a running process as output device

### DIFF
--- a/source/Modules/configopus/config_environment.c
+++ b/source/Modules/configopus/config_environment.c
@@ -2870,9 +2870,22 @@ void config_env_check_device(config_env_data *data)
 		// Lock the dos list
 		dos = LockDosList(LDF_DEVICES | LDF_READ);
 
-		// See if entry is there, and not a disk
-		if (!(dos = FindDosEntry(dos, name, LDF_DEVICES)) || dos->dol_Task ||
-			(IPTR)dos->dol_misc.dol_handler.dol_Startup > 511)
+		// See if entry is there.
+		//
+		// This used to also reject any entry with a running handler process
+		// (dol_Task), or with dol_Startup > 511, as heuristics for "this is a
+		// filesystem rather than a console handler". Both misclassify modern
+		// console handlers. CCON: creates its handler process on first
+		// reference, so dol_Task is set as soon as it has been used, and
+		// handlers mounted with a string Startup (CRAW:, RAW:) have a
+		// dol_Startup BSTR pointer well above 511. Stock CON: trips the
+		// dol_Task test too - that went unnoticed only because the fallback
+		// value is "CON:" itself, so the reset was invisible.
+		//
+		// The DOS list offers no reliable way to tell a handler from a
+		// filesystem, so just check the device exists, which is what catches
+		// typos.
+		if (!FindDosEntry(dos, name, LDF_DEVICES))
 		{
 			// Error
 			DisplayBeep(data->window->WScreen);


### PR DESCRIPTION
Fixes #164.

## The reported cause is not the actual one

There is no 3-character limit on the output device field. `output_device` is `char[80]` (`dopus5.h:2252`), the string gadget is created with `GTST_MaxChars, 60` (`config_environment_data.c:145`), the DOpus 4 config converter copies 80 bytes (`config_open.c:1821`), and both consumers — `cli_build_window_name()` and the `MENU_NEWSHELL` handler — just concatenate the string. A two-letter device would have been rejected exactly the same way.

## What actually happens

`config_env_check_device()` runs on the gadget's change event, which is why the field reverts the moment you press Enter. Alongside the existence check it rejected:

```c
|| dos->dol_Task || (IPTR)dos->dol_misc.dol_handler.dol_Startup > 511
```

Both are heuristics for *"this is a filesystem, not a console handler"*, dating to the original 1993 import. Both misclassify console handlers:

| Device | `dol_Task` | `dol_Startup` | Rejected by |
|---|---|---|---|
| `CCON:` | set once used — the handler process is created on first reference, not at Mount | 0 | `dol_Task` |
| `CRAW:` / `RAW:` | set once used | BSTR pointer (`Startup = "RAW"`) | both |
| stock `CON:` | set once used | 0 | `dol_Task` |

Stock `CON:` fails this check too. It went unnoticed because the fallback value is `"CON:"` itself, so the reset was invisible and the `DisplayBeep` read as a keypress that did nothing.

Device characteristics taken from the [CCON mountlist](https://github.com/creep-ltx/AmigaTools/blob/main/ccon/CCON-mountlist).

## The fix

The DOS list offers no reliable way to distinguish a handler from a filesystem — `dol_Startup` legitimately holds 0, a small integer, or a BSTR depending on how the device was mounted. So both heuristics are dropped and the `FindDosEntry` existence check is kept, which is what catches typos. A comment records the reasoning so the disk check does not get helpfully reinstated later.

Worst case a user points CLI output at a disk device and gets a non-working CLI window — which DOpus could not reliably prevent anyway.

## Verification

Builds clean for OS3 against the pinned CI image, with no new warnings in `config_environment.c`.

I could not exercise this against a real CCON: install — **the final confirmation that `CCON:` now sticks in the field needs testing on hardware or in an emulator.**