### PR TITLE
fix: correct FormatDate hook argument order in titlebar clock (#170)

### DIFF
--- a/source/Program/clock_task.c
+++ b/source/Program/clock_task.c
@@ -157,19 +157,17 @@ static unsigned long clock_format_append(struct Hook *hook, ULONG ch)
 	return 0;
 }
 
-#ifdef __AROS__
-static unsigned long clock_format_hook(struct Hook *hook, APTR dummy, IPTR ch)
+// FormatDate() calls this with A0=hook, A2=locale, A1=character, so the parameters must be
+// declared in the standard hook order (hook, object, message). m68k picks the registers up from
+// the REG() annotations whatever the position, but everywhere else REG() expands to nothing and
+// the declaration order *is* the calling convention. Listing the character second made OS4 and
+// MorphOS read the locale pointer as the character, painting the clock as a run of one repeated
+// garbage glyph (issue #170).
+static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a2, APTR dummy), REG(a1, IPTR ch))
 {
 	(void)dummy;
 	return clock_format_append(hook, (ULONG)ch);
 }
-#else
-static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a1, ULONG ch), REG(a2, APTR dummy))
-{
-	(void)dummy;
-	return clock_format_append(hook, ch);
-}
-#endif
 
 static BOOL clock_format_date_raw(char *buffer, short size, char *format, struct DateStamp *stamp)
 {

--- a/source/Program/tests/test_os3_screentitle_clock.py
+++ b/source/Program/tests/test_os3_screentitle_clock.py
@@ -49,7 +49,7 @@ class OS3ScreenTitleClockTests(unittest.TestCase):
         self.assertIn("clock_build_title_text(&date, datebuf, titlebuf, show_seconds);", source)
         self.assertIn('format = (show_seconds) ? "%Q:%M:%S %p" : "%Q:%M %p";', source)
         self.assertIn("FormatDate(locale.li_Locale, format, stamp, &hook);", source)
-        self.assertIn("REG(a1, ULONG ch)", source)
+        self.assertIn("REG(a1, IPTR ch)", source)
         self.assertIn("GetLocaleStr(locale.li_Locale, (hours > 11) ? PM_STR : AM_STR)", source)
         self.assertNotIn("%lcm", source)
         self.assertIn("strcmp(last_screen_title, GUI->screen_title) != 0", source)
@@ -76,12 +76,22 @@ class OS3ScreenTitleClockTests(unittest.TestCase):
         self.assertIn("(custom_title_uses_clock) ? titlebuf : 0", source)
         self.assertIn("Clock text", source)
 
-    def test_aros_clock_format_uses_hookentry_argument_order(self):
+    def test_clock_format_hook_uses_standard_hook_argument_order(self):
         source = read_source(CLOCK_TASK_C)
 
-        self.assertIn("#ifdef __AROS__", source)
-        self.assertIn("clock_format_hook(struct Hook *hook, APTR dummy, IPTR ch)", source)
+        # A0=hook, A2=object, A1=message. On every non-m68k target REG() is a no-op, so the
+        # declaration order is the calling convention: the character must be the third parameter.
+        self.assertIn(
+            "clock_format_hook(REG(a0, struct Hook *hook), REG(a2, APTR dummy), REG(a1, IPTR ch))",
+            source,
+        )
         self.assertIn("return clock_format_append(hook, (ULONG)ch);", source)
+
+        # A single definition has to serve all targets; no platform-specific parameter orders.
+        self.assertEqual(source.count("clock_format_hook(REG("), 1)
+        self.assertNotIn("clock_format_hook(struct Hook *hook, APTR dummy, IPTR ch)", source)
+        self.assertNotIn("REG(a1, ULONG ch), REG(a2, APTR dummy)", source)
+
         self.assertIn("#if defined(__AROS__) || defined(__MORPHOS__)", source)
         self.assertIn("hook.h_Entry = (HOOKFUNC)HookEntry;", source)
         self.assertIn("hook.h_SubEntry = (HOOKFUNC)clock_format_hook;", source)


### PR DESCRIPTION
Fixes #170.

## Symptom

On a custom screen, OS4 paints the titlebar clock as a run of one repeated garbage glyph:

`5.102 AMCC PPC460EX 2147483648 1726394368 07-Ago-26  ÐÐÐÐÐÐÐÐÐ`

The date is correct; only the time is replaced. It affects the default titlebar and any custom titlebar, because both draw from the same `titlebuf`.

## Cause

`locale.library` invokes the `FormatDate()` putChar hook with **A0 = hook, A2 = locale, A1 = character** — the standard hook order `(hook, object, message)`.

`clock_format_hook()` declared the character *second*:

```c
static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a1, ULONG ch), REG(a2, APTR dummy))
```

That is harmless on m68k: `REG(reg, arg)` expands to `arg __asm("a1")` (`source/Include/SDI/SDI_compiler.h:143`), so the registers are pinned regardless of parameter position. On every other target `REG(reg, arg)` expands to just `arg` (`SDI_compiler.h:146`) and the declaration order *is* the calling convention — so OS4 and MorphOS bind `ch` to the **locale pointer** and write its low byte once per emitted character.

That matches the screenshot exactly: a constant byte (`0xD0`, low nibble `0` — an aligned pointer), repeated once for each character the time format would have produced.

`clock_build_title_text()` composes `lsprintf(titlebuf, "%s  %s  ", datebuf, timebuf)`, and only `timebuf` goes through the hook — which is why the date survives.

## Prior art

The identical defect was diagnosed on AROS as part of #128 (commit 7a319c04, ChangeLog: *"so locale `FormatDate()` hook output does not repeat one bogus character"*). The fix there added a correctly-ordered variant under `#ifdef __AROS__` and left OS4 and MorphOS on the broken declaration.

## Fix

Drop the platform split and use a single definition in a0/a2/a1 order, matching how `PatternBackfill()` (`source/Program/pattern.h:90`) and `printf_hook()` (`source/Program/misc.c:277`) are already written in this codebase:

```c
static unsigned long ASM clock_format_hook(REG(a0, struct Hook *hook), REG(a2, APTR dummy), REG(a1, IPTR ch))
```

Correct on m68k via the register annotations, correct everywhere else via plain C argument order. `IPTR` keeps 64-bit AROS right.

**MorphOS is fixed by the same change** — it routes through `HookEntry`, which also calls the subentry as `(hook, object, message)`.

## Verification

- `python -m unittest discover -s source/Program/tests` — 113 tests pass.
- `test_os3_screentitle_clock.py`: the AROS-specific test is replaced by `test_clock_format_hook_uses_standard_hook_argument_order`, which pins the parameter order for all targets and asserts there is only one definition.
- Full builds: **os3**, **os4**, **i386-aros**, **x86_64-aros** — all clean, no new warnings.
- **MorphOS could not be built locally**: the `sacredbanana/amiga-compiler:ppc-morphos` image's `ppc-morphos-gcc` fails to execute here (`qemu-aarch64: Could not open '/lib/ld-linux-aarch64.so.1'`), before it reaches the source. Worth a CI check.

Needs confirmation on real OS4 hardware.
