### PR TITLE
fix: honour selected desktop icons in User Menu and Button Bank launches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ notes/
 source/Modules/ftp/third_party/libssh2/build/
 docs/superpowers
 .omo
+docs/plans

--- a/source/Program/buttons_run.c
+++ b/source/Program/buttons_run.c
@@ -91,10 +91,29 @@ Cfg_ButtonFunction *button_find_function(Cfg_Button *button, short which, APTR *
 void buttons_run_button(Buttons *buttons, Cfg_Button *button, short which)
 {
 	Cfg_Function *function;
+	struct ArgArray *array = 0;
 
 	// Get the function to run
 	if (!(function = button_valid(button, which)))
 		return;
+
+	// Desktop selection fallback: when no lister provides a selection,
+	// honour a selected desktop icon (as the icon context menu does)
+	if (!lister_has_selection() && (array = desktop_selection_argarray(GUI->backdrop)))
+	{
+		function_launch(FUNCTION_RUN_FUNCTION_EXTERNAL,
+						function,
+						0,
+						0,
+						0,
+						0,
+						environment->env->desktop_location,
+						0,
+						array,
+						0,
+						buttons);
+		return;
+	}
 
 	// Launch function
 	function_launch(FUNCTION_RUN_FUNCTION, function, 0, 0, 0, 0, 0, 0, 0, 0, buttons);

--- a/source/Program/event_loop.c
+++ b/source/Program/event_loop.c
@@ -1589,11 +1589,34 @@ BOOL menu_process_event(IPTR id, struct MenuItem *item, struct Window *window)
 				// Match function
 				if (func == (Cfg_ButtonFunction *)id)
 				{
+					struct ArgArray *array = 0;
+
 					// Remember function
 					function = (Cfg_Function *)func;
 
-					// Launch function
-					function_launch_quick(FUNCTION_RUN_FUNCTION, function, 0);
+					// Desktop selection fallback: when no lister provides a
+					// selection, honour a selected desktop icon (as the icon
+					// context menu does)
+					if (!lister_has_selection() && (array = desktop_selection_argarray(GUI->backdrop)))
+					{
+						function_launch(FUNCTION_RUN_FUNCTION_EXTERNAL,
+										function,
+										0,
+										0,
+										0,
+										0,
+										environment->env->desktop_location,
+										0,
+										array,
+										0,
+										0);
+					}
+
+					// Otherwise launch normally
+					else
+					{
+						function_launch_quick(FUNCTION_RUN_FUNCTION, function, 0);
+					}
 					break;
 				}
 			}

--- a/source/Program/function_launch.c
+++ b/source/Program/function_launch.c
@@ -988,3 +988,98 @@ Lister *function_get_paths(FunctionHandle *handle, PathList *list, ULONG flags, 
 	// Return first pointer
 	return first;
 }
+
+// Check whether any source lister currently has a selection. This is the
+// precedence guard for the desktop selection fallback: when a lister already
+// provides entries, the desktop must not be snapshotted.
+BOOL lister_has_selection(void)
+{
+	Lister *lister;
+	IPCData *ipc;
+	BOOL found = FALSE;
+
+	// Lock lister list
+	lock_listlock(&GUI->lister_list, FALSE);
+
+	// Go through lister list
+	for (ipc = (IPCData *)GUI->lister_list.list.lh_Head; ipc->node.mln_Succ; ipc = (IPCData *)ipc->node.mln_Succ)
+	{
+		// Get lister
+		lister = IPCDATA(ipc);
+
+		// Dual lister sides are resolved locally by their launch path.
+		if (lister_dual_is_side(lister))
+			continue;
+
+		// Same candidacy as function_get_paths for a source lister: must be a
+		// source, not busy, and an icon view only when in icon action mode.
+		if (!(lister->flags & LISTERF_SOURCE) || lister->flags & LISTERF_BUSY ||
+			(lister->flags & LISTERF_VIEW_ICONS && !(lister->flags & LISTERF_ICON_ACTION)))
+			continue;
+
+		// Icon mode: look for a selected backdrop object
+		if (lister->flags & (LISTERF_VIEW_ICONS | LISTERF_ICON_ACTION))
+		{
+			BackdropInfo *info;
+			BackdropObject *object;
+
+			if ((info = lister->backdrop_info))
+			{
+				// Lock backdrop list
+				lock_listlock(&info->objects, FALSE);
+
+				// Go through backdrop list
+				for (object = (BackdropObject *)info->objects.list.lh_Head; object->node.ln_Succ;
+					 object = (BackdropObject *)object->node.ln_Succ)
+				{
+					// Selected?
+					if (object->state)
+					{
+						found = TRUE;
+						break;
+					}
+				}
+
+				// Unlock backdrop list
+				unlock_listlock(&info->objects);
+			}
+		}
+
+		// Normal mode: look for a selected buffer entry
+		else
+		{
+			DirBuffer *buffer;
+			DirEntry *entry;
+
+			if ((buffer = lister->cur_buffer))
+			{
+				// Lock buffer
+				buffer_lock(buffer, FALSE);
+
+				// Go through buffer
+				for (entry = (DirEntry *)buffer->entry_list.mlh_Head; entry->de_Node.dn_Succ;
+					 entry = (DirEntry *)entry->de_Node.dn_Succ)
+				{
+					// Selected?
+					if (entry->de_Flags & ENTF_SELECTED)
+					{
+						found = TRUE;
+						break;
+					}
+				}
+
+				// Unlock buffer
+				buffer_unlock(buffer);
+			}
+		}
+
+		// Found a selection?
+		if (found)
+			break;
+	}
+
+	// Unlock lister list
+	unlock_listlock(&GUI->lister_list);
+
+	return found;
+}

--- a/source/Program/function_launch.h
+++ b/source/Program/function_launch.h
@@ -488,6 +488,7 @@ char *function_build_file_string(FunctionHandle *handle, short);
 void function_progress_on(FunctionHandle *handle, char *operation, ULONG total, ULONG flags);
 BOOL function_progress_update(FunctionHandle *handle, FunctionEntry *entry, ULONG count);
 Lister *function_get_paths(FunctionHandle *, PathList *, ULONG, short);
+BOOL lister_has_selection(void);
 BOOL function_valid_path(PathNode *path);
 PathNode *function_add_path(FunctionHandle *, PathList *, Lister *, char *);
 void function_init_path_node(PathNode *);

--- a/source/Program/icon_function.c
+++ b/source/Program/icon_function.c
@@ -210,3 +210,90 @@ void icon_function(BackdropInfo *info, BackdropObject *only_one, char *data, Cfg
 	// Unlock list
 	unlock_listlock(&info->objects);
 }
+
+// Collect the selected objects of a desktop backdrop into an argument array,
+// in the same form the icon context menu supplies them. Returns NULL when no
+// object is selected. Used by the desktop selection fallback for User Menu and
+// Button Bank launches.
+struct ArgArray *desktop_selection_argarray(BackdropInfo *info)
+{
+	struct ArgArray *array;
+	BackdropObject *object;
+	short count = 0;
+
+	// Lock backdrop list
+	lock_listlock(&info->objects, FALSE);
+
+	// Go through backdrop list, count the objects we can supply
+	for (object = (BackdropObject *)info->objects.list.lh_Head; object->node.ln_Succ;
+		 object = (BackdropObject *)object->node.ln_Succ)
+	{
+		// Selected object of a type we supply?
+		if (object->state && object->icon &&
+			(object->type == BDO_DISK || object->type == BDO_BAD_DISK || object->type == BDO_LEFT_OUT))
+			++count;
+	}
+
+	// Nothing to work on?
+	if (count == 0 || !(array = NewArgArray()))
+	{
+		unlock_listlock(&info->objects);
+		return 0;
+	}
+
+	// Go through backdrop list again
+	for (object = (BackdropObject *)info->objects.list.lh_Head; object->node.ln_Succ;
+		 object = (BackdropObject *)object->node.ln_Succ)
+	{
+		char name[80];
+		BOOL dir = 0, link = 0;
+		struct ArgArrayEntry *aae;
+
+		// Selected object of a type we supply?
+		if (!(object->state && object->icon) ||
+			!(object->type == BDO_DISK || object->type == BDO_BAD_DISK || object->type == BDO_LEFT_OUT))
+			continue;
+
+		// Drive/disk: supply the device name
+		if (object->type == BDO_DISK || object->type == BDO_BAD_DISK)
+		{
+			// Need a device name
+			if (!object->device_name)
+				continue;
+			stccpy(name, object->device_name, sizeof(name));
+		}
+
+		// Left-out icon: supply the object name
+		else
+		{
+			stccpy(name, object->name, sizeof(name));
+
+			// Directory or link?
+			if (object->icon->do_Type == WBDRAWER || object->icon->do_Type == WBGARBAGE)
+				dir = 1;
+			if (object->flags & BDOF_LINK_ICON)
+				link = 1;
+
+			// Tack on a / for directories
+			if (dir)
+				strcat(name, "/");
+		}
+
+		// Allocate array entry
+		if ((aae = NewArgArrayEntry(array, name)))
+		{
+			// Dir?
+			if (dir)
+				aae->ae_Flags |= AEF_DIR;
+
+			// Link?
+			if (link)
+				aae->ae_Flags |= AEF_LINK;
+		}
+	}
+
+	// Unlock backdrop list
+	unlock_listlock(&info->objects);
+
+	return array;
+}

--- a/source/Program/icons.h
+++ b/source/Program/icons.h
@@ -39,6 +39,8 @@ char *isicon(char *);
 
 void icon_function(BackdropInfo *, BackdropObject *, char *, Cfg_Function *, ULONG);
 
+struct ArgArray *desktop_selection_argarray(BackdropInfo *info);
+
 void icon_rename(IPCData *, BackdropInfo *, BackdropObject *);
 
 struct DiskObject *GetProperIcon(char *, short *, ULONG);

--- a/source/Program/tests/test_desktop_selection_fallback.py
+++ b/source/Program/tests/test_desktop_selection_fallback.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Static checks for the desktop selection fallback (issue #155).
+
+User Menu and Button Bank launches must honour selected desktop icons when no
+lister provides a selection, mirroring the icon context menu. These checks pin
+the three pieces of wiring: the lister-selection guard, the desktop-selection
+collection helper, and the two launch sites that consult them.
+"""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PROGRAM = ROOT / "source" / "Program"
+
+
+def read_program_source(name):
+    return (PROGRAM / name).read_text(encoding="latin-1")
+
+
+class DesktopSelectionFallbackTests(unittest.TestCase):
+    def test_lister_selection_guard_present(self):
+        function_launch_c = read_program_source("function_launch.c")
+        function_launch_h = read_program_source("function_launch.h")
+
+        # Guard is declared and defined
+        self.assertIn("BOOL lister_has_selection(void);", function_launch_h)
+        self.assertIn("BOOL lister_has_selection(void)", function_launch_c)
+
+        # Everything after the definition is the guard body (it is the last
+        # function in the file), so it must carry the locking and candidacy.
+        body = function_launch_c.split("BOOL lister_has_selection(void)", 1)[1]
+        self.assertIn("lock_listlock(&GUI->lister_list", body)
+        self.assertIn("unlock_listlock(&GUI->lister_list)", body)
+        self.assertIn("LISTERF_SOURCE", body)
+        self.assertIn("LISTERF_BUSY", body)
+        self.assertIn("ENTF_SELECTED", body)
+
+    def test_desktop_collection_helper_present(self):
+        icon_function_c = read_program_source("icon_function.c")
+        icons_h = read_program_source("icons.h")
+
+        # Helper is declared and defined
+        self.assertIn("desktop_selection_argarray", icons_h)
+        self.assertIn(
+            "struct ArgArray *desktop_selection_argarray(BackdropInfo *info)",
+            icon_function_c,
+        )
+
+        # The body supplies drive/disk icons by device name, locks the object
+        # list while iterating, and builds argument-array entries.
+        body = icon_function_c.split(
+            "struct ArgArray *desktop_selection_argarray(BackdropInfo *info)", 1
+        )[1]
+        self.assertIn("device_name", body)
+        self.assertIn("lock_listlock(&info->objects", body)
+        self.assertIn("unlock_listlock(&info->objects)", body)
+        self.assertIn("NewArgArrayEntry", body)
+        self.assertIn("BDO_DISK", body)
+        self.assertIn("BDO_LEFT_OUT", body)
+
+    def test_launch_sites_wired(self):
+        event_loop_c = read_program_source("event_loop.c")
+        buttons_run_c = read_program_source("buttons_run.c")
+
+        # Both launch sites consult the guard and the collection helper.
+        for source in (event_loop_c, buttons_run_c):
+            self.assertIn("lister_has_selection", source)
+            self.assertIn("desktop_selection_argarray", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #155.

Functions launched from the **User Menu** or a **Button Bank** passed no source lister and no arguments, so entry wildcards like `{f}` could not see a drive icon selected on the desktop and the command silently did nothing — while the same function worked from the icon context menu.

This adds a launch-time desktop-selection fallback that mirrors the context menu:

- `lister_has_selection()` — precedence guard. Returns true when any source-eligible lister already has a selection, in which case the desktop is **not** snapshotted (a lister's selection keeps precedence).
- `desktop_selection_argarray()` — collects the selected desktop objects into an argument array in the same form the icon context menu supplies them: drives/assigns contribute their device name (e.g. `DH0:`), left-out icons their name.
- Both launch sites (User Menu in `event_loop.c`, Button Bank in `buttons_run.c`) consult the guard and, when no lister provides a selection, launch the function externally with the snapshot and the desktop folder as the source path.

Result: `C:List {f}` on a selected drive icon now lists that device's contents, as expected.

## Product decisions (from the brainstorm plan)

- **Behavioural target:** match the icon context menu.
- **Launch scope:** User Menu + Button Bank only (hotkey/ARexx launches are deferred).
- **Precedence:** desktop is a fallback; a lister's selection wins when present.
- **Mechanism:** launch-time snapshot (not an engine-level source-resolution change).

Plan: `docs/plans/2026-08-03-001-fix-desktop-icon-selection-plan.md` (requirements R1–R6; the plans directory is gitignored).

## Testing

- New static test `source/Program/tests/test_desktop_selection_fallback.py` (3 tests), written red-first, now green.
- Full static suite: **113 passed**, no regressions.
- Builds verified for **os3, os4, mos, i386-aros, x86_64-aros**. (The local `ppc-morphos` tag image is the broken 2026-07-04 rebuild, so MorphOS was built with the known-good digest pinned in CI.)
- No new compiler warnings introduced (the remaining `function_launch.c` warning is pre-existing, in untouched code).

## Runtime acceptance (manual — not covered by CI)

On a built AmigaOS target:

- [x] Select a drive icon on the desktop, run `C:List {f}` from the User Menu (output to window) → a shell lists the device contents.
- [x] With files selected in a lister, run the same from a button → the lister selection is used, not the drive.
- [x] Lister open but nothing selected → falls back to the drive icon.
- [x] The drive icon remains selected after the function runs.
- [x] A selected left-out icon is honoured too.

## Notes

- `source/Program/tests/__pycache__/` is generated by pytest and is intentionally not committed; consider adding `__pycache__/` to `.gitignore` as a follow-up.
